### PR TITLE
Support commands that only require a context

### DIFF
--- a/elisp/haskell-ide-engine.el
+++ b/elisp/haskell-ide-engine.el
@@ -164,9 +164,9 @@ association lists and count on HIE to use default values there."
   (format "%s:%s" (car cmd) (cdr cmd)))
 
 (defun hie-get-context (context)
-  (let ((start (save-excursion (goto-char (region-beginning))
+  (let ((start (save-excursion (if (use-region-p) (goto-char (region-beginning)))
                                (list (line-number-at-pos) (current-column))))
-        (end (save-excursion (goto-char (region-end))
+        (end (save-excursion (if (use-region-p) (goto-char (region-end)))
                              (list (line-number-at-pos) (current-column))))
         (filename (buffer-file-name)))
     `(("file" . (("file" . ,filename)))

--- a/elisp/haskell-ide-engine.el
+++ b/elisp/haskell-ide-engine.el
@@ -192,7 +192,7 @@ association lists and count on HIE to use default values there."
                    (mapcar
                     (lambda (command)
                       (vector (cdr (assq 'ui_description command)) (list 'hie-run-command (symbol-name (car plugin)) (cdr (assq 'name command)))))
-                    (cdr (assq 'commands (cdr plugin)))))
+                    (cdr plugin)))
                  (cdr (assq 'plugins json))))))
     (setq haskell-ide-engine-plugins (cdr (assq 'plugins json)))
     (easy-menu-define hie-menu hie-mode-map

--- a/elisp/haskell-ide-engine.el
+++ b/elisp/haskell-ide-engine.el
@@ -34,6 +34,8 @@
 
 (defvar haskell-ide-engine-post-message-hook nil
   "Function to call with message that will be send to hie process.")
+(defvar haskell-ide-engine-plugins nil
+  "Plugin information gained by calling the base:plugins plugin")
 
 (defun haskell-ide-engine-process-filter (process input)
   (with-current-buffer haskell-ide-engine-buffer
@@ -166,7 +168,7 @@ association lists and count on HIE to use default values there."
                       (vector (cdr (assq 'ui_description command)) (list 'hie-run-command (symbol-name (car plugin)) (cdr (assq 'name command)))))
                     (cdr (assq 'commands (cdr plugin)))))
                  (cdr (assq 'plugins json))))))
-
+    (setq haskell-ide-engine-plugins (cdr (assq 'plugins json)))
     (easy-menu-define hie-menu hie-mode-map
       "Menu for Haskell IDE Engine"
       (cons "HIE" menu-items))))

--- a/elisp/haskell-ide-engine.el
+++ b/elisp/haskell-ide-engine.el
@@ -36,8 +36,6 @@
   "Function to call with message that will be send to hie process.")
 (defvar haskell-ide-engine-plugins nil
   "Plugin information gained by calling the base:plugins plugin")
-(defvar haskell-ide-engine-current-cmd nil
-  "Last cmd that got called")
 
 (defun haskell-ide-engine-process-filter (process input)
   (let ((prev-buffer (current-buffer)))
@@ -159,7 +157,7 @@ association lists and count on HIE to use default values there."
     (setq haskell-ide-engine-process-handle-message
           #'hie-handle-message)
     (haskell-ide-engine-post-message
-     `(("cmd" . ,(hie-format-cmd haskell-ide-engine-current-cmd))
+     `(("cmd" . ,(hie-format-cmd (cons (cdr (assq 'plugin_name json)) (cdr (assq 'name json)))))
        ("params" . ,context)))))
 
 (defun hie-format-cmd (cmd)

--- a/elisp/haskell-ide-engine.el
+++ b/elisp/haskell-ide-engine.el
@@ -155,7 +155,7 @@ association lists and count on HIE to use default values there."
 
 (defun hie-handle-command-detail (json)
   (let ((context
-         (hie-get-context (cadr (assq 'contexts json)))))
+         (hie-get-context (cdr (assq 'contexts json)))))
     (setq haskell-ide-engine-process-handle-message
           #'hie-handle-message)
     (haskell-ide-engine-post-message
@@ -166,13 +166,14 @@ association lists and count on HIE to use default values there."
   (format "%s:%s" (car cmd) (cdr cmd)))
 
 (defun hie-get-context (context)
-  (cond
-   ((string= context "point")
-    (let ((col (current-column))
-          (row (line-number-at-pos))
-          (filename (buffer-file-name)))
-      `(("file" . (("file" . ,filename)))
-        ("start_pos" . (("pos" . ,(vector row col)))))))))
+  (let ((start (save-excursion (goto-char (region-beginning))
+                               (list (line-number-at-pos) (current-column))))
+        (end (save-excursion (goto-char (region-end))
+                             (list (line-number-at-pos) (current-column))))
+        (filename (buffer-file-name)))
+    `(("file" . (("file" . ,filename)))
+      ("start_pos" . (("pos" . ,(apply 'vector start))))
+      ("end_pos" . (("pos" . ,(apply 'vector end)))))))
 
 (defun hie-run-command (plugin command)
   (setq haskell-ide-engine-process-handle-message

--- a/elisp/haskell-ide-engine.el
+++ b/elisp/haskell-ide-engine.el
@@ -145,11 +145,12 @@ association lists and count on HIE to use default values there."
    '()))
 
 (defun hie-handle-message (json)
-  (message "%s" (cdr (assq 'contents json))))
+  (message (format "%s" json)))
 
 (defun hie-run-command (plugin command)
   (setq haskell-ide-engine-process-handle-message
         #'hie-handle-message)
+  (message (format "running %s:%s" plugin command))
   (haskell-ide-engine-post-message
    (list (cons "cmd" (concat plugin ":" command)))))
 
@@ -164,7 +165,7 @@ association lists and count on HIE to use default values there."
                     (lambda (command)
                       (vector (cdr (assq 'ui_description command)) (list 'hie-run-command (symbol-name (car plugin)) (cdr (assq 'name command)))))
                     (cdr (assq 'commands (cdr plugin)))))
-                 (cdr (assq 'contents json))))))
+                 (cdr (assq 'plugins json))))))
 
     (easy-menu-define hie-menu hie-mode-map
       "Menu for Haskell IDE Engine"


### PR DESCRIPTION
This supports commands like ghc-mod’s type command. Currently the information is only printed to the mini buffer.

Also there are some ugly workaround for what I consider flaws in our protocol. I’ll clean it up and try to fix the protocol, where I feel necessary and then we can merge this.

I’m not an elisp wizard so feel free to tell me what I should change.