### PR TITLE
New logger

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -7,7 +7,7 @@ module Main where
 import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
 import           Control.Exception
-import           Control.Logging
+import           Control.Monad.Logger
 import           Control.Monad
 import           Control.Monad.STM
 import           Control.Monad.Trans.Maybe

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -52,14 +52,14 @@ library
                      , pipes-attoparsec >= 0.5
                      , pipes-bytestring
                      , pipes-parse
-                     , stm
                      , servant-server
+                     , stm
                      , text
                      , time
                      , transformers
+                     , vinyl >= 0.5 && < 0.6
                      , wai
                      , warp
-                     , vinyl >= 0.5 && < 0.6
   ghc-options:         -Wall
   default-language:    Haskell2010
 
@@ -78,9 +78,9 @@ executable hie
                      , gitrev >= 1.1
                      , haskell-ide-engine
                      , hie-example-plugin2
-                     , hie-plugin-api
                      , hie-ghc-mod
                      , hie-hare
+                     , hie-plugin-api
                      , monad-logger
                      , optparse-applicative
                      , optparse-simple
@@ -104,9 +104,9 @@ test-suite haskell-ide-test
                        UtilsSpec
   build-depends:       base
                      , Diff
+                     , QuickCheck
                      , aeson
                      , containers
-                     , unordered-containers
                      , directory
                      , fast-logger
                      , haskell-ide-engine
@@ -114,14 +114,12 @@ test-suite haskell-ide-test
                      , hie-hare
                      , hie-plugin-api
                      , hspec
-                     , fast-logger
                      , monad-logger
+                     , quickcheck-instances
                      , stm
                      , text
                      , transformers
                      , unordered-containers
-                     , quickcheck-instances
-                     , QuickCheck
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -34,14 +34,16 @@ library
                      , containers
                      , directory
                      , either
+                     , fast-logger
                      , ghc >= 7.10.2 && < 7.11
                      , ghc-mod >= 5.4
                      , gitrev >= 1.1
                      , haskeline
                      , hie-plugin-api
                      , lens
-                     , logging
+                     , lifted-base
                      , monad-control
+                     , monad-logger
                      , mtl
                      , optparse-applicative
                      , optparse-simple >= 0.0.3
@@ -70,6 +72,7 @@ executable hie
                      , aeson
                      , containers
                      , directory
+                     , fast-logger
                      , ghc
                      , ghc-mod
                      , gitrev >= 1.1
@@ -78,7 +81,7 @@ executable hie
                      , hie-plugin-api
                      , hie-ghc-mod
                      , hie-hare
-                     , logging
+                     , monad-logger
                      , optparse-applicative
                      , optparse-simple
                      , stm
@@ -105,12 +108,14 @@ test-suite haskell-ide-test
                      , containers
                      , unordered-containers
                      , directory
+                     , fast-logger
                      , haskell-ide-engine
                      , hie-ghc-mod
                      , hie-hare
                      , hie-plugin-api
                      , hspec
-                     , logging
+                     , fast-logger
+                     , monad-logger
                      , stm
                      , text
                      , transformers

--- a/src/Haskell/Ide/Engine/Monad.hs
+++ b/src/Haskell/Ide/Engine/Monad.hs
@@ -11,6 +11,7 @@ import qualified HscTypes      as GHC
 
 import           Control.Applicative
 import           Control.Exception
+import           Control.Monad.IO.Class
 import           Control.Monad.State
 import           Data.IORef
 import           Exception

--- a/src/Haskell/Ide/Engine/MonadFunctions.hs
+++ b/src/Haskell/Ide/Engine/MonadFunctions.hs
@@ -1,21 +1,163 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-} -- For MonadLogger IO instance
 module Haskell.Ide.Engine.MonadFunctions
   (
   -- * Logging functions
-    logm
+    withStdoutLogging
+  , withStderrLogging
+  , withFileLogging
+  , setLogLevel
+  , setLogTimeFormat
+  , logm
   , debugm
   ) where
 
-
-import           Control.Logging
 import           Control.Monad.IO.Class
+import           Control.Monad.Logger
 import qualified Data.Text as T
+import           Haskell.Ide.Engine.Monad()
 import           Prelude hiding (log)
+import Control.Exception.Lifted
+import Control.Monad
+import Control.Monad.Trans.Control
+import Data.IORef
+import Data.Monoid
+import Data.Text as T
+import Data.Time
+import Prelude hiding (log)
+import System.IO.Unsafe
+import System.Log.FastLogger
 
 -- ---------------------------------------------------------------------
 
 logm :: MonadIO m => String -> m ()
