### PR TITLE
Dispatcher validation

### DIFF
--- a/elisp/tests/haskell-ide-engine-tests.el
+++ b/elisp/tests/haskell-ide-engine-tests.el
@@ -42,7 +42,7 @@
           (lambda (json)
             (setq response json)))
     (haskell-ide-engine-post-message
-     '(("cmd" . "base:version") ("context" . ()) ("params" . ())))
+     '(("cmd" . "base:version") ("params" . ())))
 
     (sit-for 2)
     (should response)

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -85,7 +85,9 @@ test-suite haskell-ide-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  other-modules:       GhcModPluginSpec
+  other-modules:
+                       DispatcherSpec
+                       GhcModPluginSpec
                        HaRePluginSpec
                        JsonStdioSpec
   build-depends:       base
@@ -97,6 +99,7 @@ test-suite haskell-ide-test
                      , haskell-ide-plugin-ghcmod
                      , hspec
                      , logging
+                     , text
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 

--- a/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -43,11 +43,11 @@ example2Descriptor = PluginDescriptor
 
 -- ---------------------------------------------------------------------
 
-sayHelloCmd :: Dispatcher
-sayHelloCmd _ = return (IdeResponseOk (String sayHello))
+sayHelloCmd :: CommandFunc
+sayHelloCmd _  _ = return (IdeResponseOk (String sayHello))
 
-sayHelloToCmd :: Dispatcher
-sayHelloToCmd req = do
+sayHelloToCmd :: CommandFunc
+sayHelloToCmd _ req = do
   case Map.lookup "name" (ideParams req) of
     Nothing -> return $ IdeResponseFail "expecting parameter `name`"
     Just (ParamText n) -> do
@@ -57,8 +57,8 @@ sayHelloToCmd req = do
 
 -- ---------------------------------------------------------------------
 {-
-example2Dispatcher :: Dispatcher
-example2Dispatcher (IdeRequest name ctx params) = do
+example2CommandFunc :: CommandFunc
+example2CommandFunc (IdeRequest name ctx params) = do
   case name of
     "sayHello"   -> return (IdeResponseOk (String sayHello))
     "sayHelloTo" -> do

--- a/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -32,7 +32,7 @@ example2Descriptor = PluginDescriptor
                        , cmdUiDescription = "say hello to the passed in param"
                        , cmdFileExtensions = []
                        , cmdContexts = [CtxNone]
-                       , cmdAdditionalParams = [RP "name"]
+                       , cmdAdditionalParams = [RP "name" "the name to greet" PtText]
                        }
           , cmdFunc = sayHelloToCmd
           }

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -248,9 +248,9 @@ instance FromJSON ParamType where
 -- -------------------------------------
 
 instance ToJSON ParamDecription where
-    toJSON (RP n h t) = object [ "tag" .= String "RP"
+    toJSON (RP n h t) = object [ "tag" .= String "rp"
                                , "contents" .= toJSON (n,h,t) ]
-    toJSON (OP n h t) = object [ "tag" .= String "OP"
+    toJSON (OP n h t) = object [ "tag" .= String "op"
                                , "contents" .= toJSON (n,h,t) ]
 
 instance FromJSON ParamDecription where
@@ -258,8 +258,8 @@ instance FromJSON ParamDecription where
       tag <- v .: "tag" :: Parser T.Text
       (n,h,t) <- v .: "contents"
       case tag of
-        "RP" -> return $ RP n h t
-        "OP" -> return $ OP n h t
+        "rp" -> return $ RP n h t
+        "op" -> return $ OP n h t
         _ -> empty
     parseJSON _ = empty
 

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -2,6 +2,7 @@
 module Haskell.Ide.Engine.PluginUtils
   (
     getParams
+  , mapEithers
   ) where
 
 import           Data.Aeson

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -48,8 +48,8 @@ ghcmodDescriptor = PluginDescriptor
 
 -- ---------------------------------------------------------------------
 
-checkCmd :: Dispatcher
-checkCmd req = do
+checkCmd :: CommandFunc
+checkCmd _ctxs req = do
   case getParams ["file"] req of
     Left err -> return err
     Right [ParamFile fileName] -> do
@@ -58,8 +58,8 @@ checkCmd req = do
 
 -- ---------------------------------------------------------------------
 
-typesCmd :: Dispatcher
-typesCmd req = do
+typesCmd :: CommandFunc
+typesCmd _ctxs req = do
   case getParams ["file","start_pos"] req of
     Left err -> return err
     Right [ParamFile fileName,ParamPos (r,c)] -> do

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -31,6 +31,16 @@ ghcmodDescriptor = PluginDescriptor
                      }
           , cmdFunc = checkCmd
           }
