### PR TITLE
Plugin state

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -118,7 +118,7 @@ run opts = do
       Nothing -> return ()
 
     -- launch the dispatcher.
-    _ <- forkIO (runIdeM (IdeState plugins) (dispatcher cin))
+    _ <- forkIO (runIdeM (IdeState plugins Map.empty) (dispatcher cin))
 
     -- TODO: pass port in as a param from GlobalOpts
     when (optHttp opts) $

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -98,6 +98,7 @@ test-suite haskell-ide-test
   other-modules:
                        ApplyRefactPluginSpec
                        DispatcherSpec
+                       ExtensibleStateSpec
                        GhcModPluginSpec
                        HaRePluginSpec
                        JsonStdioSpec

--- a/hie-plugin-api/Haskell/Ide/Engine/ExtensibleState.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ExtensibleState.hs
@@ -28,8 +28,6 @@ import Control.Applicative
 import Data.Typeable (typeOf,Typeable,cast)
 import qualified Data.Map as M
 import Haskell.Ide.Engine.PluginDescriptor
--- import XMonad.Core
--- import qualified Control.Monad.State as State
 import qualified Control.Monad.State.Strict as State
 import Data.Maybe (fromMaybe)
 import Control.Monad

--- a/hie-plugin-api/Haskell/Ide/Engine/ExtensibleState.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ExtensibleState.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE PatternGuards #-}
+-- Based on the one in xmonad-contrib, original header below
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Util.ExtensibleState
+-- Copyright   :  (c) Daniel Schoepe 2009
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  daniel.schoepe@gmail.com
+-- Stability   :  unstable
+-- Portability :  not portable
+--
+-- Module for storing custom mutable state in xmonad.
+--
+-----------------------------------------------------------------------------
+
+module Haskell.Ide.Engine.ExtensibleState (
+                              -- * Usage
+                              -- $usage
+                              put
+                              , modify
+                              , remove
+                              , get
+                              , gets
+                              ) where
+
+import Control.Applicative
+import Data.Typeable (typeOf,Typeable,cast)
+import qualified Data.Map as M
+import Haskell.Ide.Engine.PluginDescriptor
+-- import XMonad.Core
+-- import qualified Control.Monad.State as State
+import qualified Control.Monad.State.Strict as State
+import Data.Maybe (fromMaybe)
+import Control.Monad
+import Control.Monad.Trans.Class
+
+-- ---------------------------------------------------------------------
+-- $usage
+--
+-- To utilize this feature in a contrib module, create a data type
+-- and make it an instance of ExtensionClass. You can then use
+-- the functions from this module for storing and retrieving your data:
+--
+-- > {-# LANGUAGE DeriveDataTypeable #-}
+-- > import qualified XMonad.Util.ExtensibleState as XS
+-- >
+-- > data ListStorage = ListStorage [Integer] deriving Typeable
+-- > instance ExtensionClass ListStorage where
+-- >   initialValue = ListStorage []
+-- >
+-- > .. XS.put (ListStorage [23,42])
+--
+-- To retrieve the stored value call:
+--
+-- > .. XS.get
+--
+-- If the type can't be inferred from the usage of the retrieved data, you
+-- have to add an explicit type signature:
+--
+-- > .. XS.get :: X ListStorage
+--
+-- To make your data persistent between restarts, the data type needs to be
+-- an instance of Read and Show and the instance declaration has to be changed:
+--
+-- > data ListStorage = ListStorage [Integer] deriving (Typeable,Read,Show)
+-- >
+-- > instance ExtensionClass ListStorage where
+-- >   initialValue = ListStorage []
+-- >   extensionType = PersistentExtension
+--
+-- One should take care that the string representation of the chosen type
+-- is unique among the stored values, otherwise it will be overwritten.
+-- Normally these string representations contain fully qualified module names
+-- when automatically deriving Typeable, so
+-- name collisions should not be a problem in most cases.
+-- A module should not try to store common datatypes(e.g. a list of Integers)
+-- without a custom data type as a wrapper to avoid collisions with other modules
+-- trying to store the same data type without a wrapper.
+--
+
+-- | Modify the map of state extensions by applying the given function.
+modifyStateExts :: (M.Map String (Either String StateExtension)
+                   -> M.Map String (Either String StateExtension))
+                -> IdeM ()
+modifyStateExts f = lift $ lift $ State.modify $ \st -> st { extensibleState = f (extensibleState st) }
+
+-- | Apply a function to a stored value of the matching type or the initial value if there
+-- is none.
+modify :: ExtensionClass a => (a -> a) -> IdeM ()
+modify f = put . f =<< get
+
+-- | Add a value to the extensible state field. A previously stored value with the same
+-- type will be overwritten. (More precisely: A value whose string representation of its type
+-- is equal to the new one's)
+put :: ExtensionClass a => a -> IdeM ()
+put v = modifyStateExts . M.insert (show . typeOf $ v) . Right . extensionType $ v
+
+-- | Try to retrieve a value of the requested type, return an initial value if there is no such value.
+get :: ExtensionClass a => IdeM a
+get = getState' undefined -- `trick' to avoid needing -XScopedTypeVariables
+  where toValue val = maybe initialValue id $ cast val
+        getState' :: ExtensionClass a => a -> IdeM a
+        getState' k = do
+          v <- lift $ lift $ State.gets $ M.lookup (show . typeOf $ k) . extensibleState
+          case v of
+            Just (Right (StateExtension val)) -> return $ toValue val
+            Just (Right (PersistentExtension val)) -> return $ toValue val
+            Just (Left str) | PersistentExtension x <- extensionType k -> do
+                let val = fromMaybe initialValue $ cast =<< safeRead str `asTypeOf` Just x
+                put (val `asTypeOf` k)
+                return val
+            _ -> return $ initialValue
+        safeRead str = case reads str of
+                         [(x,"")] -> Just x
+                         _ -> Nothing
+
+gets :: ExtensionClass a => (a -> b) -> IdeM b
+gets = flip fmap get
+
+-- | Remove the value from the extensible state field that has the same type as the supplied argument
+remove :: ExtensionClass a => a -> IdeM ()
+remove wit = modifyStateExts $ M.delete (show . typeOf $ wit)

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -134,7 +134,8 @@ data Command = forall a. (ValidResponse a) => Command
 instance Show Command where
   show (Command desc _func) = "(Command " ++ show desc ++ ")"
 
--- | Build a command, ensuring the command response type name and the command function match
+-- | Build a command, ensuring the command response type name and the command
+-- function match
 buildCommand :: forall a. (ValidResponse a)
   => CommandFunc a
   -> CommandName
@@ -143,9 +144,18 @@ buildCommand :: forall a. (ValidResponse a)
   -> [AcceptedContext]
   -> [ParamDescription]
   -> Command
-buildCommand fun n d exts ctxs parm = Command
-  (CommandDesc n d exts ctxs parm (T.pack $ show $ typeOf (undefined::a)))
-  fun
+buildCommand fun n d exts ctxs parm =
+  Command
+  { cmdDesc = CommandDesc
+      { cmdName = n
+      , cmdUiDescription = d
+      , cmdFileExtensions = exts
+      , cmdContexts = ctxs
+      , cmdAdditionalParams = parm
+      , cmdReturnType = T.pack $ show $ typeOf (undefined::a)
+      }
+  , cmdFunc = fun
+  }
 
 
 -- | Return type of a function

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -371,12 +371,6 @@ type AsyncCommandFunc resp = (IdeResponse resp -> IO ())
                -> [AcceptedContext] -> IdeRequest -> IdeM ()
 
 -- ---------------------------------------------------------------------
--- Based on
--- http://xmonad.org/xmonad-docs/xmonad/XMonad-Core.html#t:ExtensionClass
-
-
-
--- ---------------------------------------------------------------------
 -- ValidResponse instances
 
 ok :: T.Text

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -12,7 +12,9 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 library
-  exposed-modules:     Haskell.Ide.Engine.Monad
+  exposed-modules:
+                       Haskell.Ide.Engine.ExtensibleState
+                       Haskell.Ide.Engine.Monad
                        Haskell.Ide.Engine.MonadFunctions
                        Haskell.Ide.Engine.PluginDescriptor
                        Haskell.Ide.Engine.PluginUtils

--- a/licenses/xmonad-contrib
+++ b/licenses/xmonad-contrib
@@ -1,0 +1,29 @@
+-- For the ExtensibleState module
+
+Copyright (c) The Xmonad Community
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the author nor the names of his contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.

--- a/test/ApplyRefactPluginSpec.hs
+++ b/test/ApplyRefactPluginSpec.hs
@@ -40,7 +40,7 @@ dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))
 dispatchRequest req = do
   testChan <- atomically newTChan
   let cr = CReq "applyrefact" 1 req testChan
