### PR TITLE
Use a GADT parametrized by param type, fixes #54

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -54,6 +54,7 @@ library
                      , transformers
                      , wai
                      , warp
+                     , vinyl >= 0.5 && < 0.6
   ghc-options:         -Wall
   default-language:    Haskell2010
 

--- a/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
 module Haskell.Ide.ExamplePlugin2 where
 
 import Haskell.Ide.Engine.PluginDescriptor
@@ -50,7 +51,7 @@ sayHelloToCmd :: CommandFunc
 sayHelloToCmd _ req = do
   case Map.lookup "name" (ideParams req) of
     Nothing -> return $ IdeResponseFail "expecting parameter `name`"
-    Just (ParamText n) -> do
+    Just (ParamValP (ParamText n)) -> do
       r <- liftIO $ sayHelloTo n
       return $ IdeResponseOk (String r)
     Just x -> return $ IdeResponseFail (toJSON $ T.pack $ "got wrong param type:" ++ show x)

--- a/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -51,7 +51,7 @@ sayHelloToCmd :: CommandFunc
 sayHelloToCmd _ req = do
   case Map.lookup "name" (ideParams req) of
     Nothing -> return $ IdeResponseFail "expecting parameter `name`"
-    Just (ParamValP (ParamText n)) -> do
+    Just (ParamTextP n) -> do
       r <- liftIO $ sayHelloTo n
       return $ IdeResponseOk (String r)
     Just x -> return $ IdeResponseFail (toJSON $ T.pack $ "got wrong param type:" ++ show x)

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -1,3 +1,8 @@
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE TypeSynonymInstances #-}
@@ -158,6 +163,24 @@ data ParamVal = ParamText T.Text
               | ParamFile T.Text
               | ParamPos (Int,Int)
               deriving (Show,Generic,Eq)
+
+data MyParamId (t :: ParamTag) where
+  IdText :: T.Text -> MyParamId 'Text
+  IdFile :: T.Text -> MyParamId 'File
+  IdPos :: T.Text -> MyParamId 'Pos
+
+data ParamTag = Text | File | Pos
+
+data MyParamVal (t :: ParamTag) where
+  MyParamText :: T.Text -> MyParamVal 'Text
+  MyParamFile :: T.Text -> MyParamVal 'File
+  MyParamPos :: (Int,Int) -> MyParamVal 'Pos
+
+data Rec :: (k -> *) -> [k] -> * where
+  RNil :: Rec f '[]
+  (:&) :: f t -> Rec f ts -> Rec f (t ': ts)
+
+infixr 5 :&
 
 -- TODO: should probably be able to return a plugin-specific type. Not sure how
 -- to encode it. Perhaps as an instance of a class which says it can be encoded

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -157,7 +157,7 @@ data IdeRequest = IdeRequest
   , ideParams  :: !ParamMap
   } deriving (Show)
 
-deriving instance Show (MyParamId t)
+deriving instance Show (TaggedParamId t)
 deriving instance Show (ParamVal t)
 deriving instance Show ParamValP
 
@@ -176,10 +176,10 @@ type ParamMap = Map.Map ParamId ParamValP
 
 type ParamId = T.Text
 
-data MyParamId (t :: ParamType) where
-  IdText :: T.Text -> MyParamId 'PtText
-  IdFile :: T.Text -> MyParamId 'PtFile
-  IdPos :: T.Text -> MyParamId 'PtPos
+data TaggedParamId (t :: ParamType) where
+  IdText :: T.Text -> TaggedParamId 'PtText
+  IdFile :: T.Text -> TaggedParamId 'PtFile
+  IdPos :: T.Text -> TaggedParamId 'PtPos
 
 data ParamValP = forall t. ParamValP { unParamValP ::  ParamVal t }
 

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -188,6 +188,8 @@ data ParamVal (t :: ParamType) where
   ParamFile :: T.Text -> ParamVal 'PtFile
   ParamPos :: (Int,Int) -> ParamVal 'PtPos
 
