### PR TITLE
add ShortName and Overview to PluginDescriptor

### DIFF
--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -15,7 +15,9 @@ import qualified Data.Text as T
 example2Descriptor :: PluginDescriptor
 example2Descriptor = PluginDescriptor
   {
-    pdCommands =
+    pdUIShortName = "Hello World"
+  , pdUIOverview = "An example of writing an HIE plugin"
+  , pdCommands =
       [
         Command
           { cmdDesc = CommandDesc

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -23,7 +23,11 @@ import           System.Directory
 ghcmodDescriptor :: PluginDescriptor
 ghcmodDescriptor = PluginDescriptor
   {
-    pdCommands =
+    pdUIShortName = "ghc-mod"
+  , pdUIOverview = "ghc-mod is a backend program to enrich Haskell programming \
+\in editors. It strives to offer most of the features one has come to expect \
+\from modern IDEs in any editor."
+  , pdCommands =
       [
         Command
           { cmdDesc = CommandDesc

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -17,7 +17,12 @@ import           System.Directory
 hareDescriptor :: PluginDescriptor
 hareDescriptor = PluginDescriptor
   {
-    pdCommands =
+    pdUIShortName = "HaRe"
+  , pdUIOverview = "A Haskell 2010 refactoring tool. HaRe supports the full \
+\Haskell 2010 standard, through making use of the GHC API.  HaRe attempts to \
+\operate in a safe way, by first writing new files with proposed changes, and \
+\only swapping these with the originals when the change is accepted. "
+    , pdCommands =
       [
         Command
           { cmdDesc = CommandDesc

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -44,14 +44,18 @@ import           GHC.Generics
 -- ---------------------------------------------------------------------
 
 data PluginDescriptor = PluginDescriptor
-  { pdCommands        :: [Command]
+  { pdUIShortName     :: !T.Text
+  , pdUIOverview     :: !T.Text
+  , pdCommands        :: [Command]
   , pdExposedServices :: [Service]
   , pdUsedServices    :: [Service]
   }
 
 instance Show PluginDescriptor where
-  showsPrec p (PluginDescriptor cmds svcs used) = showParen (p > 10) $
+  showsPrec p (PluginDescriptor name oview cmds svcs used) = showParen (p > 10) $
       showString "PluginDescriptor " .
+      showString (T.unpack name) .
+      showString (T.unpack oview) .
       showList cmds .
       showString " " .
       showList svcs .

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -25,7 +25,9 @@ import           Prelude hiding (log)
 baseDescriptor :: PluginDescriptor
 baseDescriptor = PluginDescriptor
   {
-    pdCommands =
+    pdUIShortName = "HIE Base"
+  , pdUIOverview = "Commands for HIE itself, "
+  , pdCommands =
       [
         Command
           { cmdDesc = CommandDesc

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -83,7 +83,7 @@ pluginCache :: Plugins -> Map.Map (T.Text,T.Text) Command
 pluginCache plugins = Map.fromList r
   where
     doOne :: T.Text -> PluginDescriptor -> [((T.Text,T.Text),Command)]
-    doOne pn (PluginDescriptor cmds _ _) =
+    doOne pn (PluginDescriptor _ _ cmds _ _) =
         map (\cmd -> ((pn,cmdName (cmdDesc cmd)),cmd)) cmds
 
     r = concatMap (\(pn,pd) -> doOne pn pd) $ Map.toList plugins

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -251,7 +251,9 @@ testPlugins chSync = Map.fromList [("test",testDescriptor chSync)]
 testDescriptor :: TChan () -> PluginDescriptor
 testDescriptor chSync = PluginDescriptor
   {
-    pdCommands =
+    pdUIShortName = "testDescriptor"
+  , pdUIOverview = "PluginDescriptor for testing Dispatcher"
+  , pdCommands =
       [
         mkCmdWithContext "cmd1" [CtxNone] []
       , mkCmdWithContext "cmd2" [CtxFile] []

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -96,7 +96,12 @@ instance Arbitrary Service where
   arbitrary = Service <$> arbitrary
 
 instance Arbitrary PluginDescriptor where
-  arbitrary = PluginDescriptor <$> smallList arbitrary <*> smallList arbitrary <*> smallList arbitrary
+  arbitrary = PluginDescriptor <$>
+              arbitrary <*>
+              arbitrary <*>
+              smallList arbitrary <*>
+              smallList arbitrary <*>
+              smallList arbitrary
 
 -- | make lists of maximum length 3 for test performance
 smallList :: Gen a -> Gen [a]


### PR DESCRIPTION
Text descriptions intended for the editor user, rather than for
messages between the editor and HIE.

closes #98 

I took the Overview text from the tools' Hackage descriptions, but no doubt they could be improved.