### PR TITLE
Fix spelling of ‘supersede’ in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ No:
 
 This project doesn't start from scratch:
 
-1. See why [we should superseed previous tools](/docs/Challenges.md)
+1. See why [we should supersede previous tools](/docs/Challenges.md)
 2. Check the [list of existting tools / features ](/docs/Tools.md)
 3. See more [other tools / ide for inpiration](/docs/Inspirations.md)
 


### PR DESCRIPTION
Citation for spelling: [supersede – Wiktionary](https://en.wiktionary.org/wiki/supersede#English)