### PR TITLE
Async dispatch

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -4,11 +4,13 @@
 
 module Main where
 
-import           Control.Monad
-import           Control.Monad.Trans.Maybe
 import           Control.Concurrent
+import           Control.Concurrent.STM.TChan
 import           Control.Exception
 import           Control.Logging
+import           Control.Monad
+import           Control.Monad.STM
+import           Control.Monad.Trans.Maybe
 import qualified Data.Map as Map
 import           Data.Version (showVersion)
 import           Development.GitRev (gitCommitCount)
@@ -104,7 +106,7 @@ run opts = do
     getUserHomeDirectory >>= mapM_ setCurrentDirectory
 
     logm $  "run entered for HIE " ++ version
-    cin <- newChan :: IO (Chan ChannelRequest)
+    cin <- atomically newTChan :: IO (TChan ChannelRequest)
 
     -- log $ T.pack $ "replPluginInfo:" ++ show replPluginInfo
 
@@ -138,6 +140,6 @@ getUserHomeDirectory = do
 -- pass the request through to the main event dispatcher, and listen on the
 -- reply channel for the response, which should go back to the IDE, using
 -- whatever it takes.
-listener :: Chan ChannelRequest -> IO ()
+listener :: TChan ChannelRequest -> IO ()
 listener = assert False undefined
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -49,6 +49,7 @@ library
                      , pipes-attoparsec >= 0.5
                      , pipes-bytestring
                      , pipes-parse
+                     , stm
                      , servant-server
                      , text
                      , time
@@ -79,6 +80,7 @@ executable hie
                      , logging
                      , optparse-applicative
                      , optparse-simple
+                     , stm
                      , text
                      , time
                      , transformers
@@ -105,7 +107,10 @@ test-suite haskell-ide-test
                      , haskell-ide-plugin-ghcmod
                      , hspec
                      , logging
+                     , stm
                      , text
+                     , transformers
+                     , unordered-containers
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 

--- a/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/haskell-ide-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -45,10 +45,10 @@ example2Descriptor = PluginDescriptor
 -- ---------------------------------------------------------------------
 
 sayHelloCmd :: CommandFunc T.Text
-sayHelloCmd _  _ = return (IdeResponseOk sayHello)
+sayHelloCmd = CmdSync $ \_ _ -> return (IdeResponseOk sayHello)
 
 sayHelloToCmd :: CommandFunc T.Text
-sayHelloToCmd _ req = do
+sayHelloToCmd = CmdSync $ \_ req -> do
   case Map.lookup "name" (ideParams req) of
     Nothing -> return $ missingParameter "name"
     Just (ParamTextP n) -> do

--- a/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/haskell-ide-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -256,8 +256,16 @@ class (Monad m) => HasIdeState m where
 -- descriptor, and has all the required parameters. Where a command has only one
 -- allowed context the supplied context list does not add much value, but allows
 -- easy case checking when multiple contexts are supported.
-type CommandFunc resp = forall m. (MonadIO m,GHC.GhcMonad m,HasIdeState m)
+data CommandFunc resp = CmdSync (SyncCommandFunc resp)
+                      | CmdAsync (AsyncCommandFunc resp)
+                        -- ^ Note: does not forkIO, the command must decide when
+                        -- to do this.
+
+type SyncCommandFunc resp = forall m. (MonadIO m,GHC.GhcMonad m,HasIdeState m)
                 => [AcceptedContext] -> IdeRequest -> m (IdeResponse resp)
+
+type AsyncCommandFunc resp = forall m. (MonadIO m,GHC.GhcMonad m,HasIdeState m)
+                => (IdeResponse resp -> IO ()) -> [AcceptedContext] -> IdeRequest -> m ()
 
 -- ---------------------------------------------------------------------
 -- ValidResponse instances

--- a/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
+++ b/haskell-ide-plugin-ghcmod/Haskell/Ide/GhcModPlugin.hs
@@ -98,7 +98,7 @@ ghcmodDescriptor = PluginDescriptor
 -- ---------------------------------------------------------------------
 
 checkCmd :: CommandFunc String
-checkCmd _ctxs req = do
+checkCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& RNil) -> do
@@ -111,7 +111,7 @@ checkCmd _ctxs req = do
 -- TODO: Must define a directory to base the search from, to be able to resolve
 -- the project root.
 findCmd :: CommandFunc String