+
+-- This is the same as Rec type from vinyl
 data Rec :: (k -> *) -> [k] -> * where
   RNil :: Rec f '[]
   (:&) :: f t -> Rec f ts -> Rec f (t ': ts)

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -189,13 +189,6 @@ data ParamVal (t :: ParamType) where
   ParamPos :: (Int,Int) -> ParamVal 'PtPos
 
 
--- This is the same as Rec type from vinyl
-data Rec :: (k -> *) -> [k] -> * where
-  RNil :: Rec f '[]
-  (:&) :: f t -> Rec f ts -> Rec f (t ': ts)
-
-infixr 5 :&
-
 -- TODO: should probably be able to return a plugin-specific type. Not sure how
 -- to encode it. Perhaps as an instance of a class which says it can be encoded
 -- on the wire.

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -10,8 +10,9 @@ module Haskell.Ide.Engine.PluginUtils
 
 import           Data.Aeson
 import           Data.List
-import           Haskell.Ide.Engine.PluginDescriptor
 import qualified Data.Map as Map
+import           Data.Vinyl
+import           Haskell.Ide.Engine.PluginDescriptor
 import           Prelude hiding (log)
 
 -- ---------------------------------------------------------------------

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -20,17 +20,17 @@ import           Prelude hiding (log)
 
 -- |If all the listed params are present in the request resturn their values,
 -- else return an error message.
-getParams :: Rec MyParamId ts -> IdeRequest -> Either IdeResponse (Rec ParamVal ts)
+getParams :: Rec TaggedParamId ts -> IdeRequest -> Either IdeResponse (Rec ParamVal ts)
 getParams params req = go params
   where
-    go :: Rec MyParamId ts -> Either IdeResponse (Rec ParamVal ts)
+    go :: Rec TaggedParamId ts -> Either IdeResponse (Rec ParamVal ts)
     go RNil = Right RNil
     go (x:&xs) = case go xs of
                     Left err -> Left err
                     Right ys -> case checkOne x of
                                   Left err -> Left err
                                   Right y -> Right (y:&ys)
-    checkOne :: MyParamId t -> Either IdeResponse (ParamVal t)
+    checkOne :: TaggedParamId t -> Either IdeResponse (ParamVal t)
     checkOne (IdText param) = case Map.lookup param (ideParams req) of
       Just (ParamTextP v)  -> Right (ParamText v)
       _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Haskell.Ide.Engine.PluginUtils
   (
@@ -17,13 +20,26 @@ import           Prelude hiding (log)
 
 -- |If all the listed params are present in the request resturn their values,
 -- else return an error message.
-getParams :: [ParamId] -> IdeRequest -> Either IdeResponse [ParamVal]
-getParams params req = mapEithers checkOne params
+getParams :: Rec MyParamId ts -> IdeRequest -> Either IdeResponse (Rec MyParamVal ts)
+getParams params req = go params
   where
-    checkOne :: ParamId -> Either IdeResponse ParamVal
-    checkOne param = case Map.lookup param (ideParams req) of
-      Nothing -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
-      Just v  -> Right v
+    go :: Rec MyParamId ts -> Either IdeResponse (Rec MyParamVal ts)
+    go RNil = Right RNil
+    go (x:&xs) = case go xs of
+                    Left err -> Left err
+                    Right ys -> case checkOne x of
+                                  Left err -> Left err
+                                  Right y -> Right (y:&ys)
+    checkOne :: MyParamId t -> Either IdeResponse (MyParamVal t)
+    checkOne (IdText param) = case Map.lookup param (ideParams req) of
+      Just (ParamText v)  -> Right (MyParamText v)
+      _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
+    checkOne (IdFile param) = case Map.lookup param (ideParams req) of
+      Just (ParamFile v)  -> Right (MyParamFile v)
+      _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
+    checkOne (IdPos param) = case Map.lookup param (ideParams req) of
+      Just (ParamPos v)  -> Right (MyParamPos v)
+      _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
 
 
 

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -20,25 +20,25 @@ import           Prelude hiding (log)
 
 -- |If all the listed params are present in the request resturn their values,
 -- else return an error message.
-getParams :: Rec MyParamId ts -> IdeRequest -> Either IdeResponse (Rec MyParamVal ts)
+getParams :: Rec MyParamId ts -> IdeRequest -> Either IdeResponse (Rec ParamVal ts)
 getParams params req = go params
   where
-    go :: Rec MyParamId ts -> Either IdeResponse (Rec MyParamVal ts)
+    go :: Rec MyParamId ts -> Either IdeResponse (Rec ParamVal ts)
     go RNil = Right RNil
     go (x:&xs) = case go xs of
                     Left err -> Left err
                     Right ys -> case checkOne x of
                                   Left err -> Left err
                                   Right y -> Right (y:&ys)
-    checkOne :: MyParamId t -> Either IdeResponse (MyParamVal t)
+    checkOne :: MyParamId t -> Either IdeResponse (ParamVal t)
     checkOne (IdText param) = case Map.lookup param (ideParams req) of
-      Just (ParamText v)  -> Right (MyParamText v)
+      Just (ParamValP (ParamText v))  -> Right (ParamText v)
       _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
     checkOne (IdFile param) = case Map.lookup param (ideParams req) of
-      Just (ParamFile v)  -> Right (MyParamFile v)
+      Just (ParamValP (ParamFile v))  -> Right (ParamFile v)
       _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
     checkOne (IdPos param) = case Map.lookup param (ideParams req) of
-      Just (ParamPos v)  -> Right (MyParamPos v)
+      Just (ParamValP (ParamPos v))  -> Right (ParamPos v)
       _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
 
 

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -32,13 +32,13 @@ getParams params req = go params
                                   Right y -> Right (y:&ys)
     checkOne :: MyParamId t -> Either IdeResponse (ParamVal t)
     checkOne (IdText param) = case Map.lookup param (ideParams req) of
-      Just (ParamValP (ParamText v))  -> Right (ParamText v)
+      Just (ParamTextP v)  -> Right (ParamText v)
       _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
     checkOne (IdFile param) = case Map.lookup param (ideParams req) of
-      Just (ParamValP (ParamFile v))  -> Right (ParamFile v)
+      Just (ParamFileP v)  -> Right (ParamFile v)
       _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
     checkOne (IdPos param) = case Map.lookup param (ideParams req) of
-      Just (ParamValP (ParamPos v))  -> Right (ParamPos v)
+      Just (ParamPosP v)  -> Right (ParamPos v)
       _ -> Left $ IdeResponseFail (toJSON $ "need `" ++ show param ++ "` parameter")
 
 

--- a/haskell-ide-plugin-api/haskell-ide-plugin-api.cabal
+++ b/haskell-ide-plugin-api/haskell-ide-plugin-api.cabal
@@ -20,5 +20,6 @@ library
                      , ghc
                      , text
                      , transformers
+                     , vinyl >= 0.5 && < 0.6
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -4,6 +4,7 @@
 module Haskell.Ide.GhcModPlugin where
 
 import           Control.Exception
+import           Data.Vinyl
 -- import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Aeson

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -53,7 +53,7 @@ checkCmd :: CommandFunc
 checkCmd _ctxs req = do
   case getParams (IdFile "file" :& RNil) req of
     Left err -> return err
-    Right (MyParamFile fileName :& RNil) -> do
+    Right (ParamFile fileName :& RNil) -> do
       liftIO $ doCheck (T.unpack fileName)
     Right _ -> error $ "GhcModPlugin.checkCmd: ghc’s exhaustiveness checker is broken"
 
@@ -63,7 +63,7 @@ typesCmd :: CommandFunc
 typesCmd _ctxs req = do
   case getParams (IdFile "file" :& IdPos "start_pos" :& RNil) req of
     Left err -> return err
-    Right (MyParamFile fileName :& MyParamPos (r,c) :& RNil) -> do
+    Right (ParamFile fileName :& ParamPos (r,c) :& RNil) -> do
       liftIO $ runGhcModCommand (GM.types (T.unpack fileName) r c)
     Right _ -> error $ "GhcModPlugin.checkCmd: ghc’s exhaustiveness checker is broken"
 

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
 module Haskell.Ide.GhcModPlugin where
 
 import           Control.Exception
@@ -50,21 +51,22 @@ ghcmodDescriptor = PluginDescriptor
 
 checkCmd :: CommandFunc
 checkCmd _ctxs req = do
-  case getParams ["file"] req of
+  case getParams (IdFile "file" :& RNil) req of
     Left err -> return err
-    Right [ParamFile fileName] -> do
+    Right (MyParamFile fileName :& RNil) -> do
       liftIO $ doCheck (T.unpack fileName)
-    Right x -> error $ "GhcModPlugin.checkCmd: got unexpected file param:" ++ show x
+    Right _ -> error $ "GhcModPlugin.checkCmd: ghc’s exhaustiveness checker is broken"
 
 -- ---------------------------------------------------------------------
 
 typesCmd :: CommandFunc
 typesCmd _ctxs req = do
-  case getParams ["file","start_pos"] req of
+  case getParams (IdFile "file" :& IdPos "start_pos" :& RNil) req of
     Left err -> return err
-    Right [ParamFile fileName,ParamPos (r,c)] -> do
+    Right (MyParamFile fileName :& MyParamPos (r,c) :& RNil) -> do
       liftIO $ runGhcModCommand (GM.types (T.unpack fileName) r c)
-    Right x -> error $ "GhcModPlugin.types: got unexpected file param:" ++ show x
+    Right _ -> error $ "GhcModPlugin.checkCmd: ghc’s exhaustiveness checker is broken"
+
 -- ---------------------------------------------------------------------
 
 -- doCheck :: (MonadIO m,GHC.GhcMonad m,HasIdeState m) => FilePath -> m IdeResponse

--- a/haskell-ide-plugin-ghcmod/haskell-ide-plugin-ghcmod.cabal
+++ b/haskell-ide-plugin-ghcmod/haskell-ide-plugin-ghcmod.cabal
@@ -21,5 +21,7 @@ library
                      , haskell-ide-plugin-api
                      , text
                      , transformers
+                     , vinyl >= 0.5 && < 0.6
+
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
+++ b/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
@@ -6,6 +6,7 @@ import           Control.Exception
 import           Control.Monad.IO.Class
 import           Data.Aeson
 import qualified Data.Text as T
+import           Data.Vinyl
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import qualified Language.Haskell.GhcMod as GM (defaultOptions)

--- a/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
+++ b/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
@@ -40,7 +40,7 @@ renameCmd :: CommandFunc
 renameCmd _ctxs req = do
   case getParams (IdFile "file" :& IdPos "start_pos" :& IdText "name" :& RNil) req of
     Left err -> return err
-    Right (MyParamFile fileName :& MyParamPos pos :& MyParamText name :& RNil) -> do
+    Right (ParamFile fileName :& ParamPos pos :& ParamText name :& RNil) -> do
       res <- liftIO $ catchException $ rename defaultSettings GM.defaultOptions (T.unpack fileName) (T.unpack name) pos
       case res of
         Left err -> return (IdeResponseFail (toJSON err))

--- a/haskell-ide-plugin-hare/haskell-ide-plugin-hare.cabal
+++ b/haskell-ide-plugin-hare/haskell-ide-plugin-hare.cabal
@@ -22,5 +22,6 @@ library
                      , haskell-ide-plugin-api
                      , text
                      , transformers
+                     , vinyl >= 0.5 && < 0.6
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -110,7 +110,7 @@ commandsCmd _ req = do
   -- TODO: Use Maybe Monad. What abut error reporting?
   case Map.lookup "plugin" (ideParams req) of
     Nothing -> return (IdeResponseFail (toJSON $ T.pack "need 'plugin' parameter"))
-    Just (ParamValP (ParamText p)) -> case Map.lookup p plugins of
+    Just (ParamTextP p) -> case Map.lookup p plugins of
       Nothing -> return (IdeResponseFail (toJSON $ "Can't find plugin:'" <> p <> "'"))
       Just pl -> return (IdeResponseOk (toJSON $ map (cmdName . cmdDesc) $ pdCommands pl))
     Just x -> return $ (IdeResponseFail (toJSON $ "invalid parameter for plugin:" ++ show x))
@@ -138,7 +138,7 @@ cwdCmd :: CommandFunc
 cwdCmd _ req = do
   case Map.lookup "dir" (ideParams req) of
     Nothing -> return (IdeResponseFail (String "need 'dir' parameter"))
-    Just (ParamValP (ParamFile dir)) -> do
+    Just (ParamFileP dir) -> do
       liftIO $ setCurrentDirectory (T.unpack dir)
       return (IdeResponseOk Null)
     Just x -> return $ (IdeResponseFail (toJSON $ "invalid parameter for plugin:" ++ show x))

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -110,7 +110,7 @@ commandsCmd _ req = do
   -- TODO: Use Maybe Monad. What abut error reporting?
   case Map.lookup "plugin" (ideParams req) of
     Nothing -> return (IdeResponseFail (toJSON $ T.pack "need 'plugin' parameter"))
-    Just (ParamText p) -> case Map.lookup p plugins of
+    Just (ParamValP (ParamText p)) -> case Map.lookup p plugins of
       Nothing -> return (IdeResponseFail (toJSON $ "Can't find plugin:'" <> p <> "'"))
       Just pl -> return (IdeResponseOk (toJSON $ map (cmdName . cmdDesc) $ pdCommands pl))
     Just x -> return $ (IdeResponseFail (toJSON $ "invalid parameter for plugin:" ++ show x))
@@ -120,7 +120,7 @@ commandDetailCmd _ req = do
   plugins <- getPlugins
   case getParams (IdText "plugin" :& IdText "command" :& RNil) req of
     Left err -> return err
-    Right (MyParamText p :& MyParamText command :& RNil) -> do
+    Right (ParamText p :& ParamText command :& RNil) -> do
       case Map.lookup p plugins of
         Nothing -> return (IdeResponseFail (toJSON $ "Can't find plugin:'" <> p <> "'"))
         Just pl -> case find (\cmd -> command == (cmdName $ cmdDesc cmd) ) (pdCommands pl) of
@@ -138,7 +138,7 @@ cwdCmd :: CommandFunc
 cwdCmd _ req = do
   case Map.lookup "dir" (ideParams req) of
     Nothing -> return (IdeResponseFail (String "need 'dir' parameter"))
-    Just (ParamFile dir) -> do
+    Just (ParamValP (ParamFile dir)) -> do
       liftIO $ setCurrentDirectory (T.unpack dir)
       return (IdeResponseOk Null)
     Just x -> return $ (IdeResponseFail (toJSON $ "invalid parameter for plugin:" ++ show x))

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
 module Haskell.Ide.Engine.BasePlugin where
 
 import           Control.Monad
@@ -117,15 +118,15 @@ commandsCmd _ req = do
 commandDetailCmd :: CommandFunc
 commandDetailCmd _ req = do
   plugins <- getPlugins
-  case getParams ["plugin","command"] req of
+  case getParams (IdText "plugin" :& IdText "command" :& RNil) req of
     Left err -> return err
-    Right [ParamText p,ParamText command] -> do
+    Right (MyParamText p :& MyParamText command :& RNil) -> do
       case Map.lookup p plugins of
         Nothing -> return (IdeResponseFail (toJSON $ "Can't find plugin:'" <> p <> "'"))
         Just pl -> case find (\cmd -> command == (cmdName $ cmdDesc cmd) ) (pdCommands pl) of
           Nothing -> return (IdeResponseFail (toJSON $ "Can't find command:'" <> command <> "'"))
           Just detail -> return (IdeResponseOk (toJSON (cmdDesc detail)))
-    Right _ -> error $ "commandDetailCmd:should not be possible"
+    Right _ -> error $ "commandDetailCmd: ghc’s exhaustiveness checker is broken"
 
 
 pwdCmd :: CommandFunc

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -8,15 +8,16 @@ import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Data.Foldable
 import           Data.List
+import qualified Data.Map as Map
 import           Data.Monoid
 import qualified Data.Text as T
+import           Data.Vinyl
 import           Development.GitRev (gitCommitCount)
 import           Distribution.System (buildArch)
 import           Distribution.Text (display)
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Options.Applicative.Simple (simpleVersion)
-import qualified Data.Map as Map
 import qualified Paths_haskell_ide_engine as Meta
 import           Prelude hiding (log)
 import           System.Directory

--- a/src/Haskell/Ide/Engine/Console.hs
+++ b/src/Haskell/Ide/Engine/Console.hs
@@ -88,20 +88,21 @@ describeDescriptor d =
 
 -- ---------------------------------------------------------------------
 
-convertToParams :: CommandDescriptor -> [T.Text] -> Map.Map T.Text ParamVal
+convertToParams :: CommandDescriptor -> [T.Text] -> ParamMap
 convertToParams cmd ss = Map.fromList $ map (\(k,v) -> (k,convertParam k v)) $  map splitOnColon ss
   where
     possibleParams = cmdAdditionalParams cmd ++ (concatMap contextMapping $ cmdContexts cmd)
     possibles = Map.fromList $ map (\pd -> (pName pd,pd)) possibleParams
+    convertParam :: T.Text -> T.Text -> ParamValP
     convertParam pn str =
       case Map.lookup pn possibles of
-        Nothing -> ParamText str -- TODO: should this be an error of some kind
+        Nothing -> ParamValP $ ParamText str -- TODO: should this be an error of some kind
         Just p -> case pType p of
-          PtText -> ParamText str
-          PtFile -> ParamFile str
+          PtText -> ParamValP $ ParamText str
+          PtFile -> ParamValP $ ParamFile str
           PtPos  -> case parseOnly parsePos str of
-            Left _err -> ParamText str -- TODO: should this be an error of some kind
-            Right pos -> ParamPos pos
+            Left _err -> ParamValP $ ParamText str -- TODO: should this be an error of some kind
+            Right pos -> ParamValP $ ParamPos pos
 
 parseInt :: Parser Int
 parseInt = do

--- a/src/Haskell/Ide/Engine/Console.hs
+++ b/src/Haskell/Ide/Engine/Console.hs
@@ -96,13 +96,13 @@ convertToParams cmd ss = Map.fromList $ map (\(k,v) -> (k,convertParam k v)) $  
     convertParam :: T.Text -> T.Text -> ParamValP
     convertParam pn str =
       case Map.lookup pn possibles of
-        Nothing -> ParamValP $ ParamText str -- TODO: should this be an error of some kind
+        Nothing -> ParamTextP str -- TODO: should this be an error of some kind
         Just p -> case pType p of
-          PtText -> ParamValP $ ParamText str
-          PtFile -> ParamValP $ ParamFile str
+          PtText -> ParamTextP str
+          PtFile -> ParamFileP str
           PtPos  -> case parseOnly parsePos str of
-            Left _err -> ParamValP $ ParamText str -- TODO: should this be an error of some kind
-            Right pos -> ParamValP $ ParamPos pos
+            Left _err -> ParamTextP str -- TODO: should this be an error of some kind
+            Right pos -> ParamPosP pos
 
 parseInt :: Parser Int
 parseInt = do

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -118,7 +118,7 @@ checkParams pds params = mapEithers checkOne pds
 
 
     paramMatches :: ParamType -> ParamValP -> Bool
-    paramMatches PtText (ParamValP (ParamText _)) = True
-    paramMatches PtFile (ParamValP (ParamFile _)) = True
-    paramMatches PtPos  (ParamValP (ParamPos _))  = True
+    paramMatches PtText (ParamTextP _) = True
+    paramMatches PtFile (ParamFileP _) = True
+    paramMatches PtPos  (ParamPosP _)  = True
     paramMatches _       _            = False

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -79,7 +79,7 @@ channelToWire cr =
 
 data WireRequest = WireReq
   { cmd     :: T.Text -- ^combination of PluginId ":" CommandName
-  , params  :: Map.Map ParamId ParamVal
+  , params  :: ParamMap
   } deriving (Show,Eq)
 
 instance A.ToJSON WireRequest where

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -55,7 +55,7 @@ dispatcherSpec = do
 
     it "identifies CtxFile" $ do
       chan <- newChan
-      let req = IdeRequest "cmd2" (Map.fromList [("file",ParamFile "foo.hs")])
+      let req = IdeRequest "cmd2" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile]\")"
@@ -64,7 +64,7 @@ dispatcherSpec = do
 
     it "identifies CtxPoint" $ do
       chan <- newChan
-      let req = IdeRequest "cmd3" (Map.fromList [("file",ParamFile "foo.hs"),("start_pos",ParamPos (1,2))])
+      let req = IdeRequest "cmd3" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs"),("start_pos",ParamValP $ ParamPos (1,2))])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxPoint]\")"
@@ -73,9 +73,9 @@ dispatcherSpec = do
 
     it "identifies CtxRegion" $ do
       chan <- newChan
-      let req = IdeRequest "cmd4" (Map.fromList [("file",ParamFile "foo.hs")
-                                                ,("start_pos",ParamPos (1,2))
-                                                ,("end_pos",ParamPos (3,4))])
+      let req = IdeRequest "cmd4" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
+                                                ,("start_pos",ParamValP $ ParamPos (1,2))
+                                                ,("end_pos",ParamValP $ ParamPos (3,4))])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxRegion]\")"
@@ -84,7 +84,7 @@ dispatcherSpec = do
 
     it "identifies CtxCabal" $ do
       chan <- newChan
