### PR TITLE
Add plugin name to command descriptor

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -46,11 +46,11 @@ plugins = Map.fromList
   [
     -- Note: statically including known plugins. In future this map could be set
     -- up via a config file of some kind.
-    ("eg2",    example2Descriptor)
-  , ("ghcmod", ghcmodDescriptor)
-  , ("hare",   hareDescriptor)
+    ("eg2",    example2Descriptor "eg2")
+  , ("ghcmod", ghcmodDescriptor "ghcmod")
+  , ("hare",   hareDescriptor "hare")
     -- The base plugin, able to answer questions about the IDE Engine environment.
-  , ("base",   baseDescriptor)
+  , ("base",   baseDescriptor "base")
   ]
 
 -- ---------------------------------------------------------------------

--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -12,8 +12,8 @@ import qualified Data.Text as T
 
 -- ---------------------------------------------------------------------
 
-example2Descriptor :: PluginDescriptor
-example2Descriptor = PluginDescriptor
+example2Descriptor :: PluginName -> PluginDescriptor
+example2Descriptor pluginName = PluginDescriptor
   {
     pdCommands =
       [
@@ -24,6 +24,7 @@ example2Descriptor = PluginDescriptor
                        , cmdFileExtensions = []
                        , cmdContexts = [CtxNone]
                        , cmdAdditionalParams = []
+                       , cmdPluginName = pluginName
                        }
           , cmdFunc = sayHelloCmd
           }
@@ -34,6 +35,7 @@ example2Descriptor = PluginDescriptor
                        , cmdFileExtensions = []
                        , cmdContexts = [CtxNone]
                        , cmdAdditionalParams = [RP "name" "the name to greet" PtText]
+                       , cmdPluginName = pluginName
                        }
           , cmdFunc = sayHelloToCmd
           }

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -16,8 +16,8 @@ import qualified Language.Haskell.GhcMod.Monad as GM
 
 -- ---------------------------------------------------------------------
 
-ghcmodDescriptor :: PluginDescriptor
-ghcmodDescriptor = PluginDescriptor
+ghcmodDescriptor :: PluginName -> PluginDescriptor
+ghcmodDescriptor pluginName = PluginDescriptor
   {
     pdCommands =
       [
@@ -28,6 +28,7 @@ ghcmodDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs",".lhs"]
                      , cmdContexts = [CtxFile]
                      , cmdAdditionalParams = []
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = checkCmd
           }
@@ -38,6 +39,7 @@ ghcmodDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs",".lhs"]
                      , cmdContexts = [CtxFile]
                      , cmdAdditionalParams = []
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = lintCmd
           }
@@ -48,6 +50,7 @@ ghcmodDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs",".lhs"]
                      , cmdContexts = [CtxProject]
                      , cmdAdditionalParams = [RP "symbol" "The SYMBOL to look up" PtText]
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = findCmd
           }
@@ -58,6 +61,7 @@ ghcmodDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs",".lhs"]
                      , cmdContexts = [CtxFile]
                      , cmdAdditionalParams = [RP "expr" "The EXPR to provide info on" PtText]
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = infoCmd
           }
@@ -68,6 +72,7 @@ ghcmodDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs",".lhs"]
                      , cmdContexts = [CtxPoint]
                      , cmdAdditionalParams = []
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = typeCmd
           }

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -14,8 +14,8 @@ import           System.Directory
 
 -- ---------------------------------------------------------------------
 
-hareDescriptor :: PluginDescriptor
-hareDescriptor = PluginDescriptor
+hareDescriptor :: PluginName -> PluginDescriptor
+hareDescriptor pluginName = PluginDescriptor
   {
     pdCommands =
       [
@@ -26,6 +26,7 @@ hareDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs"]
                      , cmdContexts = [CtxPoint]
                      , cmdAdditionalParams = []
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = demoteCmd
           }
@@ -36,6 +37,7 @@ hareDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs"]
                      , cmdContexts = [CtxPoint]
                      , cmdAdditionalParams = [RP "name" "the new name" PtText]
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = dupdefCmd
           }
@@ -46,6 +48,7 @@ hareDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs"]
                      , cmdContexts = [CtxRegion]
                      , cmdAdditionalParams = []
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = iftocaseCmd
           }
@@ -56,6 +59,7 @@ hareDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs"]
                      , cmdContexts = [CtxPoint]
                      , cmdAdditionalParams = []
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = liftonelevelCmd
           }