-findCmd _ctxs req = do
+findCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdText "symbol" :& RNil) req of
     Left err -> return err
     Right (ParamText _symbol :& RNil) -> do
@@ -126,7 +126,7 @@ findCmd _ctxs req = do
 -- ---------------------------------------------------------------------
 
 lintCmd :: CommandFunc String
-lintCmd _ctxs req = do
+lintCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& RNil) -> do
@@ -137,7 +137,7 @@ lintCmd _ctxs req = do
 -- ---------------------------------------------------------------------
 
 infoCmd :: CommandFunc String
-infoCmd _ctxs req = do
+infoCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& IdText "expr" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& ParamText expr :& RNil) -> do
@@ -148,7 +148,7 @@ infoCmd _ctxs req = do
 -- ---------------------------------------------------------------------
 
 typeCmd :: CommandFunc String
-typeCmd _ctxs req = do
+typeCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& IdPos "start_pos" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& ParamPos (r,c) :& RNil) -> do

--- a/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
+++ b/haskell-ide-plugin-hare/Haskell/Ide/HaRePlugin.hs
@@ -87,7 +87,7 @@ hareDescriptor = PluginDescriptor
 -- ---------------------------------------------------------------------
 
 demoteCmd :: CommandFunc [FilePath]
-demoteCmd _ctxs req = do
+demoteCmd  = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& IdPos "start_pos" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& RNil) -> do
@@ -106,7 +106,7 @@ demoteCmd _ctxs req = do
 -- ---------------------------------------------------------------------
 
 dupdefCmd :: CommandFunc [FilePath]
-dupdefCmd _ctxs req = do
+dupdefCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& IdPos "start_pos" :& IdText "name" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& ParamText name :& RNil) -> do
@@ -125,7 +125,7 @@ dupdefCmd _ctxs req = do
 -- ---------------------------------------------------------------------
 
 iftocaseCmd :: CommandFunc [FilePath]
-iftocaseCmd _ctxs req = do
+iftocaseCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& IdPos "start_pos" :& IdPos "end_pos" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& ParamPos start :& ParamPos end :& RNil) -> do
@@ -144,7 +144,7 @@ iftocaseCmd _ctxs req = do
 -- ---------------------------------------------------------------------
 
 liftonelevelCmd :: CommandFunc [FilePath]
-liftonelevelCmd _ctxs req = do
+liftonelevelCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& IdPos "start_pos" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& RNil) -> do
@@ -163,7 +163,7 @@ liftonelevelCmd _ctxs req = do
 -- ---------------------------------------------------------------------
 
 lifttotoplevelCmd :: CommandFunc [FilePath]
-lifttotoplevelCmd _ctxs req = do
+lifttotoplevelCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& IdPos "start_pos" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& RNil) -> do
@@ -182,7 +182,7 @@ lifttotoplevelCmd _ctxs req = do
 -- ---------------------------------------------------------------------
 
 renameCmd :: CommandFunc [FilePath]
-renameCmd _ctxs req = do
+renameCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& IdPos "start_pos" :& IdText "name" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& ParamText name :& RNil) -> do

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -76,15 +76,15 @@ baseDescriptor = PluginDescriptor
 -- ---------------------------------------------------------------------
 
 versionCmd :: CommandFunc String
-versionCmd _ _ = return (IdeResponseOk version)
+versionCmd = CmdSync $ \_ _ -> return (IdeResponseOk version)
 
 pluginsCmd :: CommandFunc Plugins
-pluginsCmd _ _ = do
+pluginsCmd = CmdSync $ \_ _ -> do
   plugins <- getPlugins
   return (IdeResponseOk plugins)
 
 commandsCmd :: CommandFunc [CommandName]
-commandsCmd _ req = do
+commandsCmd = CmdSync $ \_ req -> do
   plugins <- getPlugins
   -- TODO: Use Maybe Monad. What abut error reporting?
   case Map.lookup "plugin" (ideParams req) of
@@ -97,7 +97,7 @@ commandsCmd _ req = do
     Just x -> return $ incorrectParameter "plugin" ("ParamText"::String) x
 
 commandDetailCmd :: CommandFunc CommandDescriptor
-commandDetailCmd _ req = do
+commandDetailCmd = CmdSync $ \_ req -> do
   plugins <- getPlugins
   case getParams (IdText "plugin" :& IdText "command" :& RNil) req of
     Left err -> return err