-  r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+  r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch testPlugins cr)
   return r
 
 -- ---------------------------------------------------------------------

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -44,7 +44,7 @@ dispatcherSpec = do
       chSync <- atomically newTChan
       let req = IdeRequest "cmd1" (Map.fromList [])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxNone]"::String)]))
 
     -- ---------------------------------
@@ -54,7 +54,7 @@ dispatcherSpec = do
       chSync <- atomically newTChan
       let req = IdeRequest "cmd2" (Map.fromList [])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `file` parameter", ideInfo = Just (String "file")}))
 
     -- ---------------------------------
@@ -64,7 +64,7 @@ dispatcherSpec = do
       chSync <- atomically newTChan
       let req = IdeRequest "cmd2" (Map.fromList [("file", ParamFileP "foo.hs")])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxFile]"::String)]))
 
     -- ---------------------------------
@@ -74,7 +74,7 @@ dispatcherSpec = do
       chSync <- atomically newTChan
       let req = IdeRequest "cmd3" (Map.fromList [("file", ParamFileP "foo.hs"),("start_pos", ParamPosP (1,2))])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxPoint]"::String)]))
 
     -- ---------------------------------
@@ -86,7 +86,7 @@ dispatcherSpec = do
                                                 ,("start_pos", ParamPosP (1,2))
                                                 ,("end_pos", ParamPosP (3,4))])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxRegion]"::String)]))
 
     -- ---------------------------------
