### PR TITLE
Expect json input separated by STX, fix #43

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -25,10 +25,10 @@ library
                        Haskell.Ide.Engine.Transport.JsonStdio
                        Haskell.Ide.Engine.Types
   other-modules:       Paths_haskell_ide_engine
-  build-depends:       base >= 4.7 && < 5
-                     , Cabal >= 1.22
+  build-depends:       Cabal >= 1.22
                      , aeson
                      , attoparsec
+                     , base >= 4.7 && < 5
                      , bytestring
                      , containers
                      , directory
@@ -46,6 +46,7 @@ library
                      , optparse-simple >= 0.0.3
                      , pipes
                      , pipes-aeson
+                     , pipes-attoparsec >= 0.5
                      , pipes-bytestring
                      , pipes-parse
                      , servant-server

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -233,6 +233,7 @@ data IdeErrorCode = IncorrectParameterType  -- ^ Wrong parameter type
                   | InvalidContext          -- ^ Context invalid for command
                   | OtherError              -- ^ An error for which we didn't
                                             -- have a better code
+                  | ParseError              -- ^ Input could not be parsed
                   deriving (Show,Read,Eq,Ord,Bounded,Enum,Generic)
 
 -- | A more structured error than just a string

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -46,7 +46,7 @@ parseToJsonPipe cin cout cid =
          do let rsp =
                   CResp "" cid $
                   IdeResponseError
-                    (A.toJSON (HieError (A.String $ T.pack $ show decodeErr)))
+                    (IdeError ParseError (T.pack $ show decodeErr) Nothing)
             liftIO $ debug $
               T.pack $ "jsonStdioTransport:parse error:" ++ show decodeErr
             P.yield $ A.toJSON $ channelToWire rsp

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -94,9 +94,9 @@ parseFrames prod0 = do
                                            A.Success wireReq -> Right wireReq
 
            P.yield wrappedRet
-           -- prod3 is guaranteed to be empty by the use of A8.endOfInput in ap1
+           -- leftoverProd is guaranteed to be empty by the use of A8.endOfInput in ap1
            newProd <- lift $ P.runEffect (leftoverProd P.>-> P.drain)
-           -- recur into parseLines to parse the next line, drop the leading '\n'
+           -- recur into parseFrames to parse the next line, drop the leading '\n'
            parseFrames (PB.drop (1::Int) newProd)
 
 -- to help with type inference


### PR DESCRIPTION
So we now exit if we get invalid input which means either a parse failure or some random stuff between a parse and a separator. in particular that means that each message must be followed by a separator directly which seems reasonable to me.