### PR TITLE
Support more commands

### DIFF
--- a/elisp/hie.el
+++ b/elisp/hie.el
@@ -243,11 +243,15 @@ association lists and count on HIE to use default values there."
                          `(list (cons 'name ,(downcase name))
                                 (cons 'type ,type)
                                 (cons 'val ,(intern (downcase name)))))
-                       required-params)))
+                       required-params))
+          (interactive-strings
+           (-map
+            (-lambda ((&alist 'name name 'help desc))
+              (format "s%s (%s): " name desc))
+            required-params)))
     `(defun ,(intern (concat "hie-" (symbol-name plugin) "-" command-name)) ,param-args
        ,docstring
-       (interactive)
-
+       (interactive ,(mapconcat 'identity interactive-strings "\n"))
        (hie-run-command ,(symbol-name plugin) ,command-name
                         (list ,@param-vals)))))
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -113,6 +113,7 @@ test-suite haskell-ide-test
                      , containers
                      , directory
                      , fast-logger
+                     , filepath
                      , haskell-ide-engine
                      , hie-apply-refact
                      , hie-base

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -141,7 +141,7 @@ makeRefactorResult changedFiles = do
       (HieDiff f s d) <- diffFiles f1 f2
       f' <- liftIO $ makeRelativeToCurrentDirectory f
       s' <- liftIO $ makeRelativeToCurrentDirectory s
-      return (HieDiff f' s' d)
+      return (HieDiff f s d)
   diffs <- mapM diffOne changedFiles
   return (RefactorResult diffs)
 

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -13,6 +13,8 @@ import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.SemanticTypes
 import           Haskell.Ide.Engine.Types
 import           Haskell.Ide.HaRePlugin
+import           System.Directory
+import           System.FilePath
 import           Test.Hspec
 
 -- ---------------------------------------------------------------------
@@ -48,7 +50,7 @@ dispatchRequest req = do
 hareSpec :: Spec
 hareSpec = do
   describe "hare plugin commands" $ do
-
+    cwd <- runIO $ getCurrentDirectory
     -- ---------------------------------
 
     it "renames" $ do
@@ -59,8 +61,8 @@ hareSpec = do
       r <- dispatchRequest req
       r `shouldBe`
         Just (IdeResponseOk (jsWrite (RefactorResult [HieDiff
-                                                           "test/testdata/HaReRename.hs"
-                                                           "test/testdata/HaReRename.refactored.hs"
+                                                           (cwd </> "test/testdata/HaReRename.hs")
+                                                           (cwd </> "test/testdata/HaReRename.refactored.hs")
                                                            ("4,5c4,5\n"++
                                                             "< foo :: Int -> Int\n"++
                                                             "< foo x = x + 3\n"++
@@ -88,8 +90,8 @@ hareSpec = do
       r <- dispatchRequest req
       -- r `shouldBe` Just (IdeResponseOk (H.fromList ["refactor" .= ["test/testdata/HaReDemote.hs"::FilePath]]))
       r `shouldBe` Just (IdeResponseOk $ jsWrite (RefactorResult [HieDiff
-                                                           "test/testdata/HaReDemote.hs"
-                                                           "test/testdata/HaReDemote.refactored.hs"
+                                                           (cwd </> "test/testdata/HaReDemote.hs")
+                                                           (cwd </> "test/testdata/HaReDemote.refactored.hs")
                                                            ("5,6c5,6\n"++
                                                             "< \n"++
                                                             "< y = 7\n"++
@@ -112,8 +114,8 @@ hareSpec = do
                                                   ,("name",ParamValP $ ParamText "foonew")])
       r <- dispatchRequest req
       r `shouldBe` Just (IdeResponseOk $ jsWrite (RefactorResult [HieDiff
-                                                           "test/testdata/HaReRename.hs"
-                                                           "test/testdata/HaReRename.refactored.hs"
+                                                           (cwd </> "test/testdata/HaReRename.hs")
+                                                           (cwd </> "test/testdata/HaReRename.refactored.hs")
                                                            ("6a7,9\n"++
                                                             "> foonew :: Int -> Int\n"++
                                                             "> foonew x = x + 3\n"++
@@ -129,8 +131,8 @@ hareSpec = do
                                                     ,("end_pos",  ParamValP $ ParamPos (9,12))])
       r <- dispatchRequest req
       r `shouldBe` Just (IdeResponseOk $ jsWrite (RefactorResult [HieDiff
-                                                           "test/testdata/HaReCase.hs"
-                                                           "test/testdata/HaReCase.refactored.hs"
+                                                           (cwd </> "test/testdata/HaReCase.hs")
+                                                           (cwd </> "test/testdata/HaReCase.refactored.hs")
                                                            ("5,9c5,9\n"++
                                                             "< foo x = if odd x\n"++
                                                             "<         then\n"++
@@ -152,8 +154,8 @@ hareSpec = do
                                                     ,("start_pos",ParamValP $ ParamPos (6,5))])
       r <- dispatchRequest req
       r `shouldBe` Just (IdeResponseOk $ jsWrite (RefactorResult [HieDiff
-                                                           "test/testdata/HaReMoveDef.hs"
-                                                           "test/testdata/HaReMoveDef.refactored.hs"
+                                                           (cwd </> "test/testdata/HaReMoveDef.hs")
+                                                           (cwd </> "test/testdata/HaReMoveDef.refactored.hs")
                                                            ("5,6d4\n"++
                                                             "<   where\n"++
                                                             "<     y = 4\n"++
@@ -170,8 +172,8 @@ hareSpec = do
                                                           ,("start_pos",ParamValP $ ParamPos (12,9))])
       r <- dispatchRequest req
       r `shouldBe` Just (IdeResponseOk $ jsWrite (RefactorResult [HieDiff
-                                                           "test/testdata/HaReMoveDef.hs"
-                                                           "test/testdata/HaReMoveDef.refactored.hs"
+                                                           (cwd </> "test/testdata/HaReMoveDef.hs")
+                                                           (cwd </> "test/testdata/HaReMoveDef.refactored.hs")
                                                            ("11,12d10\n"++
                                                             "<       where\n"++
                                                             "<         z = 7\n"++


### PR DESCRIPTION
This is a bunch of different things but they built upon each other so splitting it up doesn’t really gain us anything.

In particular the generated functions now have docstrings, parameters and ask for the required paramaters when called interactively. Apart from that I also added support for the refactor type returned by hare-rename (and probably also a lot of the other hare commands, that was just what I tested). Currently I just overwrite the old buffer content. I know at least @alanz would like to have an ediff window so we should add an option like `hie-refactor-confirm` which when enabled causes an ediff window to pop up. There’s nothing particularly difficult about adding that, I simply haven’t gotten around to it yet. Imho that can be done in a separate commit as in the disucssions it seemed like most people just want the buffer to be overwritten.