+      , Command
+          { cmdDesc = CommandDesc
+                     { cmdName = "types"
+                     , cmdUiDescription = "Get the type of the expression under (LINE,COL)"
+                     , cmdFileExtensions = [".hs",".lhs"]
+                     , cmdContexts = [CtxPoint]
+                     , cmdAdditionalParams = []
+                     }
+          , cmdFunc = typesCmd
+          }
       ]
   , pdExposedServices = []
   , pdUsedServices    = []
@@ -46,13 +56,15 @@ checkCmd req = do
       liftIO $ doCheck (T.unpack fileName)
     Right x -> error $ "GhcModPlugin.checkCmd: got unexpected file param:" ++ show x
 
--- --   Warnings and errors are returned.
--- checkSyntax :: IOish m
---             => [FilePath]  -- ^ The target files.
---             -> GhcModT m String
--- checkSyntax []    = return ""
--- checkSyntax files = either id id <$> check files
+-- ---------------------------------------------------------------------
 
+typesCmd :: Dispatcher
+typesCmd req = do
+  case getParams ["file","start_pos"] req of
+    Left err -> return err
+    Right [ParamFile fileName,ParamPos (r,c)] -> do
+      liftIO $ runGhcModCommand (GM.types (T.unpack fileName) r c)
+    Right x -> error $ "GhcModPlugin.types: got unexpected file param:" ++ show x
 -- ---------------------------------------------------------------------
 
 -- doCheck :: (MonadIO m,GHC.GhcMonad m,HasIdeState m) => FilePath -> m IdeResponse

--- a/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
+++ b/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
@@ -24,7 +24,7 @@ hareDescriptor = PluginDescriptor
                      , cmdUiDescription = "rename a variable or type"
                      , cmdFileExtensions = [".hs"]
                      , cmdContexts = [CtxPoint]
-                     , cmdAdditionalParams = [RP "name"]
+                     , cmdAdditionalParams = [RP "name" "the new name" PtText]
                      }
           , cmdFunc = renameCmd
           }

--- a/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
+++ b/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
@@ -35,8 +35,8 @@ hareDescriptor = PluginDescriptor
 
 -- ---------------------------------------------------------------------
 
-renameCmd :: Dispatcher
-renameCmd req = do
+renameCmd :: CommandFunc
+renameCmd _ctxs req = do
   case getParams ["file","start_pos","name"] req of
     Left err -> return err
     Right [ParamFile fileName,ParamPos pos,ParamText name] -> do

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -95,16 +95,16 @@ baseDescriptor = PluginDescriptor
 
 -- ---------------------------------------------------------------------
 
-versionCmd :: Dispatcher
-versionCmd _ = return (IdeResponseOk (String $ T.pack version))
+versionCmd :: CommandFunc
+versionCmd _ _ = return (IdeResponseOk (String $ T.pack version))
 
-pluginsCmd :: Dispatcher
-pluginsCmd _ = do
+pluginsCmd :: CommandFunc
+pluginsCmd _ _ = do
   plugins <- getPlugins
   return (IdeResponseOk (String $ T.pack $ show $ Map.keys plugins))
 
-commandsCmd :: Dispatcher
-commandsCmd req = do
+commandsCmd :: CommandFunc
+commandsCmd _ req = do
   plugins <- getPlugins
   -- TODO: Use Maybe Monad. What abut error reporting?
   case Map.lookup "plugin" (ideParams req) of