--- a/src/Haskell/Ide/Engine/Types.hs
+++ b/src/Haskell/Ide/Engine/Types.hs
@@ -4,7 +4,7 @@
 module Haskell.Ide.Engine.Types where
 
 import           Data.Aeson
-import           Control.Concurrent
+import           Control.Concurrent.STM.TChan
 import           Haskell.Ide.Engine.PluginDescriptor
 
 -- ---------------------------------------------------------------------
@@ -18,14 +18,14 @@ data ChannelRequest = CReq
                               -- e.g. a promise id. It is returned with the
                               -- ChannelResponse.
   , cinReq       :: IdeRequest
-  , cinReplyChan :: Chan ChannelResponse
-  }  deriving Show
+  , cinReplyChan :: TChan ChannelResponse
+  } deriving Show
 
-instance Show (Chan ChannelResponse) where
-  show _ = "(Chan ChannelResponse)"
+instance Show (TChan ChannelResponse) where
+  show _ = "(TChan ChannelResponse)"
 
 data ChannelResponse = CResp
   { couPlugin :: PluginId
   , coutReqId :: RequestId
   , coutResp  :: IdeResponse Object
-  }  deriving Show
+  } deriving (Show,Eq)

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -232,16 +232,14 @@ dispatcherSpec = do
       r2 <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr2)
       r1 `shouldBe` Nothing
       r2 `shouldBe` Nothing
-      yield
-      rc1 <- atomically $ tryReadTChan chan
-      yield
-      rc2 <- atomically $ tryReadTChan chan
-      rc1 `shouldBe` Just (CResp { couPlugin = "test"
-                                 , coutReqId = 2
-                                 , coutResp = IdeResponseOk (HM.fromList [("response",String "asyncCmd2 sent strobe")])})
-      rc2 `shouldBe` Just (CResp { couPlugin = "test"
-                                 , coutReqId = 1
-                                 , coutResp = IdeResponseOk (HM.fromList [("response",String "asyncCmd1 got strobe")])})
+      rc1 <- atomically $ readTChan chan
+      rc2 <- atomically $ readTChan chan
+      rc1 `shouldBe` (CResp { couPlugin = "test"
+                            , coutReqId = 2
+                            , coutResp = IdeResponseOk (HM.fromList [("response",String "asyncCmd2 sent strobe")])})
+      rc2 `shouldBe` (CResp { couPlugin = "test"
+                            , coutReqId = 1
+                            , coutResp = IdeResponseOk (HM.fromList [("response",String "asyncCmd1 got strobe")])})
 
 -- ---------------------------------------------------------------------
 

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -2,12 +2,18 @@
 module DispatcherSpec where
 
 import           Control.Concurrent
+import           Control.Concurrent.STM.TChan
 import           Control.Logging
+import           Control.Monad.IO.Class
+import           Control.Monad.STM
 import           Data.Aeson
 import qualified Data.HashMap.Strict as H
+import qualified Data.Text as T
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Map as Map
 import           Haskell.Ide.Engine.Dispatcher
 import           Haskell.Ide.Engine.Monad
+import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.Types
 
@@ -33,164 +39,217 @@ spec = do
 dispatcherSpec :: Spec
 dispatcherSpec = do
   describe "checking contexts" $ do
-    -- ---------------------------------
 
     it "identifies CtxNone" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmd1" (Map.fromList [])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxNone]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxNone]"::String)]))
 
     -- ---------------------------------
 
     it "identifies bad CtxFile" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmd2" (Map.fromList [])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `file` parameter", ideInfo = Just (String "file")})
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `file` parameter", ideInfo = Just (String "file")}))
 
     -- ---------------------------------
 
     it "identifies CtxFile" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmd2" (Map.fromList [("file", ParamFileP "foo.hs")])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxFile]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxFile]"::String)]))
 
     -- ---------------------------------
 
     it "identifies CtxPoint" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmd3" (Map.fromList [("file", ParamFileP "foo.hs"),("start_pos", ParamPosP (1,2))])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxPoint]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxPoint]"::String)]))
 
     -- ---------------------------------
 
     it "identifies CtxRegion" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmd4" (Map.fromList [("file", ParamFileP "foo.hs")
                                                 ,("start_pos", ParamPosP (1,2))
                                                 ,("end_pos", ParamPosP (3,4))])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxRegion]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxRegion]"::String)]))
 
     -- ---------------------------------
 
     it "identifies CtxCabal" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmd5" (Map.fromList [("cabal", ParamTextP "lib")])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxCabalTarget]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxCabalTarget]"::String)]))
 
     -- ---------------------------------
 
     it "identifies CtxProject" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmd6" (Map.fromList [])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxProject]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxProject]"::String)]))
 
     -- ---------------------------------
 
     it "identifies all multiple" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmdmultiple" (Map.fromList [("file", ParamFileP "foo.hs")
                                                        ,("start_pos", ParamPosP (1,2))
                                                        ,("end_pos", ParamPosP (3,4))])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxFile,CtxPoint,CtxRegion]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxFile,CtxPoint,CtxRegion]"::String)]))
 
     -- ---------------------------------
 
     it "identifies CtxFile,CtxPoint multiple" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmdmultiple" (Map.fromList [("file", ParamFileP "foo.hs")
                                                        ,("start_pos", ParamPosP (1,2))])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxFile,CtxPoint]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxFile,CtxPoint]"::String)]))