-      let req = IdeRequest "cmd5" (Map.fromList [("cabal",ParamText "lib")])
+      let req = IdeRequest "cmd5" (Map.fromList [("cabal",ParamValP $ ParamText "lib")])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxCabalTarget]\")"
@@ -103,9 +103,9 @@ dispatcherSpec = do
 
     it "identifies all multiple" $ do
       chan <- newChan
-      let req = IdeRequest "cmdmultiple" (Map.fromList [("file",ParamFile "foo.hs")
-                                                       ,("start_pos",ParamPos (1,2))
-                                                       ,("end_pos",ParamPos (3,4))])
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
+                                                       ,("start_pos",ParamValP $ ParamPos (1,2))
+                                                       ,("end_pos",ParamValP $ ParamPos (3,4))])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile,CtxPoint,CtxRegion]\")"
@@ -115,8 +115,8 @@ dispatcherSpec = do
 
     it "identifies CtxFile,CtxPoint multiple" $ do
       chan <- newChan
-      let req = IdeRequest "cmdmultiple" (Map.fromList [("file",ParamFile "foo.hs")
-                                                       ,("start_pos",ParamPos (1,2))])
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
+                                                       ,("start_pos",ParamValP $ ParamPos (1,2))])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile,CtxPoint]\")"
@@ -125,7 +125,7 @@ dispatcherSpec = do
 
     it "identifies error when no match multiple" $ do
       chan <- newChan