@@ -96,7 +96,7 @@ dispatcherSpec = do
       chSync <- atomically newTChan
       let req = IdeRequest "cmd5" (Map.fromList [("cabal", ParamTextP "lib")])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxCabalTarget]"::String)]))
 
 
@@ -107,7 +107,7 @@ dispatcherSpec = do
       chSync <- atomically newTChan
       let req = IdeRequest "cmd6" (Map.fromList [("dir", ParamFileP ".")])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxProject]"::String)]))
 
     -- ---------------------------------
@@ -119,7 +119,7 @@ dispatcherSpec = do
                                                        ,("start_pos", ParamPosP (1,2))
                                                        ,("end_pos", ParamPosP (3,4))])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxFile,CtxPoint,CtxRegion]"::String)]))
 
     -- ---------------------------------
@@ -130,7 +130,7 @@ dispatcherSpec = do
       let req = IdeRequest "cmdmultiple" (Map.fromList [("file", ParamFileP "foo.hs")
                                                        ,("start_pos", ParamPosP (1,2))])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxFile,CtxPoint]"::String)]))
 
     -- ---------------------------------
@@ -140,7 +140,7 @@ dispatcherSpec = do
       chSync <- atomically newTChan
       let req = IdeRequest "cmdmultiple" (Map.fromList [("cabal", ParamTextP "lib")])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe`
         Just (IdeResponseFail (IdeError { ideCode = MissingParameter
                                         , ideMessage = "need `file` parameter"
@@ -159,7 +159,7 @@ dispatcherSpec = do
                                                     ,("pos",  ParamPosP (1,2))
                                                     ])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxFile]"::String)]))
 
 
@@ -174,7 +174,7 @@ dispatcherSpec = do
                                                     ,("pos",  ParamPosP (1,2))
                                                     ])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe`
          Just (IdeResponseFail
                (IdeError
@@ -194,7 +194,7 @@ dispatcherSpec = do
                                                        ,("poso",  ParamPosP (1,2))
                                                        ])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:ctxs=[CtxNone]"::String)]))
 
     -- ---------------------------------
@@ -207,7 +207,7 @@ dispatcherSpec = do
                                                        ,("poso",  ParamPosP (1,2))
                                                        ])
           cr = CReq "test" 1 req chan
-      r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr)
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
       r `shouldBe`
         Just (IdeResponseFail
               (IdeError { ideCode = IncorrectParameterType
@@ -229,8 +229,8 @@ dispatcherSpec = do
           req2 = IdeRequest "cmdasync2" Map.empty
           cr1 = CReq "test" 1 req1 chan
           cr2 = CReq "test" 2 req2 chan
-      r1 <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr1)
-      r2 <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch (testPlugins chSync) cr2)
+      r1 <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr1)
+      r2 <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr2)
       r1 `shouldBe` Nothing
       r2 `shouldBe` Nothing
       rc1 <- atomically $ readTChan chan