+
     -- ---------------------------------
 
     it "identifies error when no match multiple" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmdmultiple" (Map.fromList [("cabal", ParamTextP "lib")])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe`
-        "IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = \"need `file` parameter\", ideInfo = Just (String \"file\")})"
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe`
+        Just (IdeResponseFail (IdeError { ideCode = MissingParameter
+                                        , ideMessage = "need `file` parameter"
+                                        , ideInfo = Just (String "file")}))
 
   -- -----------------------------------
 
   describe "checking extra params" $ do
-    -- ---------------------------------
 
     it "identifies matching params" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmdextra" (Map.fromList [("file", ParamFileP "foo.hs")
                                                     ,("txt",  ParamTextP "a")
                                                     ,("file", ParamFileP "f")
                                                     ,("pos",  ParamPosP (1,2))
                                                     ])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxFile]"::String)])
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxFile]"::String)]))
+
     -- ---------------------------------
 
     it "reports mismatched param" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmdextra" (Map.fromList [("file", ParamFileP "foo.hs")
                                                     ,("txt",  ParamFileP "a")
                                                     ,("file", ParamFileP "f")
                                                     ,("pos",  ParamPosP (1,2))
                                                     ])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe`
-        "IdeResponseFail (IdeError {ideCode = IncorrectParameterType, ideMessage = \"got wrong parameter type for `txt`, expected: PtText , got:ParamValP {unParamValP = ParamFile \\\"a\\\"}\", ideInfo = Just (Object (fromList [(\"value\",String \"ParamValP {unParamValP = ParamFile \\\"a\\\"}\"),(\"param\",String \"txt\"),(\"expected\",String \"PtText\")]))})"
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe`
+         Just (IdeResponseFail
+               (IdeError
+                 { ideCode = IncorrectParameterType
+                 , ideMessage = "got wrong parameter type for `txt`, expected: PtText , got:ParamValP {unParamValP = ParamFile \"a\"}"
+                 , ideInfo = Just (Object (HM.fromList [("value",String "ParamValP {unParamValP = ParamFile \"a\"}"),("param",String "txt"),("expected",String "PtText")]))}))
 
 
 
     -- ---------------------------------
 
     it "reports matched optional param" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmdoptional" (Map.fromList [("txt",   ParamTextP "a")
                                                        ,("fileo", ParamFileP "f")
                                                        ,("poso",  ParamPosP (1,2))
                                                        ])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxNone]"::String)])
-      
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("result:ctxs=[CtxNone]"::String)]))
+
     -- ---------------------------------
 
     it "reports mismatched optional param" $ do
-      chan <- newChan
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
       let req = IdeRequest "cmdoptional" (Map.fromList [("txt",   ParamTextP "a")
                                                        ,("fileo", ParamTextP "f")
                                                        ,("poso",  ParamPosP (1,2))
                                                        ])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
-      (show r) `shouldBe`
-        "IdeResponseFail (IdeError {ideCode = IncorrectParameterType, ideMessage = \"got wrong parameter type for `fileo`, expected: PtFile , got:ParamValP {unParamValP = ParamText \\\"f\\\"}\", ideInfo = Just (Object (fromList [(\"value\",String \"ParamValP {unParamValP = ParamText \\\"f\\\"}\"),(\"param\",String \"fileo\"),(\"expected\",String \"PtFile\")]))})"
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r `shouldBe`
+        Just (IdeResponseFail
+              (IdeError { ideCode = IncorrectParameterType
+                        , ideMessage = "got wrong parameter type for `fileo`, expected: PtFile , got:ParamValP {unParamValP = ParamText \"f\"}"
+                        , ideInfo = Just (Object (HM.fromList [("value"
+                                                            ,String "ParamValP {unParamValP = ParamText \"f\"}")
+                                                           ,("param"
+                                                            ,String "fileo")
+                                                            ,("expected",String "PtFile")]))}))
+
+  -- -----------------------------------
+
+  describe "async dispatcher operation" $ do
+
+    it "receives replies out of order" $ do
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
+      let req1 = IdeRequest "cmdasync1" Map.empty
+          req2 = IdeRequest "cmdasync2" Map.empty
+          cr1 = CReq "test" 1 req1 chan
+          cr2 = CReq "test" 2 req2 chan
+      r1 <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr1)
+      r2 <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr2)
+      r1 `shouldBe` Nothing
+      r2 `shouldBe` Nothing
+      yield
+      rc1 <- atomically $ tryReadTChan chan
+      yield
+      rc2 <- atomically $ tryReadTChan chan
+      rc1 `shouldBe` Just (CResp { couPlugin = "test"
+                                 , coutReqId = 2
+                                 , coutResp = IdeResponseOk (HM.fromList [("response",String "asyncCmd2 sent strobe")])})
+      rc2 `shouldBe` Just (CResp { couPlugin = "test"
+                                 , coutReqId = 1
+                                 , coutResp = IdeResponseOk (HM.fromList [("response",String "asyncCmd1 got strobe")])})
 
 -- ---------------------------------------------------------------------
 
-testPlugins :: Plugins
-testPlugins = Map.fromList [("test",testDescriptor)]
+testPlugins :: TChan () -> Plugins
+testPlugins chSync = Map.fromList [("test",testDescriptor chSync)]
 
-testDescriptor :: PluginDescriptor
-testDescriptor = PluginDescriptor
+testDescriptor :: TChan () -> PluginDescriptor
+testDescriptor chSync = PluginDescriptor
   {
     pdCommands =
       [
@@ -212,6 +271,8 @@ testDescriptor = PluginDescriptor
                                                  , OP "fileo" "help" PtFile
                                                  , OP "poso"  "help" PtPos
                                                  ]
+      , mkAsyncCmdWithContext (asyncCmd1 chSync) "cmdasync1" [CtxNone] []
+      , mkAsyncCmdWithContext (asyncCmd2 chSync) "cmdasync2" [CtxNone] []
       ]
   , pdExposedServices = []
   , pdUsedServices    = []
@@ -227,7 +288,37 @@ mkCmdWithContext n cts pds =
                         , cmdContexts = cts
                         , cmdAdditionalParams = pds
                         }
-          , cmdFunc = \ctxs _ -> return (IdeResponseOk ("result:ctxs=" ++ show ctxs))
+          , cmdFunc = CmdSync $ \ctxs _ -> return (IdeResponseOk ("result:ctxs=" ++ show ctxs))
           }
+
+mkAsyncCmdWithContext :: (ValidResponse a) => CommandFunc a -> CommandName -> [AcceptedContext] -> [ParamDescription] -> Command
+mkAsyncCmdWithContext cf n cts pds =
+        Command
+          { cmdDesc = CommandDesc
+                        { cmdName = n
+                        , cmdUiDescription = "description"
+                        , cmdFileExtensions = []
+                        , cmdContexts = cts
+                        , cmdAdditionalParams = pds
+                        }
+          , cmdFunc = cf
+          }
+
+-- ---------------------------------------------------------------------
+
+asyncCmd1 :: TChan () -> CommandFunc T.Text
+asyncCmd1 ch = CmdAsync $ \f _ctxs _ -> do
+  _ <- liftIO $ forkIO $ do
+    _synced <- atomically $ readTChan ch
+    logm $ "asyncCmd1 got val"
+    f (IdeResponseOk "asyncCmd1 got strobe")
+  return ()
+
+asyncCmd2 :: TChan () -> CommandFunc T.Text
+asyncCmd2 ch  = CmdAsync $ \f _ctxs _ -> do
+  _ <- liftIO $ forkIO $ do
+    atomically $ writeTChan ch ()
+    f (IdeResponseOk "asyncCmd2 sent strobe")
+  return ()
 
 -- ---------------------------------------------------------------------

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 module GhcModPluginSpec where
 
-import           Control.Concurrent
+import           Control.Concurrent.STM.TChan
 import           Control.Logging
+import           Control.Monad.STM
 import           Data.Aeson
 import qualified Data.HashMap.Strict as H
 import           Haskell.Ide.Engine.Dispatcher
@@ -36,9 +37,9 @@ testPlugins :: Plugins
 testPlugins = Map.fromList [("ghcmod",ghcmodDescriptor)]
 
 -- TODO: break this out into a TestUtils file
-dispatchRequest :: IdeRequest -> IO (IdeResponse Object)
+dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))
 dispatchRequest req = do
-  testChan <- newChan
+  testChan <- atomically newTChan
   let cr = CReq "ghcmod" 1 req testChan
   r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
   return r
@@ -51,21 +52,21 @@ ghcmodSpec = do
     it "runs the check command" $ do
       let req = IdeRequest "check" (Map.fromList [("file", ParamFileP "./test/testdata/FileWithWarning.hs")])
       r <- dispatchRequest req
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("test/testdata/FileWithWarning.hs:4:7:Not in scope: \8216x\8217\n"::String)])
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("test/testdata/FileWithWarning.hs:4:7:Not in scope: \8216x\8217\n"::String)]))
 
     -- ---------------------------------
 
     it "runs the lint command" $ do
       let req = IdeRequest "lint" (Map.fromList [("file", ParamFileP "./test/testdata/FileWithWarning.hs")])
       r <- dispatchRequest req
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("./test/testdata/FileWithWarning.hs:6:9: Error: Redundant do\NULFound:\NUL  do return (3 + x)\NULWhy not:\NUL  return (3 + x)\n"::String)])
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("./test/testdata/FileWithWarning.hs:6:9: Error: Redundant do\NULFound:\NUL  do return (3 + x)\NULWhy not:\NUL  return (3 + x)\n"::String)]))
 
     -- ---------------------------------
 
     it "runs the find command" $ do
       let req = IdeRequest "find" (Map.fromList [("symbol", ParamTextP "map")])
       r <- dispatchRequest req
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("Placholder:Need to debug this in ghc-mod, returns 'does not exist (No such file or directory)'"::String)])
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("Placholder:Need to debug this in ghc-mod, returns 'does not exist (No such file or directory)'"::String)]))
       pendingWith "need to debug in ghc-mod"
 
     -- ---------------------------------
@@ -73,14 +74,14 @@ ghcmodSpec = do
     it "runs the info command" $ do
       let req = IdeRequest "info" (Map.fromList [("file", ParamFileP "./test/testdata/HaReRename.hs"),("expr", ParamTextP "main")])
       r <- dispatchRequest req
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("main :: IO () \t-- Defined at test/testdata/HaReRename.hs:2:1\n"::String)])
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("main :: IO () \t-- Defined at test/testdata/HaReRename.hs:2:1\n"::String)]))
 
     -- ---------------------------------
 
     it "runs the type command, incorrect params" $ do
       let req = IdeRequest "type" (Map.fromList [("file", ParamFileP "./test/testdata/FileWithWarning.hs")])
       r <- dispatchRequest req
-      r `shouldBe` IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `start_pos` parameter", ideInfo = Just (String "start_pos")})
+      r `shouldBe` Just (IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `start_pos` parameter", ideInfo = Just (String "start_pos")}))
 
     -- ---------------------------------
 
@@ -88,6 +89,6 @@ ghcmodSpec = do
       let req = IdeRequest "type" (Map.fromList [("file", ParamFileP "./test/testdata/HaReRename.hs")
                                                  ,("start_pos", ParamPosP (5,9))])
       r <- dispatchRequest req
-      r `shouldBe` IdeResponseOk (H.fromList ["response" .= ("5 9 5 10 \"Int\"\n5 9 5 14 \"Int\"\n5 1 5 14 \"Int -> Int\"\n"::String)])
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["response" .= ("5 9 5 10 \"Int\"\n5 9 5 14 \"Int\"\n5 1 5 14 \"Int -> Int\"\n"::String)]))
 
     -- ---------------------------------


### PR DESCRIPTION
Closes #67 

A plugin can decide on a per-command basis whether it should have the option to return an async result.

If so, it takes responsibility for managing whatever threads are required to create the async processing, but each message has a callback function for when the result is ready.