### PR TITLE
Error structure with code

### DIFF
--- a/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -54,7 +54,7 @@ sayHelloToCmd _ req = do
     Just (ParamText n) -> do
       r <- liftIO $ sayHelloTo n
       return $ IdeResponseOk (String r)
-    Just x -> return $ incorrectParameter "name" "ParamText" x
+    Just x -> return $ incorrectParameter "name" ("ParamText"::String) x
 
 -- ---------------------------------------------------------------------
 {-

--- a/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -2,6 +2,7 @@
 module Haskell.Ide.ExamplePlugin2 where
 
 import Haskell.Ide.Engine.PluginDescriptor
+import Haskell.Ide.Engine.PluginUtils
 
 import           Control.Monad.IO.Class
 import           Data.Aeson
@@ -49,11 +50,11 @@ sayHelloCmd _  _ = return (IdeResponseOk (String sayHello))
 sayHelloToCmd :: CommandFunc
 sayHelloToCmd _ req = do
   case Map.lookup "name" (ideParams req) of
-    Nothing -> return $ IdeResponseFail "expecting parameter `name`"
+    Nothing -> return $ missingParameter "name"
     Just (ParamText n) -> do
       r <- liftIO $ sayHelloTo n
       return $ IdeResponseOk (String r)
-    Just x -> return $ IdeResponseFail (toJSON $ T.pack $ "got wrong param type:" ++ show x)
+    Just x -> return $ incorrectParameter "name" "ParamText" x
 
 -- ---------------------------------------------------------------------
 {-

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -3,12 +3,15 @@ module Haskell.Ide.Engine.PluginUtils
   (
     getParams
   , mapEithers
+  , missingParameter
+  , incorrectParameter
   ) where
 
 import           Data.Aeson
-import           Data.List
+import           Data.Monoid
 import           Haskell.Ide.Engine.PluginDescriptor
 import qualified Data.Map as Map
+import qualified Data.Text as T
 import           Prelude hiding (log)
 
 -- ---------------------------------------------------------------------
@@ -22,7 +25,7 @@ getParams params req = mapEithers checkOne params
   where
     checkOne :: ParamId -> Either IdeResponse ParamVal
     checkOne param = case Map.lookup param (ideParams req) of
-      Nothing -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
+      Nothing -> Left (missingParameter param)
       Just v  -> Right v
 
 
@@ -36,3 +39,21 @@ mapEithers f (x:xs) = case mapEithers f xs of
                                       Left err -> Left err
                                       Right y -> Right (y:ys)
 mapEithers _ _ = Right []
+
+-- ---------------------------------------------------------------------
+-- Helper functions for errors
+
+-- Missing parameter error
+missingParameter :: ParamId -> IdeResponse
+missingParameter param = IdeResponseFail (IdeError MissingParameter
+            ("need `" <> param <> "` parameter")
+            (Just $ toJSON param))
+
+-- Incorrect parameter error
+incorrectParameter :: (Show a,Show b) => ParamId -> a -> b -> IdeResponse
+incorrectParameter name expected value = IdeResponseFail
+    (IdeError IncorrectParameterType
+    ("got wrong parameter type for `" <> name <> "`, expected: " <>
+      T.pack (show expected) <>" , got:" <> T.pack (show value))
+    (Just $ object ["param" .= toJSON name,"expected".= toJSON (show expected),
+      "value" .= toJSON (show value)]))

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -54,7 +54,7 @@ checkCmd _ctxs req = do
     Left err -> return err
     Right [ParamFile fileName] -> do
       liftIO $ doCheck (T.unpack fileName)
-    Right x -> error $ "GhcModPlugin.checkCmd: got unexpected file param:" ++ show x
+    Right x -> return $ incorrectParameter "file" "ParamFile" x
 
 -- ---------------------------------------------------------------------
 
@@ -64,7 +64,7 @@ typesCmd _ctxs req = do
     Left err -> return err
     Right [ParamFile fileName,ParamPos (r,c)] -> do
       liftIO $ runGhcModCommand (GM.types (T.unpack fileName) r c)
-    Right x -> error $ "GhcModPlugin.types: got unexpected file param:" ++ show x
+    Right x -> return $ incorrectParameter "file" "ParamFile" x
 -- ---------------------------------------------------------------------
 
 -- doCheck :: (MonadIO m,GHC.GhcMonad m,HasIdeState m) => FilePath -> m IdeResponse
@@ -91,7 +91,7 @@ runGhcModCommand cmd = do
       return (cr,s')
   -- (Either GM.GhcModError String, GM.GhcModLog)
   case r of
-    Left e -> return $ IdeResponseError (toJSON $ T.pack $ "doCheck:got " ++ show e)
+    Left e -> return $ IdeResponseError (IdeError PluginError (T.pack $ "doCheck:got " ++ show e) Nothing)
     Right (checkResult,_s3) -> do
       -- GHC.setSession s3
       return $ (IdeResponseOk (toJSON checkResult))
@@ -117,4 +117,3 @@ catchException f = do
   where
     handler:: SomeException -> IO (Either String t)
     handler e = return (Left (show e))
-

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -54,7 +54,7 @@ checkCmd _ctxs req = do
     Left err -> return err
     Right [ParamFile fileName] -> do
       liftIO $ doCheck (T.unpack fileName)
-    Right x -> return $ incorrectParameter "file" "ParamFile" x
+    Right x -> return $ incorrectParameter "file" ("ParamFile"::String) x
 
 -- ---------------------------------------------------------------------
 
@@ -64,7 +64,7 @@ typesCmd _ctxs req = do
     Left err -> return err
     Right [ParamFile fileName,ParamPos (r,c)] -> do
       liftIO $ runGhcModCommand (GM.types (T.unpack fileName) r c)
-    Right x -> return $ incorrectParameter "file" "ParamFile" x
+    Right x -> return $ incorrectParameter "file" ("ParamFile"::String) x
 -- ---------------------------------------------------------------------
 
 -- doCheck :: (MonadIO m,GHC.GhcMonad m,HasIdeState m) => FilePath -> m IdeResponse

--- a/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
+++ b/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
@@ -42,13 +42,16 @@ renameCmd _ctxs req = do
     Right [ParamFile fileName,ParamPos pos,ParamText name] -> do
       res <- liftIO $ catchException $ rename defaultSettings GM.defaultOptions (T.unpack fileName) (T.unpack name) pos
       case res of
-        Left err -> return (IdeResponseFail (toJSON err))
+        Left err -> return $ IdeResponseFail (IdeError PluginError
+                      (T.pack $ "rename: " ++ show err) Nothing)
         Right fs -> do
           fs' <- liftIO $ mapM makeRelativeToCurrentDirectory fs
           return (IdeResponseOk (toJSON fs'))
-    Right ps -> error $ "HarePlugin.renameCmd: unexpected parameters:" ++ show ps
+    Right ps -> return $ IdeResponseFail (IdeError UnexpectedParameter
+        (T.pack ("HarePlugin.renameCmd: unexpected parameters:" ++ show ps))
+        Nothing)
 
--- rename :: RefactSettings -> Options -> FilePath -> String -> SimpPos -> IO [FilePath] 
+-- rename :: RefactSettings -> Options -> FilePath -> String -> SimpPos -> IO [FilePath]
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -114,7 +114,7 @@ commandsCmd _ req = do
                   UnknownPlugin ("Can't find plugin:" <> p )
                   (Just $ toJSON $ p)))
       Just pl -> return (IdeResponseOk (toJSON $ map (cmdName . cmdDesc) $ pdCommands pl))
-    Just x -> return $ incorrectParameter "plugin" "ParamText" x
+    Just x -> return $ incorrectParameter "plugin" ("ParamText"::String) x
 
 commandDetailCmd :: CommandFunc
 commandDetailCmd _ req = do
@@ -147,7 +147,7 @@ cwdCmd _ req = do
     Just (ParamFile dir) -> do
       liftIO $ setCurrentDirectory (T.unpack dir)
       return (IdeResponseOk Null)
-    Just x -> return $ incorrectParameter "dir" "ParamFile" x
+    Just x -> return $ incorrectParameter "dir" ("ParamFile"::String) x
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -39,14 +39,18 @@ dispatcher cin = do
 doDispatch :: Plugins -> ChannelRequest -> IdeM IdeResponse
 doDispatch plugins creq = do
   case Map.lookup (cinPlugin creq) plugins of
-    Nothing -> return (IdeResponseError (toJSON $ "No plugin found for:" <> cinPlugin creq ))
+    Nothing -> return (IdeResponseError (IdeError
+                UnknownPlugin ("No plugin found for:" <> cinPlugin creq )
+                (Just $ toJSON $ cinPlugin creq)))
     Just desc -> do
       let pn  = cinPlugin creq
           req = cinReq creq
       debugm $ "doDispatch:desc=" ++ show desc
       debugm $ "doDispatch:req=" ++ show req
       case Map.lookup (pn,ideCommand req) (pluginCache plugins) of
-        Nothing -> return (IdeResponseError (toJSON $ "No such command:" <> ideCommand req))
+        Nothing -> return (IdeResponseError (IdeError
+                    UnknownCommand ("No such command:" <> ideCommand req )
+                    (Just $ toJSON $ ideCommand req)))
         Just cmd -> do
           case validateContexts (cmdDesc cmd) req of
             Left err   -> return err
@@ -73,8 +77,9 @@ validateContexts cd req = r
     (errs,oks) = partitionEithers $ map (\c -> validContext c (ideParams req)) $ cmdContexts cd
     r = case oks of
           [] -> case errs of
-            [] -> Left $ IdeResponseFail (toJSON $ T.pack $ "no valid context found, expecting one of:"
-                                          ++ show (cmdContexts cd))
+            [] -> Left $ IdeResponseFail (IdeError InvalidContext
+                      (T.pack $ "no valid context found, expecting one of:"
+                                          ++ show (cmdContexts cd)) Nothing)
             (e:_) -> Left e
           ctxs -> case checkParams (cmdAdditionalParams cd) (ideParams req) of
                     Right _  -> Right ctxs
@@ -103,14 +108,13 @@ checkParams pds params = mapEithers checkOne pds
 
     checkParamRP pn pt =
       case Map.lookup pn params of
-        Nothing -> Left (IdeResponseFail (String $ T.pack $ "missing parameter '"++ show pn ++"'"))
+        Nothing -> Left $ missingParameter pn
         Just p  -> checkParamMatch pn pt p
 
     checkParamMatch pn' pt' p' =
       if paramMatches pt' p'
         then Right ()
-        else Left (IdeResponseFail (String $ T.pack $ "parameter type mismatch for '" ++ T.unpack pn' ++ "', expected "
-                                                ++ show pt' ++ " but got "++ show p'))
+        else Left $ incorrectParameter pn' pt' p'
 
 
     paramMatches PtText (ParamText _) = True

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -72,8 +72,8 @@ channelToWire :: ChannelResponse -> WireResponse
 channelToWire cr =
   case coutResp cr of
     IdeResponseOk v -> Ok v
-    IdeResponseFail v -> Fail v
-    IdeResponseError v -> HieError v
+    IdeResponseFail v -> Fail $ A.toJSON v
+    IdeResponseError v -> HieError $ A.toJSON v
 
 -- ---------------------------------------------------------------------
 

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -49,7 +49,8 @@ dispatcherSpec = do
       let req = IdeRequest "cmd2" (Map.fromList [])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe` "IdeResponseFail (String \"missing parameter '\\\"file\\\"'\")"
+      (show r) `shouldBe`
+        "IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = \"need `file` parameter\", ideInfo = Just (String \"file\")})"
 
     -- ---------------------------------
 
@@ -128,7 +129,8 @@ dispatcherSpec = do
       let req = IdeRequest "cmdmultiple" (Map.fromList [("cabal",ParamText "lib")])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe` "IdeResponseFail (String \"missing parameter '\\\"file\\\"'\")"
+      (show r) `shouldBe`
+        "IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = \"need `file` parameter\", ideInfo = Just (String \"file\")})"
 
   -- -----------------------------------
 
@@ -157,7 +159,8 @@ dispatcherSpec = do
                                                     ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch for 'txt', expected PtText but got ParamFile \\\"a\\\"\")"
+      (show r) `shouldBe`
+        "IdeResponseFail (IdeError {ideCode = IncorrectParameterType, ideMessage = \"got wrong parameter type for `txt`, expected: PtText , got:ParamFile \\\"a\\\"\", ideInfo = Just (Object (fromList [(\"value\",String \"ParamFile \\\"a\\\"\"),(\"param\",String \"txt\"),(\"expected\",String \"PtText\")]))})"
 
 
     -- ---------------------------------
@@ -182,8 +185,9 @@ dispatcherSpec = do
                                                        ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch for 'fileo', expected PtFile but got ParamText \\\"f\\\"\")"
-
+      (show r) `shouldBe`
+        "IdeResponseFail (IdeError {ideCode = IncorrectParameterType, ideMessage = \"got wrong parameter type for `fileo`, expected: PtFile , got:ParamText \\\"f\\\"\", ideInfo = Just (Object (fromList [(\"value\",String \"ParamText \\\"f\\\"\"),(\"param\",String \"fileo\"),(\"expected\",String \"PtFile\")]))})"
+      
 -- ---------------------------------------------------------------------
 
 testPlugins :: Plugins

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -38,7 +38,8 @@ ghcmodSpec = do
     it "runs the types command, incorrect params" $ do
       let req = IdeRequest "types" (Map.fromList [("file", ParamFile "./test/testdata/FileWithWarning.hs")])
       r <- runIdeM (IdeState Map.empty) (typesCmd [] req)
-      (show r) `shouldBe` "IdeResponseFail (String \"need `\\\"start_pos\\\"` parameter\")"
+      (show r) `shouldBe`
+        "IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = \"need `start_pos` parameter\", ideInfo = Just (String \"start_pos\")})"
 
     it "runs the types command, correct params" $ do
       let req = IdeRequest "types" (Map.fromList [("file", ParamFile "./test/testdata/HaReRename.hs")

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -39,4 +39,5 @@ hareSpec = do
     it "returns an error for invalid rename" $ do
       let req = IdeRequest "rename" (Map.fromList [("file",ParamFile "./test/testdata/HaReRename.hs"),("start_pos",ParamPos (15,1)),("name",ParamText "foolong")])
       r <- runIdeM (IdeState Map.empty) (renameCmd [] req)
-      (show r) `shouldBe` "IdeResponseFail (String \"Invalid cursor position!\")"
+      (show r) `shouldBe`
+        "IdeResponseFail (IdeError {ideCode = PluginError, ideMessage = \"rename: \\\"Invalid cursor position!\\\"\", ideInfo = Nothing})"


### PR DESCRIPTION
Hello, not sure if that's useful, but at least it forced me to have a look a bit everywhere in the code (-:. This replaces simple string errors by more structured ones, with a code, a human readable string and some JSON parameters. Also, I've removed calls to error to return IdeResponseFail.