### PR TITLE
Introduce cmdFileExtensions for the CommandDescriptor

### DIFF
--- a/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -20,6 +20,7 @@ example2Descriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                        { cmdName = "sayHello"
                        , cmdUiDescription = "say hello"
+                       , cmdFileExtensions = []
                        , cmdContexts = [CtxNone]
                        , cmdAdditionalParams = []
                        }
@@ -29,6 +30,7 @@ example2Descriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                        { cmdName = "sayHelloTo"
                        , cmdUiDescription = "say hello to the passed in param"
+                       , cmdFileExtensions = []
                        , cmdContexts = [CtxNone]
                        , cmdAdditionalParams = [RP "name"]
                        }

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -56,6 +56,7 @@ instance Show Command where
 data CommandDescriptor = CommandDesc
   { cmdName :: !CommandName -- ^As returned in the 'IdeRequest'
   , cmdUiDescription :: !T.Text -- ^ Can be presented to the IDE user
+  , cmdFileExtensions :: ![T.Text] -- ^ File extensions this command can be applied to
   , cmdContexts :: ![AcceptedContext] -- TODO: should this be a non empty list? or should empty list imply CtxNone.
   , cmdAdditionalParams :: ![RequiredParam]
   } deriving (Show,Generic)
@@ -194,6 +195,7 @@ instance FromJSON RequiredParam where
 instance ToJSON CommandDescriptor where
     toJSON cmdDescriptor = object [ "name" .= cmdName cmdDescriptor
                                   , "ui_description" .= cmdUiDescription cmdDescriptor
+                                  , "file_extensions" .= cmdFileExtensions cmdDescriptor
                                   , "contexts" .= cmdContexts cmdDescriptor
                                   , "additional_params" .= cmdAdditionalParams cmdDescriptor ]
 
@@ -201,6 +203,7 @@ instance FromJSON CommandDescriptor where
     parseJSON (Object v) =
       CommandDesc <$> v .: "name"
                   <*> v .: "ui_description"
+                  <*> v .: "file_extensions"
                   <*> v .: "contexts"
                   <*> v .: "additional_params"
     parseJSON _ = empty

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -25,6 +25,7 @@ ghcmodDescriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                      { cmdName = "check"
                      , cmdUiDescription = "check a file for GHC warnings and errors"
+                     , cmdFileExtensions = [".hs",".lhs"]
                      , cmdContexts = [CtxFile]
                      , cmdAdditionalParams = []
                      }

--- a/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
+++ b/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
@@ -22,6 +22,7 @@ hareDescriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                      { cmdName = "rename"
                      , cmdUiDescription = "rename a variable or type"
+                     , cmdFileExtensions = [".hs"]
                      , cmdContexts = [CtxPoint]
                      , cmdAdditionalParams = [RP "name"]
                      }

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -31,6 +31,7 @@ baseDescriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                         { cmdName = "version"
                         , cmdUiDescription = "return HIE version"
+                        , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = []
                         }
@@ -40,6 +41,7 @@ baseDescriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                         { cmdName = "plugins"
                         , cmdUiDescription = "list available plugins"
+                        , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = []
                         }
@@ -49,6 +51,7 @@ baseDescriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                         { cmdName = "commands"
                         , cmdUiDescription = "list available commands for a given plugin"
+                        , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = [RP "plugin"]
                         }
@@ -58,6 +61,7 @@ baseDescriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                         { cmdName = "commandDetail"
                         , cmdUiDescription = "list parameters required for a given command"
+                        , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = [RP "plugin",RP "command"]
                         }
@@ -67,6 +71,7 @@ baseDescriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                         { cmdName = "pwd"
                         , cmdUiDescription = "return the current working directory for the HIE process"
+                        , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = []
                         }
@@ -76,6 +81,7 @@ baseDescriptor = PluginDescriptor
           { cmdDesc = CommandDesc
                         { cmdName = "cwd"
                         , cmdUiDescription = "change the current working directory for the HIE process"
+                        , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = [RP "dir"]
                        }


### PR DESCRIPTION
This allows us to expose a command for a .hs file, or a .cabal file, etc