@@ -114,8 +114,8 @@ commandsCmd req = do
       Just pl -> return (IdeResponseOk (toJSON $ map (cmdName . cmdDesc) $ pdCommands pl))
     Just x -> return $ (IdeResponseFail (toJSON $ "invalid parameter for plugin:" ++ show x))
 
-commandDetailCmd :: Dispatcher
-commandDetailCmd req = do
+commandDetailCmd :: CommandFunc
+commandDetailCmd _ req = do
   plugins <- getPlugins
   case getParams ["plugin","command"] req of
     Left err -> return err
@@ -128,13 +128,13 @@ commandDetailCmd req = do
     Right _ -> error $ "commandDetailCmd:should not be possible"
 
 
-pwdCmd :: Dispatcher
-pwdCmd _ = do
+pwdCmd :: CommandFunc
+pwdCmd _ _ = do
   dir <- liftIO $ getCurrentDirectory
   return (IdeResponseOk (String $ T.pack dir))
 
-cwdCmd :: Dispatcher
-cwdCmd req = do
+cwdCmd :: CommandFunc
+cwdCmd _ req = do
   case Map.lookup "dir" (ideParams req) of
     Nothing -> return (IdeResponseFail (String "need 'dir' parameter"))
     Just (ParamFile dir) -> do

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -53,7 +53,7 @@ baseDescriptor = PluginDescriptor
                         , cmdUiDescription = "list available commands for a given plugin"
                         , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
-                        , cmdAdditionalParams = [RP "plugin"]
+                        , cmdAdditionalParams = [RP "plugin" "the plugin name" PtText]
                         }
           , cmdFunc = commandsCmd
           }
@@ -63,7 +63,8 @@ baseDescriptor = PluginDescriptor
                         , cmdUiDescription = "list parameters required for a given command"
                         , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
-                        , cmdAdditionalParams = [RP "plugin",RP "command"]
+                        , cmdAdditionalParams = [RP "plugin"  "the plugin name"  PtText
+                                                ,RP "command" "the command name" PtText]
                         }
           , cmdFunc = commandDetailCmd
           }
@@ -83,7 +84,7 @@ baseDescriptor = PluginDescriptor
                         , cmdUiDescription = "change the current working directory for the HIE process"
                         , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
-                        , cmdAdditionalParams = [RP "dir"]
+                        , cmdAdditionalParams = [RP "dir" "the new working directory" PtFile]
                        }
           , cmdFunc = cwdCmd
           }

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -33,6 +33,9 @@ dispatcher cin = do
 
 -- ---------------------------------------------------------------------
 
+-- |Manage the process of looking up the request in the known plugins,
+-- validating the parameters passed and handing off to the appropriate
+-- 'CommandFunc'
 doDispatch :: Plugins -> ChannelRequest -> IdeM IdeResponse
 doDispatch plugins creq = do
   case Map.lookup (cinPlugin creq) plugins of
@@ -83,6 +86,7 @@ validContext ctx params =
     Left err -> Left err
     Right _  -> Right ctx
 
+
 -- |If all listed 'ParamDescripion' values are present return a Right, else
 -- return an error.
 checkParams :: [ParamDecription] -> ParamMap -> Either IdeResponse [()]
@@ -95,17 +99,17 @@ checkParams pds params = mapEithers checkOne pds
     checkParamOP pn pt =
       case Map.lookup pn params of
         Nothing -> Right ()
-        Just p  -> checkParamMatch pt p
+        Just p  -> checkParamMatch pn pt p
 
     checkParamRP pn pt =
       case Map.lookup pn params of
         Nothing -> Left (IdeResponseFail (String $ T.pack $ "missing parameter '"++ show pn ++"'"))
-        Just p  -> checkParamMatch pt p
+        Just p  -> checkParamMatch pn pt p
 
-    checkParamMatch pt' p' =
+    checkParamMatch pn' pt' p' =
       if paramMatches pt' p'
         then Right ()