-      let req = IdeRequest "cmdmultiple" (Map.fromList [("cabal",ParamText "lib")])
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("cabal",ParamValP $ ParamText "lib")])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseFail (String \"missing parameter '\\\"file\\\"'\")"
@@ -137,10 +137,10 @@ dispatcherSpec = do
 
     it "identifies matching params" $ do
       chan <- newChan
-      let req = IdeRequest "cmdextra" (Map.fromList [("file",ParamFile "foo.hs")
-                                                    ,("txt", ParamText "a")
-                                                    ,("file",ParamFile "f")
-                                                    ,("pos", ParamPos (1,2))
+      let req = IdeRequest "cmdextra" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
+                                                    ,("txt", ParamValP $ ParamText "a")
+                                                    ,("file",ParamValP $ ParamFile "f")
+                                                    ,("pos", ParamValP $ ParamPos (1,2))
                                                     ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
@@ -150,23 +150,23 @@ dispatcherSpec = do
 
     it "reports mismatched param" $ do
       chan <- newChan
-      let req = IdeRequest "cmdextra" (Map.fromList [("file",ParamFile "foo.hs")
-                                                    ,("txt", ParamFile "a")
-                                                    ,("file",ParamFile "f")
-                                                    ,("pos", ParamPos (1,2))
+      let req = IdeRequest "cmdextra" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
+                                                    ,("txt", ParamValP $ ParamFile "a")
+                                                    ,("file",ParamValP $ ParamFile "f")
+                                                    ,("pos", ParamValP $ ParamPos (1,2))
                                                     ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch for 'txt', expected PtText but got ParamFile \\\"a\\\"\")"
+      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch for 'txt', expected PtText but got ParamValP {unParamValP = ParamFile \\\"a\\\"}\")"
 
 
     -- ---------------------------------
 
     it "reports matched optional param" $ do
       chan <- newChan
-      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",  ParamText "a")
-                                                       ,("fileo",ParamFile "f")
-                                                       ,("poso", ParamPos (1,2))
+      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",  ParamValP $ ParamText "a")
+                                                       ,("fileo",ParamValP $ ParamFile "f")
+                                                       ,("poso", ParamValP $ ParamPos (1,2))
                                                        ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
@@ -176,13 +176,13 @@ dispatcherSpec = do
 
     it "reports mismatched optional param" $ do
       chan <- newChan
-      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",  ParamText "a")
-                                                       ,("fileo",ParamText "f")
-                                                       ,("poso", ParamPos (1,2))
+      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",  ParamValP $ ParamText "a")
+                                                       ,("fileo",ParamValP $ ParamText "f")
+                                                       ,("poso", ParamValP $ ParamPos (1,2))
                                                        ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch for 'fileo', expected PtFile but got ParamText \\\"f\\\"\")"
+      (show r) `shouldBe` "IdeResponseFail (String \"parameter type mismatch for 'fileo', expected PtFile but got ParamValP {unParamValP = ParamText \\\"f\\\"}\")"
 
 -- ---------------------------------------------------------------------
 

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -55,7 +55,7 @@ dispatcherSpec = do
 
     it "identifies CtxFile" $ do
       chan <- newChan
-      let req = IdeRequest "cmd2" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")])
+      let req = IdeRequest "cmd2" (Map.fromList [("file", ParamFileP "foo.hs")])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile]\")"
@@ -64,7 +64,7 @@ dispatcherSpec = do
 
     it "identifies CtxPoint" $ do
       chan <- newChan
-      let req = IdeRequest "cmd3" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs"),("start_pos",ParamValP $ ParamPos (1,2))])
+      let req = IdeRequest "cmd3" (Map.fromList [("file", ParamFileP "foo.hs"),("start_pos", ParamPosP (1,2))])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxPoint]\")"
@@ -73,9 +73,9 @@ dispatcherSpec = do
 
     it "identifies CtxRegion" $ do
       chan <- newChan
-      let req = IdeRequest "cmd4" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
-                                                ,("start_pos",ParamValP $ ParamPos (1,2))
-                                                ,("end_pos",ParamValP $ ParamPos (3,4))])
+      let req = IdeRequest "cmd4" (Map.fromList [("file", ParamFileP "foo.hs")
+                                                ,("start_pos", ParamPosP (1,2))
+                                                ,("end_pos", ParamPosP (3,4))])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxRegion]\")"
@@ -84,7 +84,7 @@ dispatcherSpec = do
 
     it "identifies CtxCabal" $ do
       chan <- newChan
-      let req = IdeRequest "cmd5" (Map.fromList [("cabal",ParamValP $ ParamText "lib")])
+      let req = IdeRequest "cmd5" (Map.fromList [("cabal", ParamTextP "lib")])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxCabalTarget]\")"
@@ -103,9 +103,9 @@ dispatcherSpec = do
 
     it "identifies all multiple" $ do
       chan <- newChan