-logm s = liftIO $ log $ T.pack s
+logm s = liftIO $ logInfoN $ T.pack s
 
-debugm :: MonadIO m =>String -> m ()
-debugm s = liftIO $ log $ T.pack s
+debugm :: MonadIO m => String -> m ()
+debugm s = liftIO $ logDebugN $ T.pack s
 
+-- ---------------------------------------------------------------------
+
+-- instance MonadLoggerIO IO where
+instance MonadLogger IO where
+    monadLoggerLog loc src lvl msg = loggingLogger loc lvl src msg
+
+-- ---------------------------------------------------------------------
+
+{-
+From https://hackage.haskell.org/package/logging-3.0.2/docs/src/Control-Logging.html
+-}
+
+-- data LogLevel = LevelDebug | LevelInfo | LevelWarn | LevelError | LevelOther Text
+--     deriving (Eq, Prelude.Show, Prelude.Read, Ord)
+
+-- type LogSource = Text
+
+logLevel :: IORef LogLevel
+{-# NOINLINE logLevel #-}
+logLevel = unsafePerformIO $ newIORef LevelDebug
+
+-- | Set the verbosity level.  Messages at our higher than this level are
+--   displayed.  It defaults to 'LevelDebug'.
+setLogLevel :: LogLevel -> IO ()
+setLogLevel = atomicWriteIORef logLevel
+
+logSet :: IORef LoggerSet
+{-# NOINLINE logSet #-}
+logSet = unsafePerformIO $
+    newIORef (error "Must call withStdoutLogging or withStderrLogging")
+
+logTimeFormat :: IORef String
+{-# NOINLINE logTimeFormat #-}
+logTimeFormat = unsafePerformIO $ newIORef "%Y %b-%d %H:%M:%S%Q"
+
+-- | Set the format used for log timestamps.
+setLogTimeFormat :: String -> IO ()
+setLogTimeFormat = atomicWriteIORef logTimeFormat
+
+-- | This function, or 'withStderrLogging', must be wrapped around whatever
+--   region of your application intends to use logging.  Typically it would be
+--   wrapped around the body of 'main'.
+withStdoutLogging :: (MonadBaseControl IO m, MonadIO m) => m a -> m a
+withStdoutLogging f = do
+    liftIO $ do
+        set <- newStdoutLoggerSet defaultBufSize
+        atomicWriteIORef logSet set
+    f `finally` flushLog
+
+withStderrLogging :: (MonadBaseControl IO m, MonadIO m) => m a -> m a
+withStderrLogging f = do
+    liftIO $ do
+        set <- newStderrLoggerSet defaultBufSize
+        atomicWriteIORef logSet set
+    f `finally` flushLog
+
+withFileLogging :: (MonadBaseControl IO m, MonadIO m) => FilePath -> m a -> m a
+withFileLogging path f = do
+    liftIO $ do
+        set <- newFileLoggerSet defaultBufSize path
+        atomicWriteIORef logSet set
+    f `finally` flushLog
+
+-- | Flush all collected logging messages.  This is automatically called by
+--   'withStdoutLogging' and 'withStderrLogging' when those blocks are exited
+--   by whatever means.
+flushLog :: MonadIO m => m ()
+flushLog = liftIO $ do
+    set <- readIORef logSet
+    flushLogStr set
+
+-- ---------------------------------------------------------------------
+-- Taken from Control.Monad.Logger source
+
+
+-- NOTE: general principle: a log line should not have more than one "\n" in it,
+-- else grepping the log becomes impossible.
+loggingLogger :: ToLogStr msg => Loc -> LogLevel -> LogSource -> msg -> IO ()
+loggingLogger !loc !lvl !src str = do
+    maxLvl <- readIORef logLevel
+    when (lvl >= maxLvl) $ do
+        let willLog = True
+        when willLog $ do
+            now <- getCurrentTime
+            fmt <- readIORef logTimeFormat
+            let stamp = formatTime defaultTimeLocale fmt now
+            set <- readIORef logSet
+            pushLogStr set
+                $ toLogStr (stamp ++ " " ++ renderLevel lvl
+                                  ++ " " ++ renderSource src)
+                <> toLogStr str
+                <> toLogStr locStr
+                <> toLogStr (pack "\n")
+  where
+    renderSource :: Text -> String
+    renderSource txt
+        | T.null txt = ""
+        | otherwise  = unpack txt ++ ": "
+
+    renderLevel LevelDebug = "[DEBUG]"
+    renderLevel LevelInfo  = "[INFO]"
+    renderLevel LevelWarn  = "[WARN]"
+    renderLevel LevelError = "[ERROR]"
+    renderLevel (LevelOther txt) = "[" ++ unpack txt ++ "]"
+
+    locStr =
+      if isDefaultLoc loc
+        then ""
+        else (" @(" ++ fileLocStr ++ ")" )
+
+    -- taken from file-location package
+    -- turn the TH Loc loaction information into a human readable string
+    -- leaving out the loc_end parameter
+    fileLocStr = (loc_package loc) ++ ':' : (loc_module loc) ++
+      ' ' : (loc_filename loc) ++ ':' : (line loc) ++ ':' : (char loc)
+      where
+        line = show . fst . loc_start
+        char = show . snd . loc_start
+
+isDefaultLoc :: Loc -> Bool
+isDefaultLoc (Loc "<unknown>" "<unknown>" "<unknown>" (0,0) (0,0)) = True
+isDefaultLoc _ = False
+
+-- EOF

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -9,7 +9,7 @@ import           Control.Applicative
 import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
 import           Control.Lens (view)
-import           Control.Logging
+-- import           Control.Logging
 import           Control.Monad.IO.Class
 import           Control.Monad.STM
 import           Control.Monad.State.Strict
@@ -21,6 +21,7 @@ import qualified Data.ByteString.Lazy as BL
 import           Data.Char
 import qualified Data.Map as Map
 import qualified Data.Text as T
+import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.Types
 import qualified Pipes as P
@@ -51,8 +52,7 @@ parseToJsonPipe cin cout cid =
                   CResp "" cid $
                   IdeResponseError
                     (IdeError ParseError (T.pack $ show decodeErr) Nothing)
-            liftIO $ debug $
-              T.pack $ "jsonStdioTransport:parse error:" ++ show decodeErr
+            liftIO $ debugm $ "jsonStdioTransport:parse error:" ++ show decodeErr
             liftIO $ atomically $ writeTChan cout rsp
        Right req ->
          do liftIO $ atomically $ writeTChan cin (wireToChannel cout cid req)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 #resolver: lts-3.11
 # Nightly has ghc-mod/cabal-helper, not in lts yet
-resolver: nightly-2015-10-27
+resolver: nightly-2015-12-02
 packages:
 - .
 - hie-example-plugin2
@@ -9,6 +9,5 @@ packages:
 - hie-hare
 extra-deps:
  - HaRe-0.8.2.1
- - logging-3.0.2
  - rosezipper-0.2
  - syz-0.2.0.0

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -3,7 +3,6 @@ module DispatcherSpec where
 
 import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
-import           Control.Logging
 import           Control.Monad.IO.Class
 import           Control.Monad.STM
 import           Data.Aeson

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -2,12 +2,12 @@
 module GhcModPluginSpec where
 
 import           Control.Concurrent.STM.TChan
-import           Control.Logging
 import           Control.Monad.STM
 import           Data.Aeson
 import qualified Data.HashMap.Strict as H
 import           Haskell.Ide.Engine.Dispatcher
 import           Haskell.Ide.Engine.Monad
+import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.SemanticTypes
 import           Haskell.Ide.Engine.Types

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -3,13 +3,12 @@ module HaRePluginSpec where
 
 import           Control.Concurrent.STM.TChan
 import           Control.Monad.STM
-import           Control.Logging
 import           Data.Aeson
 import           Data.Algorithm.Diff
--- import qualified Data.HashMap.Strict as H
 import qualified Data.Map as Map
 import           Haskell.Ide.Engine.Dispatcher
 import           Haskell.Ide.Engine.Monad
+import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.SemanticTypes
 import           Haskell.Ide.Engine.Types
@@ -132,9 +131,11 @@ hareSpec = do
                                                            , (First (9, "          x"))
                                                            , (Second (5, "foo x = case odd x of"))
                                                            , (Second (6, "  True  ->"))
-                                                           , (Second (7, "    x + 3"))
+                                                           -- , (Second (7, "    x + 3"))
+                                                           , (Second (7, "            x + 3"))
                                                            , (Second (8, "  False ->"))
-                                                           , (Second (9, "    x"))
+                                                           -- , (Second (9, "    x"))
+                                                           , (Second (9, "            x"))
                                                            ]
                                                            ]))
 


### PR DESCRIPTION
 Updated logging to remove PCRE dependency

It now makes use of a blend of Control.Monad.Logger and Control.Logging,
in that it uses the monad logger log formatting functions, which
includes using TH for a location, and the Control.Logging IORef process,
so logging is available in any thread that has access to IO.

At the moment it has the same flushing behaviour as before.

Closes #112 

cc @bergey 