-        else Left (IdeResponseFail (String $ T.pack $ "parameter type mismatch, expected "
+        else Left (IdeResponseFail (String $ T.pack $ "parameter type mismatch for '" ++ T.unpack pn' ++ "', expected "
                                                 ++ show pt' ++ " but got "++ show p'))
 
 

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -157,12 +157,32 @@ dispatcherSpec = do
                                                     ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch, expected PtText but got ParamFile \\\"a\\\"\")"
+      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch for 'txt', expected PtText but got ParamFile \\\"a\\\"\")"
+
+
+    -- ---------------------------------
+
+    it "reports matched optional param" $ do
+      chan <- newChan
+      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",  ParamText "a")
+                                                       ,("fileo",ParamFile "f")
+                                                       ,("poso", ParamPos (1,2))
+                                                       ])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxNone]\")"
 
     -- ---------------------------------
 
     it "reports mismatched optional param" $ do
-      pendingWith "write this test"
+      chan <- newChan
+      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",  ParamText "a")
+                                                       ,("fileo",ParamText "f")
+                                                       ,("poso", ParamPos (1,2))
+                                                       ])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch for 'fileo', expected PtFile but got ParamText \\\"f\\\"\")"
 
 -- ---------------------------------------------------------------------
 
@@ -187,6 +207,11 @@ testDescriptor = PluginDescriptor
                                               , RP "pos"  "help" PtPos
                                               ]
 
