### PR TITLE
Ghc mod find

### DIFF
--- a/docs/IdeIntegration.md
+++ b/docs/IdeIntegration.md
@@ -105,7 +105,7 @@ contextMapping CtxFile        = [fileParam]
 contextMapping CtxPoint       = [fileParam,startPosParam]
 contextMapping CtxRegion      = [fileParam,startPosParam,endPosParam]
 contextMapping CtxCabalTarget = [cabalParam]
-contextMapping CtxProject     = []
+contextMapping CtxProject     = [fileParam]
 
 fileParam :: ParamDescription
 fileParam = RP "file" "a file name" PtFile
@@ -119,5 +119,3 @@ endPosParam = RP "end_pos" "end line and col" PtPos
 cabalParam :: ParamDescription
 cabalParam = RP "cabal" "cabal target" PtText
 ```
-
-

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -85,6 +85,7 @@ checkCmd = CmdSync $ \_ctxs req -> do
 
 -- ---------------------------------------------------------------------
 
+-- | Runs the find command from the given directory, for the given symbol
 findCmd :: CommandFunc ModuleList
 findCmd = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "dir" :& IdText "symbol" :& RNil) req of
@@ -92,6 +93,7 @@ findCmd = CmdSync $ \_ctxs req -> do
     Right (ParamFile dirName :& ParamText symbol :& RNil) -> do
       runGhcModCommand (T.pack (T.unpack dirName </> "dummy")) (\_->
           do
+            -- adapted from ghc-mod find command, which launches the executable again
             tmpdir <- GM.cradleTempDir <$> GM.cradle
             sf <- takeWhile (`notElem` ['\r','\n']) <$> GM.dumpSymbol tmpdir
             db <- M.fromAscList . map conv . lines <$> liftIO (readFile sf)

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -234,11 +234,12 @@ contextMapping CtxFile        = [fileParam]
 contextMapping CtxPoint       = [fileParam,startPosParam]
 contextMapping CtxRegion      = [fileParam,startPosParam,endPosParam]
 contextMapping CtxCabalTarget = [cabalParam]
-contextMapping CtxProject     = [dirParam]
+contextMapping CtxProject     = [dirParam] -- the root directory of the project
 
 fileParam :: ParamDescription
 fileParam = RP "file" "a file name" PtFile
 
+-- | A parameter for a directory
 dirParam :: ParamDescription
 dirParam = RP "dir" "a directory name" PtFile
 

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -226,7 +226,7 @@ type Plugins = Map.Map PluginId PluginDescriptor
 
 -- ---------------------------------------------------------------------
 
--- |For a given 'AcceptedContext', define the parameters that are required in
+-- | For a given 'AcceptedContext', define the parameters that are required in
 -- the corresponding 'IdeRequest'
 contextMapping :: AcceptedContext -> [ParamDescription]
 contextMapping CtxNone        = []
@@ -234,10 +234,13 @@ contextMapping CtxFile        = [fileParam]
 contextMapping CtxPoint       = [fileParam,startPosParam]
 contextMapping CtxRegion      = [fileParam,startPosParam,endPosParam]
 contextMapping CtxCabalTarget = [cabalParam]
-contextMapping CtxProject     = []
+contextMapping CtxProject     = [dirParam]
 
 fileParam :: ParamDescription
 fileParam = RP "file" "a file name" PtFile
+
+dirParam :: ParamDescription
+dirParam = RP "dir" "a directory name" PtFile
 
 startPosParam :: ParamDescription
 startPosParam = RP "start_pos" "start line and col" PtPos

--- a/hie-plugin-api/Haskell/Ide/Engine/SemanticTypes.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/SemanticTypes.hs
@@ -42,6 +42,13 @@ data HieDiff = HieDiff
   } deriving (Show,Eq,Generic)
 
 -- ---------------------------------------------------------------------
+
+-- | A list of modules
+data ModuleList = ModuleList {
+    mModules :: [T.Text]
+  } deriving (Show,Read,Eq,Ord,Generic)
+
+-- ---------------------------------------------------------------------
 -- JSON instances
 
 instance ValidResponse TypeInfo where
@@ -99,3 +106,9 @@ instance FromJSON (Diff (Int,T.Text)) where
       Just d -> return d
       _ -> empty
   parseJSON _ = empty
+
+-- ---------------------------------------------------------------------
+
+instance ValidResponse ModuleList where
+  jsWrite (ModuleList ms) = H.fromList ["modules" .= ms]
+  jsRead v = ModuleList <$> v .: "modules"

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -105,7 +105,7 @@ dispatcherSpec = do
     it "identifies CtxProject" $ do
       chan <- atomically newTChan
       chSync <- atomically newTChan
-      let req = IdeRequest "cmd6" (Map.fromList [])
+      let req = IdeRequest "cmd6" (Map.fromList [("dir", ParamFileP ".")])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxProject]"::String)]))

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -69,10 +69,10 @@ ghcmodSpec = do
     -- ---------------------------------
 
     it "runs the find command" $ do
-      let req = IdeRequest "find" (Map.fromList [("symbol", ParamTextP "map")])
+      let req = IdeRequest "find" (Map.fromList [("dir", ParamFileP "."),("symbol", ParamTextP "Show")])
       r <- dispatchRequest req
-      r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("Placholder:Need to debug this in ghc-mod, returns 'does not exist (No such file or directory)'"::String)]))
-      pendingWith "need to debug in ghc-mod"
+      r `shouldBe` Just (IdeResponseOk (H.fromList ["modules" .= ["GHC.Show"::String,"Prelude","Test.Hspec.Discover","Text.Show"]]))
+
 
     -- ---------------------------------
 


### PR DESCRIPTION
Implement the find command since it was a placeholder. The issue was that the find command in ghc-mod launches another copy of the executable. The source doesn't say why, and if dumping the symbol file in the same session should be avoided. It works without it: I basically just copied the code from findSymbol. The return type is a `ModuleList`, a specific type added to SemanticTypes.
A side effect is that CtxProject does require the project directory, since we need it for ghc-mod. So there's a `dir` parameter for CtxProject commands. Its type is still `PtFile`, not sure it's worth creating a different `PtDir` parameter type.