@@ -66,6 +70,7 @@ hareDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs"]
                      , cmdContexts = [CtxPoint]
                      , cmdAdditionalParams = []
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = lifttotoplevelCmd
           }
@@ -76,6 +81,7 @@ hareDescriptor = PluginDescriptor
                      , cmdFileExtensions = [".hs"]
                      , cmdContexts = [CtxPoint]
                      , cmdAdditionalParams = [RP "name" "the new name" PtText]
+                     , cmdPluginName = pluginName
                      }
           , cmdFunc = renameCmd
           }

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -77,9 +77,11 @@ data CommandDescriptor = CommandDesc
   , cmdFileExtensions :: ![T.Text] -- ^ File extensions this command can be applied to
   , cmdContexts :: ![AcceptedContext] -- TODO: should this be a non empty list? or should empty list imply CtxNone.
   , cmdAdditionalParams :: ![ParamDescription]
+  , cmdPluginName :: !PluginName
   } deriving (Show,Eq,Generic)
 
 type CommandName = T.Text
+type PluginName = T.Text
 
 -- | Define what context will be accepted from the frontend for the specific
 -- command. Matches up to corresponding values for CommandContext
@@ -315,13 +317,16 @@ instance ValidResponse CommandDescriptor where
                                   , "ui_description" .= cmdUiDescription cmdDescriptor
                                   , "file_extensions" .= cmdFileExtensions cmdDescriptor
                                   , "contexts" .= cmdContexts cmdDescriptor
-                                  , "additional_params" .= cmdAdditionalParams cmdDescriptor ]
+                                  , "additional_params" .= cmdAdditionalParams cmdDescriptor
+                                  , "plugin_name" .= cmdPluginName cmdDescriptor]
   jsRead v =
         CommandDesc <$> v .: "name"
                     <*> v .: "ui_description"
                     <*> v .: "file_extensions"
                     <*> v .: "contexts"
                     <*> v .: "additional_params"
+                    <*> v .: "plugin_name"
+
 
 instance ValidResponse Plugins where
   jsWrite m = H.fromList ["plugins" .= H.fromList

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -22,8 +22,8 @@ import           Prelude hiding (log)
 
 -- ---------------------------------------------------------------------
 
-baseDescriptor :: PluginDescriptor
-baseDescriptor = PluginDescriptor
+baseDescriptor :: PluginName -> PluginDescriptor
+baseDescriptor pluginName = PluginDescriptor
   {
     pdCommands =
       [
@@ -34,6 +34,7 @@ baseDescriptor = PluginDescriptor
                         , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = []
+                        , cmdPluginName = pluginName
                         }
           , cmdFunc = versionCmd
           }
@@ -44,6 +45,7 @@ baseDescriptor = PluginDescriptor
                         , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = []
+                        , cmdPluginName = pluginName
                         }
           , cmdFunc = pluginsCmd
           }
@@ -54,6 +56,7 @@ baseDescriptor = PluginDescriptor
                         , cmdFileExtensions = []
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = [RP "plugin" "the plugin name" PtText]
+                        , cmdPluginName = pluginName
                         }
           , cmdFunc = commandsCmd
           }
@@ -65,6 +68,7 @@ baseDescriptor = PluginDescriptor
                         , cmdContexts = [CtxNone]
                         , cmdAdditionalParams = [RP "plugin"  "the plugin name"  PtText
                                                 ,RP "command" "the command name" PtText]