+      , mkCmdWithContext "cmdoptional" [CtxNone] [ RP "txt"   "help" PtText
+                                                 , OP "txto"  "help" PtText
+                                                 , OP "fileo" "help" PtFile
+                                                 , OP "poso"  "help" PtPos
+                                                 ]
       ]
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -1,0 +1,203 @@
+{-# LANGUAGE OverloadedStrings #-}
+module DispatcherSpec where
+
+import           Control.Concurrent
+import           Control.Logging
+import           Data.Aeson
+import qualified Data.Text as T
+import qualified Data.Map as Map
+import           Haskell.Ide.Engine.Dispatcher
+import           Haskell.Ide.Engine.Monad
+import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.Types
+
+import           Test.Hspec
+
+-- ---------------------------------------------------------------------
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "dispatcher" dispatcherSpec
+
+-- -- |Used when running from ghci, and it sets the current directory to ./tests
+-- tt :: IO ()
+-- tt = do
+--   cd ".."
+--   hspec spec
+
+-- ---------------------------------------------------------------------
+
+dispatcherSpec :: Spec
+dispatcherSpec = do
+  describe "checking contexts" $ do
+    -- ---------------------------------
+
+    it "identifies CtxNone" $ do
+      chan <- newChan
+      let req = IdeRequest "cmd1" (Map.fromList [])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxNone]\")"
+
+    -- ---------------------------------
+
+    it "identifies bad CtxFile" $ do
+      chan <- newChan
+      let req = IdeRequest "cmd2" (Map.fromList [])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseFail (String \"missing parameter '\\\"file\\\"'\")"
+
+    -- ---------------------------------
+
+    it "identifies CtxFile" $ do
+      chan <- newChan
+      let req = IdeRequest "cmd2" (Map.fromList [("file",ParamFile "foo.hs")])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile]\")"
+
+    -- ---------------------------------
+
+    it "identifies CtxPoint" $ do
+      chan <- newChan
+      let req = IdeRequest "cmd3" (Map.fromList [("file",ParamFile "foo.hs"),("start_pos",ParamPos (1,2))])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxPoint]\")"
+
+    -- ---------------------------------
+
+    it "identifies CtxRegion" $ do
+      chan <- newChan
+      let req = IdeRequest "cmd4" (Map.fromList [("file",ParamFile "foo.hs")
+                                                ,("start_pos",ParamPos (1,2))
+                                                ,("end_pos",ParamPos (3,4))])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxRegion]\")"
+
+    -- ---------------------------------
+
+    it "identifies CtxCabal" $ do
+      chan <- newChan
+      let req = IdeRequest "cmd5" (Map.fromList [("cabal",ParamText "lib")])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxCabalTarget]\")"
+
+    -- ---------------------------------
+
+    it "identifies CtxProject" $ do
+      chan <- newChan
+      let req = IdeRequest "cmd6" (Map.fromList [])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxProject]\")"
+
+
+    -- ---------------------------------
+
+    it "identifies all multiple" $ do
+      chan <- newChan
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("file",ParamFile "foo.hs")
+                                                       ,("start_pos",ParamPos (1,2))
+                                                       ,("end_pos",ParamPos (3,4))])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile,CtxPoint,CtxRegion]\")"
+
+
+    -- ---------------------------------
+
+    it "identifies CtxFile,CtxPoint multiple" $ do
+      chan <- newChan
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("file",ParamFile "foo.hs")
+                                                       ,("start_pos",ParamPos (1,2))])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile,CtxPoint]\")"
+
+    -- ---------------------------------
+
+    it "identifies error when no match multiple" $ do
+      chan <- newChan
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("cabal",ParamText "lib")])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseFail (String \"missing parameter '\\\"file\\\"'\")"
+
+  -- -----------------------------------
+
+  describe "checking extra params" $ do
+    -- ---------------------------------
+
+    it "identifies matching params" $ do
+      chan <- newChan
+      let req = IdeRequest "cmdextra" (Map.fromList [("file",ParamFile "foo.hs")
+                                                    ,("txt", ParamText "a")
+                                                    ,("file",ParamFile "f")
+                                                    ,("pos", ParamPos (1,2))
+                                                    ])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile]\")"
+
+    -- ---------------------------------
+
+    it "reports mismatched param" $ do
+      chan <- newChan
+      let req = IdeRequest "cmdextra" (Map.fromList [("file",ParamFile "foo.hs")
+                                                    ,("txt", ParamFile "a")
+                                                    ,("file",ParamFile "f")
+                                                    ,("pos", ParamPos (1,2))
+                                                    ])
+          cr = CReq "test" 1 req chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch, expected PtText but got ParamFile \\\"a\\\"\")"
+
+-- ---------------------------------------------------------------------
+
+testPlugins :: Plugins
+testPlugins = Map.fromList [("test",testDescriptor)]
+
+testDescriptor :: PluginDescriptor
+testDescriptor = PluginDescriptor
+  {
+    pdCommands =
+      [
+        mkCmdWithContext "cmd1" [CtxNone] []
+      , mkCmdWithContext "cmd2" [CtxFile] []
+      , mkCmdWithContext "cmd3" [CtxPoint] []
+      , mkCmdWithContext "cmd4" [CtxRegion] []
+      , mkCmdWithContext "cmd5" [CtxCabalTarget] []
+      , mkCmdWithContext "cmd6" [CtxProject] []
+      , mkCmdWithContext "cmdmultiple" [CtxFile,CtxPoint,CtxRegion] []
+
+      , mkCmdWithContext "cmdextra" [CtxFile] [ RP "txt"  "help" PtText
+                                              , RP "file" "help" PtFile
+                                              , RP "pos"  "help" PtPos
+                                              ]
+
+      ]
+  , pdExposedServices = []
+  , pdUsedServices    = []
+  }
+
+mkCmdWithContext :: CommandName -> [AcceptedContext] -> [ParamDecription] -> Command
+mkCmdWithContext n cts pds =
+        Command
+          { cmdDesc = CommandDesc
+                        { cmdName = n
+                        , cmdUiDescription = "description"
+                        , cmdFileExtensions = []
+                        , cmdContexts = cts
+                        , cmdAdditionalParams = pds
+                        }
+          , cmdFunc = \ctxs _ -> return (IdeResponseOk (String $ T.pack $ "result:ctxs=" ++ show ctxs))
+          }
+
+-- ---------------------------------------------------------------------

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -159,6 +159,11 @@ dispatcherSpec = do
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch, expected PtText but got ParamFile \\\"a\\\"\")"
 
+    -- ---------------------------------
+
+    it "reports mismatched optional param" $ do
+      pendingWith "write this test"
+
 -- ---------------------------------------------------------------------
 
 testPlugins :: Plugins

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -32,16 +32,16 @@ ghcmodSpec = do
   describe "ghc-mod plugin commands" $ do
     it "runs the check command" $ do
       let req = IdeRequest "check" (Map.fromList [("file", ParamFile "./test/testdata/FileWithWarning.hs")])