--- a/test/ExtensibleStateSpec.hs
+++ b/test/ExtensibleStateSpec.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ExtensibleStateSpec where
+
+import           Control.Concurrent
+import           Control.Concurrent.STM.TChan
+import           Control.Monad.IO.Class
+import           Control.Monad.STM
+import           Data.Aeson
+import qualified Data.HashMap.Strict as H
+import qualified Data.Text as T
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Map as Map
+import           Data.Typeable
+import           Haskell.Ide.Engine.Dispatcher
+import           Haskell.Ide.Engine.ExtensibleState
+import           Haskell.Ide.Engine.Monad
+import           Haskell.Ide.Engine.MonadFunctions
+import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.Types
+import           Haskell.Ide.Engine.Utils
+import           Haskell.Ide.Engine.PluginDescriptor
+
+import           Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "ExtensibleState" extensibleStateSpec
+
+extensibleStateSpec :: Spec
+extensibleStateSpec = do
+  describe "stores and retrieves in the state" $ do
+    it "stores the first one" $ do
+      chan <- atomically newTChan
+      chSync <- atomically newTChan
+      let req1 = IdeRequest "cmd1" (Map.fromList [])
+          cr1 = CReq "test" 1 req1 chan
+      let req2 = IdeRequest "cmd2" (Map.fromList [])
+          cr2 = CReq "test" 1 req2 chan
+      r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty)
+        (do
+          r1 <- doDispatch (testPlugins chSync) cr1
+          r2 <- doDispatch (testPlugins chSync) cr2
+          return (r1,r2))
+      fst r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:put foo"::String)]))
+      snd r `shouldBe` Just (IdeResponseOk (H.fromList ["ok" .= ("result:got:\"foo\""::String)]))
+
+    -- ---------------------------------
+
+-- ---------------------------------------------------------------------
+
+testPlugins :: TChan () -> Plugins
+testPlugins chSync = Map.fromList [("test",testDescriptor chSync)]
+
+testDescriptor :: TChan () -> PluginDescriptor
+testDescriptor chSync = PluginDescriptor
+  {
+    pdUIShortName = "testDescriptor"
+  , pdUIOverview = "PluginDescriptor for testing Dispatcher"
+  , pdCommands =
+      [
+        mkCmdWithContext cmd1 "cmd1" [CtxNone] []
+      , mkCmdWithContext cmd2 "cmd2" [CtxNone] []
+      ]
+  , pdExposedServices = []
+  , pdUsedServices    = []
+  }
+
+-- ---------------------------------------------------------------------
+
+cmd1 :: CommandFunc T.Text
+cmd1 = CmdSync $ \_ctxs _req -> do
+  put (MS1 "foo")
+  return (IdeResponseOk (T.pack $ "result:put foo"))
+
+cmd2 :: CommandFunc T.Text
+cmd2 = CmdSync $ \_ctxs _req -> do
+  (MS1 v) <- get
+  return (IdeResponseOk (T.pack $ "result:got:" ++ show v))
+
+data MyState1 = MS1 T.Text deriving Typeable
+
+instance ExtensionClass MyState1 where
+  initialValue = MS1 "initial"
+
+-- ---------------------------------------------------------------------
+
+mkCmdWithContext ::(ValidResponse a)
+                 => CommandFunc a -> CommandName -> [AcceptedContext] -> [ParamDescription] -> Command
+mkCmdWithContext cmd n cts pds =
+        Command
+          { cmdDesc = CommandDesc
+                        { cmdName = n
+                        , cmdUiDescription = "description"
+                        , cmdFileExtensions = []
+                        , cmdContexts = cts
+                        , cmdAdditionalParams = pds
+                        , cmdReturnType = "Text"
+                        }
+          , cmdFunc = cmd
+          }
+
+-- ---------------------------------------------------------------------

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -44,7 +44,7 @@ dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))
 dispatchRequest req = do
   testChan <- atomically newTChan
   let cr = CReq "ghcmod" 1 req testChan
-  r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+  r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch testPlugins cr)
   return r
 
 -- ---------------------------------------------------------------------

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -40,7 +40,7 @@ dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))
 dispatchRequest req = do
   testChan <- atomically newTChan
   let cr = CReq "hare" 1 req testChan
-  r <- withStdoutLogging $ runIdeM (IdeState Map.empty) (doDispatch testPlugins cr)
+  r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch testPlugins cr)
   return r
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
Bring in a copy of [ExtensibleState](http://xmonad.org/xmonad-docs/xmonad-contrib/XMonad-Util-ExtensibleState.html) from `xmonad-contrib` so that async commands can store a hook to get back to a running process, if needed.

Or any other purpose for state.

Note: Although the type for persistent state exists, the machinery to persist is not in place

Closes #83 