+                        , cmdPluginName = pluginName
                         }
           , cmdFunc = commandDetailCmd
           }

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -253,33 +253,33 @@ testDescriptor chSync = PluginDescriptor
   {
     pdCommands =
       [
-        mkCmdWithContext "cmd1" [CtxNone] []
-      , mkCmdWithContext "cmd2" [CtxFile] []
-      , mkCmdWithContext "cmd3" [CtxPoint] []
-      , mkCmdWithContext "cmd4" [CtxRegion] []
-      , mkCmdWithContext "cmd5" [CtxCabalTarget] []
-      , mkCmdWithContext "cmd6" [CtxProject] []
-      , mkCmdWithContext "cmdmultiple" [CtxFile,CtxPoint,CtxRegion] []
+        mkCmdWithContext "cmd1" "plugin" [CtxNone] []
+      , mkCmdWithContext "cmd2" "plugin" [CtxFile] []
+      , mkCmdWithContext "cmd3" "plugin" [CtxPoint] []
+      , mkCmdWithContext "cmd4" "plugin" [CtxRegion] []
+      , mkCmdWithContext "cmd5" "plugin" [CtxCabalTarget] []
+      , mkCmdWithContext "cmd6" "plugin" [CtxProject] []
+      , mkCmdWithContext "cmdmultiple" "plugin" [CtxFile,CtxPoint,CtxRegion] []
 
-      , mkCmdWithContext "cmdextra" [CtxFile] [ RP "txt"  "help" PtText
-                                              , RP "file" "help" PtFile
-                                              , RP "pos"  "help" PtPos
-                                              ]
+      , mkCmdWithContext "cmdextra" "plugin" [CtxFile] [ RP "txt"  "help" PtText
+                                                       , RP "file" "help" PtFile
+                                                       , RP "pos"  "help" PtPos
+                                                       ]
 
-      , mkCmdWithContext "cmdoptional" [CtxNone] [ RP "txt"   "help" PtText
-                                                 , OP "txto"  "help" PtText
-                                                 , OP "fileo" "help" PtFile
-                                                 , OP "poso"  "help" PtPos
-                                                 ]
-      , mkAsyncCmdWithContext (asyncCmd1 chSync) "cmdasync1" [CtxNone] []
-      , mkAsyncCmdWithContext (asyncCmd2 chSync) "cmdasync2" [CtxNone] []
+      , mkCmdWithContext "cmdoptional" "plugin" [CtxNone] [ RP "txt"   "help" PtText
+                                                          , OP "txto"  "help" PtText
+                                                          , OP "fileo" "help" PtFile
+                                                          , OP "poso"  "help" PtPos
+                                                          ]
+      , mkAsyncCmdWithContext (asyncCmd1 chSync) "cmdasync1" "plugin" [CtxNone] []
+      , mkAsyncCmdWithContext (asyncCmd2 chSync) "cmdasync2" "plugin" [CtxNone] []
       ]
   , pdExposedServices = []
   , pdUsedServices    = []
   }
 
-mkCmdWithContext :: CommandName -> [AcceptedContext] -> [ParamDescription] -> Command
-mkCmdWithContext n cts pds =
+mkCmdWithContext :: CommandName -> PluginName -> [AcceptedContext] -> [ParamDescription] -> Command
+mkCmdWithContext n pn cts pds =
         Command
           { cmdDesc = CommandDesc
                         { cmdName = n
@@ -287,12 +287,13 @@ mkCmdWithContext n cts pds =
                         , cmdFileExtensions = []
                         , cmdContexts = cts
                         , cmdAdditionalParams = pds
+                        , cmdPluginName = pn
                         }
           , cmdFunc = CmdSync $ \ctxs _ -> return (IdeResponseOk ("result:ctxs=" ++ show ctxs))
           }
 
-mkAsyncCmdWithContext :: (ValidResponse a) => CommandFunc a -> CommandName -> [AcceptedContext] -> [ParamDescription] -> Command
-mkAsyncCmdWithContext cf n cts pds =
+mkAsyncCmdWithContext :: (ValidResponse a) => CommandFunc a -> CommandName -> PluginName -> [AcceptedContext] -> [ParamDescription] -> Command
+mkAsyncCmdWithContext cf n pn cts pds =
         Command
           { cmdDesc = CommandDesc
                         { cmdName = n
@@ -300,6 +301,7 @@ mkAsyncCmdWithContext cf n cts pds =
                         , cmdFileExtensions = []
                         , cmdContexts = cts
                         , cmdAdditionalParams = pds
+                        , cmdPluginName = pn
                         }
           , cmdFunc = cf
           }

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -34,7 +34,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: Plugins
-testPlugins = Map.fromList [("ghcmod",ghcmodDescriptor)]
+testPlugins = Map.fromList [("ghcmod",ghcmodDescriptor "ghcmod")]
 
 -- TODO: break this out into a TestUtils file
 dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -32,7 +32,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: Plugins
-testPlugins = Map.fromList [("hare",hareDescriptor)]
+testPlugins = Map.fromList [("hare",hareDescriptor "hare")]
 
 -- TODO: break this out into a TestUtils file
 dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -77,6 +77,7 @@ instance Arbitrary CommandDescriptor where
     <*> smallList arbitrary
     <*> smallList arbitraryBoundedEnum
     <*> smallList arbitrary
+    <*> arbitrary
 
 instance Arbitrary ParamDescription where
   arbitrary = do


### PR DESCRIPTION
The reason i want this is so that I don’t have to store the plugin name on the IDE side when calling `commandDetail`. This also ties in with our "stateless philosophy".

I am not super happy with sprinkling it all over the place, but I couldn’t come up with something better. Suggestions welcome.