-      r <- runIdeM (IdeState Map.empty) (checkCmd req)
+      r <- runIdeM (IdeState Map.empty) (checkCmd [] req)
       (show r) `shouldBe` "IdeResponseOk (String \"test/testdata/FileWithWarning.hs:4:7:Not in scope: \\8216x\\8217\\n\")"
 
     it "runs the types command, incorrect params" $ do
       let req = IdeRequest "types" (Map.fromList [("file", ParamFile "./test/testdata/FileWithWarning.hs")])
-      r <- runIdeM (IdeState Map.empty) (typesCmd req)
+      r <- runIdeM (IdeState Map.empty) (typesCmd [] req)
       (show r) `shouldBe` "IdeResponseFail (String \"need `\\\"start_pos\\\"` parameter\")"
 
     it "runs the types command, correct params" $ do
       let req = IdeRequest "types" (Map.fromList [("file", ParamFile "./test/testdata/HaReRename.hs")
                                                  ,("start_pos", ParamPos (5,9))])
-      r <- runIdeM (IdeState Map.empty) (typesCmd req)
+      r <- runIdeM (IdeState Map.empty) (typesCmd [] req)
       (show r) `shouldBe` "IdeResponseOk (String \"5 9 5 10 \\\"Int\\\"\\n5 9 5 14 \\\"Int\\\"\\n5 1 5 14 \\\"Int -> Int\\\"\\n\")"

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -35,3 +35,13 @@ ghcmodSpec = do
       r <- runIdeM (IdeState Map.empty) (checkCmd req)
       (show r) `shouldBe` "IdeResponseOk (String \"test/testdata/FileWithWarning.hs:4:7:Not in scope: \\8216x\\8217\\n\")"
 
+    it "runs the types command, incorrect params" $ do
+      let req = IdeRequest "types" (Map.fromList [("file", ParamFile "./test/testdata/FileWithWarning.hs")])
+      r <- runIdeM (IdeState Map.empty) (typesCmd req)
+      (show r) `shouldBe` "IdeResponseFail (String \"need `\\\"start_pos\\\"` parameter\")"
+
+    it "runs the types command, correct params" $ do
+      let req = IdeRequest "types" (Map.fromList [("file", ParamFile "./test/testdata/HaReRename.hs")
+                                                 ,("start_pos", ParamPos (5,9))])
+      r <- runIdeM (IdeState Map.empty) (typesCmd req)
+      (show r) `shouldBe` "IdeResponseOk (String \"5 9 5 10 \\\"Int\\\"\\n5 9 5 14 \\\"Int\\\"\\n5 1 5 14 \\\"Int -> Int\\\"\\n\")"

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -33,10 +33,10 @@ hareSpec = do
   describe "hare plugin commands" $ do
     it "renames" $ do
       let req = IdeRequest "rename" (Map.fromList [("file",ParamFile "./test/testdata/HaReRename.hs"),("start_pos",ParamPos (5,1)),("name",ParamText "foolong")])
-      r <- runIdeM (IdeState Map.empty) (renameCmd req)
+      r <- runIdeM (IdeState Map.empty) (renameCmd [] req)
       (show r) `shouldBe` "IdeResponseOk (Array [String \"test/testdata/HaReRename.hs\"])"
 
     it "returns an error for invalid rename" $ do
       let req = IdeRequest "rename" (Map.fromList [("file",ParamFile "./test/testdata/HaReRename.hs"),("start_pos",ParamPos (15,1)),("name",ParamText "foolong")])
-      r <- runIdeM (IdeState Map.empty) (renameCmd req)
+      r <- runIdeM (IdeState Map.empty) (renameCmd [] req)
       (show r) `shouldBe` "IdeResponseFail (String \"Invalid cursor position!\")"


### PR DESCRIPTION
Move request validation into the dispatcher.

Now the `cmdFunc` is only ever called if the parameters in its request comply with at least one of its `AcceptedContext` values and all additional reuired parameters are present.