### PR TITLE
Enrich plugins call

### DIFF
--- a/elisp/tests/haskell-ide-engine-tests.el
+++ b/elisp/tests/haskell-ide-engine-tests.el
@@ -148,7 +148,11 @@ http://debbugs.gnu.org/cgi/bugreport.cgi?bug=15990."
    (should response)
 
    (should (equal '(tag . "Ok") (assq 'tag response)))
-   (should (assq 'contents response))))
+   (should (assq 'contents response))
+   (should (assq 'base (assq 'contents response)))
+   (should (assq 'commands (assq 'base (assq 'contents response))))
+   (should (cl-find-if (lambda (item) (equal '(name . "version") (assq 'name item)))
+                       (cdr (assq 'commands (assq 'base (assq 'contents response))))))))
 
 (haskell-ide-engine-define-test
  haskell-ide-engine-can-list-commands-for-base

--- a/elisp/tests/haskell-ide-engine-tests.el
+++ b/elisp/tests/haskell-ide-engine-tests.el
@@ -154,46 +154,6 @@ http://debbugs.gnu.org/cgi/bugreport.cgi?bug=15990."
    (should (cl-find-if (lambda (item) (equal '(name . "version") (assq 'name item)))
                        (cdr (assq 'commands (assq 'base (assq 'contents response))))))))
 
-(haskell-ide-engine-define-test
- haskell-ide-engine-can-list-commands-for-base
-
- ;; starts the process
- (should (haskell-ide-engine-start-process))
-
- (let ((response))
-   (setq haskell-ide-engine-process-handle-message
-         (lambda (json)
-           (setq response json)))
-   (haskell-ide-engine-post-message
-    '(("cmd" . "base:commands") ("params" . (("plugin" . (("contents" . "base") ("tag" . "text")))))))
-
-   (really-sleep-for 2)
-   (should response)
-
-   (should (equal '(tag . "Ok") (assq 'tag response)))
-   (should (assq 'contents response))
-   (should (member "version" (assq 'contents response)))))
-
-(haskell-ide-engine-define-test
- haskell-ide-engine-can-list-command-details-for-base-plugins
-
- ;; starts the process
- (should (haskell-ide-engine-start-process))
-
- (let ((response))
-   (setq haskell-ide-engine-process-handle-message
-         (lambda (json)
-           (setq response json)))
-   (haskell-ide-engine-post-message
-    '(("cmd" . "base:commandDetail") ("params" . (("plugin" . (("tag" . "text") ("contents"  . "base"))) ("command" . (("tag" . "text") ("contents" . "plugins")))))))
-
-   (really-sleep-for 2)
-
-   (should response)
-
-   (should (equal '(tag . "Ok") (assq 'tag response)))
-   (should (assq 'contents response))
-   (should (equal '(name . "plugins") (assq 'name (assq 'contents response))))))
 
 (ert-deftest haskell-ide-engine-can-handle-invalid-input ()
 

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -341,6 +341,32 @@ instance FromJSON CommandDescriptor where
 
 -- -------------------------------------
 
+instance ToJSON Service where
+    toJSON service = object [ "name" .= svcName service ]
+
+
+instance FromJSON Service where
+    parseJSON (Object v) =
+      Service <$> v .: "name"
+    parseJSON _ = empty
+
+-- -------------------------------------
+
+instance ToJSON PluginDescriptor where
+    toJSON pluginDescriptor = object [ "commands" .= map cmdDesc (pdCommands pluginDescriptor)
+                                     , "exposed_services" .= pdExposedServices pluginDescriptor
+                                     , "used_services" .= pdUsedServices pluginDescriptor
+                                     ]
+
+instance FromJSON PluginDescriptor where
+    parseJSON (Object v) =
+      PluginDescriptor <$> (fmap (fmap (\desc -> Command desc (error "missing"))) (v .: "commands"))
+                       <*> v .: "exposed_services"
+                       <*> v .: "used_services"
+    parseJSON _ = empty
+
+-- -------------------------------------
+
 instance ToJSON IdeRequest where
   toJSON (IdeRequest{ideCommand = command, ideParams = params}) =
     object [ "command" .= command

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -81,7 +81,7 @@ versionCmd _ _ = return (IdeResponseOk (String $ T.pack version))
 pluginsCmd :: CommandFunc
 pluginsCmd _ _ = do
   plugins <- getPlugins
-  return (IdeResponseOk (toJSON $ Map.keys plugins))
+  return (IdeResponseOk (toJSON $ plugins))
 
 commandsCmd :: CommandFunc
 commandsCmd _ req = do


### PR DESCRIPTION
An Editor's side it is rare to work with a single command so it makes sense to batch queries about all available commands and command details.

This commits puts all the information about a plugin into 'plugins' call and remove the (now redundant) 'commands' and 'commandDetails' calls.