-      let req = IdeRequest "cmdmultiple" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
-                                                       ,("start_pos",ParamValP $ ParamPos (1,2))
-                                                       ,("end_pos",ParamValP $ ParamPos (3,4))])
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("file", ParamFileP "foo.hs")
+                                                       ,("start_pos", ParamPosP (1,2))
+                                                       ,("end_pos", ParamPosP (3,4))])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile,CtxPoint,CtxRegion]\")"
@@ -115,8 +115,8 @@ dispatcherSpec = do
 
     it "identifies CtxFile,CtxPoint multiple" $ do
       chan <- newChan
-      let req = IdeRequest "cmdmultiple" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
-                                                       ,("start_pos",ParamValP $ ParamPos (1,2))])
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("file", ParamFileP "foo.hs")
+                                                       ,("start_pos", ParamPosP (1,2))])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseOk (String \"result:ctxs=[CtxFile,CtxPoint]\")"
@@ -125,7 +125,7 @@ dispatcherSpec = do
 
     it "identifies error when no match multiple" $ do
       chan <- newChan
-      let req = IdeRequest "cmdmultiple" (Map.fromList [("cabal",ParamValP $ ParamText "lib")])
+      let req = IdeRequest "cmdmultiple" (Map.fromList [("cabal", ParamTextP "lib")])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
       (show r) `shouldBe` "IdeResponseFail (String \"missing parameter '\\\"file\\\"'\")"
@@ -137,10 +137,10 @@ dispatcherSpec = do
 
     it "identifies matching params" $ do
       chan <- newChan
-      let req = IdeRequest "cmdextra" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
-                                                    ,("txt", ParamValP $ ParamText "a")
-                                                    ,("file",ParamValP $ ParamFile "f")
-                                                    ,("pos", ParamValP $ ParamPos (1,2))
+      let req = IdeRequest "cmdextra" (Map.fromList [("file", ParamFileP "foo.hs")
+                                                    ,("txt",  ParamTextP "a")
+                                                    ,("file", ParamFileP "f")
+                                                    ,("pos",  ParamPosP (1,2))
                                                     ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
@@ -150,10 +150,10 @@ dispatcherSpec = do
 
     it "reports mismatched param" $ do
       chan <- newChan
-      let req = IdeRequest "cmdextra" (Map.fromList [("file",ParamValP $ ParamFile "foo.hs")
-                                                    ,("txt", ParamValP $ ParamFile "a")
-                                                    ,("file",ParamValP $ ParamFile "f")
-                                                    ,("pos", ParamValP $ ParamPos (1,2))
+      let req = IdeRequest "cmdextra" (Map.fromList [("file", ParamFileP "foo.hs")
+                                                    ,("txt",  ParamFileP "a")
+                                                    ,("file", ParamFileP "f")
+                                                    ,("pos",  ParamPosP (1,2))
                                                     ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
@@ -164,9 +164,9 @@ dispatcherSpec = do
 
     it "reports matched optional param" $ do
       chan <- newChan
-      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",  ParamValP $ ParamText "a")
-                                                       ,("fileo",ParamValP $ ParamFile "f")
-                                                       ,("poso", ParamValP $ ParamPos (1,2))
+      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",   ParamTextP "a")
+                                                       ,("fileo", ParamFileP "f")
+                                                       ,("poso",  ParamPosP (1,2))
                                                        ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
@@ -176,9 +176,9 @@ dispatcherSpec = do
 
     it "reports mismatched optional param" $ do
       chan <- newChan
-      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",  ParamValP $ ParamText "a")
-                                                       ,("fileo",ParamValP $ ParamText "f")
-                                                       ,("poso", ParamValP $ ParamPos (1,2))
+      let req = IdeRequest "cmdoptional" (Map.fromList [("txt",   ParamTextP "a")
+                                                       ,("fileo", ParamTextP "f")
+                                                       ,("poso",  ParamPosP (1,2))
                                                        ])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -31,17 +31,17 @@ ghcmodSpec :: Spec
 ghcmodSpec = do
   describe "ghc-mod plugin commands" $ do
     it "runs the check command" $ do
-      let req = IdeRequest "check" (Map.fromList [("file", ParamValP $ ParamFile "./test/testdata/FileWithWarning.hs")])
+      let req = IdeRequest "check" (Map.fromList [("file", ParamFileP "./test/testdata/FileWithWarning.hs")])
       r <- runIdeM (IdeState Map.empty) (checkCmd [] req)
       (show r) `shouldBe` "IdeResponseOk (String \"test/testdata/FileWithWarning.hs:4:7:Not in scope: \\8216x\\8217\\n\")"
 
     it "runs the types command, incorrect params" $ do
-      let req = IdeRequest "types" (Map.fromList [("file", ParamValP $ ParamFile "./test/testdata/FileWithWarning.hs")])
+      let req = IdeRequest "types" (Map.fromList [("file", ParamFileP "./test/testdata/FileWithWarning.hs")])
       r <- runIdeM (IdeState Map.empty) (typesCmd [] req)
       (show r) `shouldBe` "IdeResponseFail (String \"need `\\\"start_pos\\\"` parameter\")"
 
     it "runs the types command, correct params" $ do
-      let req = IdeRequest "types" (Map.fromList [("file", ParamValP $ ParamFile "./test/testdata/HaReRename.hs")
-                                                 ,("start_pos", ParamValP $ ParamPos (5,9))])
+      let req = IdeRequest "types" (Map.fromList [("file", ParamFileP "./test/testdata/HaReRename.hs")
+                                                 ,("start_pos", ParamPosP (5,9))])
       r <- runIdeM (IdeState Map.empty) (typesCmd [] req)
       (show r) `shouldBe` "IdeResponseOk (String \"5 9 5 10 \\\"Int\\\"\\n5 9 5 14 \\\"Int\\\"\\n5 1 5 14 \\\"Int -> Int\\\"\\n\")"

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -31,17 +31,17 @@ ghcmodSpec :: Spec
 ghcmodSpec = do
   describe "ghc-mod plugin commands" $ do
     it "runs the check command" $ do
-      let req = IdeRequest "check" (Map.fromList [("file", ParamFile "./test/testdata/FileWithWarning.hs")])
+      let req = IdeRequest "check" (Map.fromList [("file", ParamValP $ ParamFile "./test/testdata/FileWithWarning.hs")])
       r <- runIdeM (IdeState Map.empty) (checkCmd [] req)
       (show r) `shouldBe` "IdeResponseOk (String \"test/testdata/FileWithWarning.hs:4:7:Not in scope: \\8216x\\8217\\n\")"
 
     it "runs the types command, incorrect params" $ do
-      let req = IdeRequest "types" (Map.fromList [("file", ParamFile "./test/testdata/FileWithWarning.hs")])
+      let req = IdeRequest "types" (Map.fromList [("file", ParamValP $ ParamFile "./test/testdata/FileWithWarning.hs")])
       r <- runIdeM (IdeState Map.empty) (typesCmd [] req)
       (show r) `shouldBe` "IdeResponseFail (String \"need `\\\"start_pos\\\"` parameter\")"
 
     it "runs the types command, correct params" $ do
-      let req = IdeRequest "types" (Map.fromList [("file", ParamFile "./test/testdata/HaReRename.hs")
-                                                 ,("start_pos", ParamPos (5,9))])
+      let req = IdeRequest "types" (Map.fromList [("file", ParamValP $ ParamFile "./test/testdata/HaReRename.hs")
+                                                 ,("start_pos", ParamValP $ ParamPos (5,9))])
       r <- runIdeM (IdeState Map.empty) (typesCmd [] req)
       (show r) `shouldBe` "IdeResponseOk (String \"5 9 5 10 \\\"Int\\\"\\n5 9 5 14 \\\"Int\\\"\\n5 1 5 14 \\\"Int -> Int\\\"\\n\")"

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -32,11 +32,15 @@ hareSpec :: Spec
 hareSpec = do
   describe "hare plugin commands" $ do
     it "renames" $ do
-      let req = IdeRequest "rename" (Map.fromList [("file",ParamFile "./test/testdata/HaReRename.hs"),("start_pos",ParamPos (5,1)),("name",ParamText "foolong")])
+      let req = IdeRequest "rename" (Map.fromList [("file",ParamValP $ ParamFile "./test/testdata/HaReRename.hs")
+                                                  ,("start_pos",ParamValP $ ParamPos (5,1))
+                                                  ,("name",ParamValP $ ParamText "foolong")])
       r <- runIdeM (IdeState Map.empty) (renameCmd [] req)
       (show r) `shouldBe` "IdeResponseOk (Array [String \"test/testdata/HaReRename.hs\"])"
 
     it "returns an error for invalid rename" $ do
-      let req = IdeRequest "rename" (Map.fromList [("file",ParamFile "./test/testdata/HaReRename.hs"),("start_pos",ParamPos (15,1)),("name",ParamText "foolong")])
+      let req = IdeRequest "rename" (Map.fromList [("file",ParamValP $ ParamFile "./test/testdata/HaReRename.hs")
+                                                  ,("start_pos",ParamValP $ ParamPos (15,1))
+                                                  ,("name",ParamValP $ ParamText "foolong")])
       r <- runIdeM (IdeState Map.empty) (renameCmd [] req)
       (show r) `shouldBe` "IdeResponseFail (String \"Invalid cursor position!\")"

--- a/test/JsonStdioSpec.hs
+++ b/test/JsonStdioSpec.hs
@@ -35,7 +35,7 @@ jsonSpec = do
                               \\"cmd\":\"eg1:hello\"}"
 
     it "generates a WireRequest 2" $ do
-      let wr = WireReq "eg2:helloTo"  (Map.fromList [("cabal",ParamText "lib"),("name",ParamText "foo")])
+      let wr = WireReq "eg2:helloTo"  (Map.fromList [("cabal",ParamValP $ ParamText "lib"),("name",ParamValP $ ParamText "foo")])
       (encode wr) `shouldBe` "{\"params\":{\"cabal\":{\"tag\":\"text\",\"contents\":\"lib\"},\
                                           \\"name\":{\"tag\":\"text\",\"contents\":\"foo\"}},\
                               \\"cmd\":\"eg2:helloTo\"}"
@@ -48,7 +48,7 @@ jsonSpec = do
          `shouldBe` (Just wr)
 
     it "parses a WireRequest 2" $ do
-      let wr = WireReq "eg2:helloTo" (Map.fromList [("name",ParamText "foo")])
+      let wr = WireReq "eg2:helloTo" (Map.fromList [("name",ParamValP $ ParamText "foo")])
       (decode "{\"params\":{\"name\":{\"tag\":\"text\",\"contents\":\"foo\"}},\
                \\"cmd\":\"eg2:helloTo\"}")
          `shouldBe` (Just wr)


### PR DESCRIPTION
So apart from my terrible names (that's why it's marked as WIP), there are a couple of things here.

- The `Rec` datatype is the same as the one from Vinyl, I am not sure if it's worth pulling that in as a dependency for only one type.
- The duplication is not nice, the problem is that we need to stuff that in the map and maps want a monomorphic type, so you would need to put it in a RankNType to hide the tag, but that still doesn't work because now you can no longer derive Generic and Show. Show is easily fixable using StandaloneDeriving, Generic is not because you can't derive Generic for RankNTypes. We can just not derive Generic, but we need that for the json stuff, so we would need to manually write a ToJSON and FromJSON instance for ParamMap which doesn't seem to be easily possible since you can't make instances of RankNTypes. I'll try to find a solution later, but I doubt we'll get around the duplication.
- We can't use standard list syntax (overloaded lists also don't allow for that kind of list).
- We have to specify the types of the parameters passed to `getParams`. I actually consider that to be a good thing, but it might be annoying sometimes.