### PR TITLE
Move to a plugin/command url scheme

### DIFF
--- a/docs/Hacking.md
+++ b/docs/Hacking.md
@@ -57,13 +57,13 @@ This makes use of servant, and exposes the following API
 So it can be accesed by
 
 ```
-curl -v http://localhost:8081/req/base -X POST -H Content-Type:application/json -d '{"params":{},"cmd":"version"}'
+curl -v -H "Content-Type: application/json" -X POST -d '{"command":{"text": "version"},"plugin":{"text": "base"}}' http://localhost:8001/req/base/commandDetail
 ````
 
 This returns
 
 ```json
-{"ok":"Version 0.1.0.0, Git revision 1db8ae98de2e197f5447c0a97f20ca4e06fdbc98 (dirty) (57 commits) x86_64"}
+{"contexts":["none"],"return_type":"Text","plugin_name":"base","name":"version","additional_params":[],"ui_description":"return HIE version","file_extensions":[]}
 ```
 
 ### Plugins

--- a/docs/Hacking.md
+++ b/docs/Hacking.md
@@ -57,7 +57,7 @@ This makes use of servant, and exposes the following API
 So it can be accesed by
 
 ```
-curl -v http://localhost:8081/req/base -X POST -H Content-Type:application/json --data-binary '{"ideParams":{},"ideCommand":"version","ideContext":{"ctxEndPos":null,"ctxCabal":null,"ctxStartPos":null,"ctxFile":null}}'
+curl -v http://localhost:8081/req/base -X POST -H Content-Type:application/json -d '{"params":{},"cmd":"version"}'
 ````
 
 This returns

--- a/src/Haskell/Ide/Engine/Transport/JsonHttp.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonHttp.hs
@@ -35,10 +35,10 @@ instance ToJSON Greet
 
 -- API specification
 type HieApi =
-  -- curl -v http://localhost:8081/req/base -X POST -H Content-Type:application/json --data-binary '{"ideParams":{},"ideCommand":"version","ideContext":{"ctxEndPos":null,"ctxCabal":null,"ctxStartPos":null,"ctxFile":null}}'
        "req" :> Capture "plugin" Text
+             :> Capture "command" CommandName
              :> QueryParam "rid" Int -- optional request id
-             :> ReqBody '[JSON] IdeRequest
+             :> ReqBody '[JSON] ParamMap
              :> Post '[JSON] (IdeResponse Object)
 
   :<|> "eg" :> Get '[JSON] IdeRequest
@@ -60,9 +60,9 @@ server cin cout = hieH
               :<|> egH
 
   where
-        hieH plugin mrid reqVal = do
+        hieH plugin command mrid reqVal = do
           let rid = fromMaybe 1 mrid
-          liftIO $ atomically $ writeTChan cin (CReq plugin rid reqVal cout)
+          liftIO $ atomically $ writeTChan cin (CReq plugin rid (IdeRequest command reqVal) cout)
           rsp <- liftIO $ atomically $ readTChan cout
           return (coutResp rsp)
           -- return (IdeResponseOk (String $ pack $ show r))


### PR DESCRIPTION
This changes the format of url requests from
```
curl -v -H "Content-Type: application/json" -X POST -d '{"cmd": "lint", "params":{"file":{"file":"/home/moritz/code/haskell/playground/src/Main.hs"}}}' http://localhost:8001/req/ghcmod
```
to
```
curl -v -H "Content-Type: application/json" -X POST -d '{"file":{"file":"/home/moritz/code/haskell/playground/src/Main.hs"}}' http://localhost:8001/req/ghcmod/lint
```
Imho this is a more intuitive. The double `file` parameter comes from the fact that the first is the parameter name and the second is the type so that’s nothing specific to the servant protocol.