### PR TITLE
[POC] Move plugin and command names to the typelevel

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -54,26 +54,6 @@ import           Haskell.Ide.HaRePlugin
 -- ---------------------------------------------------------------------
 
 -- | This will be read from a configuration, eventually
-
--- retagPluginDescriptor
---   :: forall name cmds.
---      KnownSymbol name
---   => Vinyl.Const (TaggedPluginDescriptor cmds) name
---   -> Vinyl.Const (T.Text,UntaggedPluginDescriptor) ('PluginType name cmds)
--- retagPluginDescriptor (Vinyl.Const desc) =
---   Vinyl.Const $
---   (T.pack $ symbolVal (Proxy :: Proxy name),untagPluginDescriptor desc)
-
--- type NamedPlugin name cmds = Vinyl.Const UntaggedPluginDescriptor ('PluginType name cmds)
-
--- tag
---   :: KnownSymbol name
---   => TaggedPluginDescriptor cmds
---   -> Vinyl.Const (T.Text,UntaggedPluginDescriptor) ('PluginType name cmds)
--- tag = retagPluginDescriptor . Vinyl.Const
-
--- buildPlugin :: Proxy s -> TaggedPluginDescriptor
-
 taggedPlugins :: Rec Plugin _
 taggedPlugins =
      Plugin (Proxy :: Proxy "applyrefact") applyRefactDescriptor

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -51,6 +51,7 @@ library
                      , pipes-bytestring
                      , pipes-parse
                      , servant-server
+                     , singletons
                      , stm
                      , text
                      , time

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -89,6 +89,7 @@ executable hie
                      , text
                      , time
                      , transformers
+                     , vinyl
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 
@@ -128,6 +129,7 @@ test-suite haskell-ide-test
                      , text
                      , transformers
                      , unordered-containers
+                     , vinyl
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall
   default-language:    Haskell2010
 

--- a/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
+++ b/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
 module Haskell.Ide.ApplyRefactPlugin where
@@ -20,20 +21,20 @@ import           System.IO.Extra
 
 -- ---------------------------------------------------------------------
 
-applyRefactDescriptor :: PluginDescriptor
+applyRefactDescriptor :: TaggedPluginDescriptor '["applyOne","applyAll"]
 applyRefactDescriptor = PluginDescriptor
   {
     pdUIShortName = "ApplyRefact"
   , pdUIOverview = "apply-refact applies refactorings specified by the refact package. It is currently integrated into hlint to enable the automatic application of suggestions."
     , pdCommands =
-      [
-        buildCommand applyOneCmd "applyOne" "Apply a single hint"
+
+        buildCommand applyOneCmd Proxy "Apply a single hint"
                     [".hs"] [CtxPoint] []
 
-      , buildCommand applyAllCmd "applyAll" "Apply all hints to the file"
-                    [".hs"] [CtxFile] []
+      :& buildCommand applyAllCmd Proxy "Apply all hints to the file"
+                     [".hs"] [CtxFile] []
 
-      ]
+      :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []
   }

--- a/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
+++ b/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
@@ -29,11 +29,11 @@ applyRefactDescriptor = PluginDescriptor
   , pdUIOverview = "apply-refact applies refactorings specified by the refact package. It is currently integrated into hlint to enable the automatic application of suggestions."
     , pdCommands =
 
-        buildCommand' applyOneCmd (Proxy :: Proxy "applyOne") "Apply a single hint"
-                    [".hs"] (SCtxPoint :& RNil) RNil
+        buildCommand applyOneCmd (Proxy :: Proxy "applyOne") "Apply a single hint"
+                   [".hs"] (SCtxPoint :& RNil) RNil
 
-      :& buildCommand' applyAllCmd (Proxy :: Proxy "applyAll") "Apply all hints to the file"
-                     [".hs"] (SCtxFile :& RNil) RNil
+      :& buildCommand applyAllCmd (Proxy :: Proxy "applyAll") "Apply all hints to the file"
+                   [".hs"] (SCtxFile :& RNil) RNil
 
       :& RNil
   , pdExposedServices = []

--- a/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
+++ b/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
 module Haskell.Ide.ApplyRefactPlugin where
@@ -21,17 +22,17 @@ import           System.IO.Extra
 
 -- ---------------------------------------------------------------------
 
-applyRefactDescriptor :: TaggedPluginDescriptor '["applyOne","applyAll"]
+applyRefactDescriptor :: TaggedPluginDescriptor _
 applyRefactDescriptor = PluginDescriptor
   {
     pdUIShortName = "ApplyRefact"
   , pdUIOverview = "apply-refact applies refactorings specified by the refact package. It is currently integrated into hlint to enable the automatic application of suggestions."
     , pdCommands =
 
-        buildCommand applyOneCmd Proxy "Apply a single hint"
+        buildCommand applyOneCmd (Proxy :: Proxy "applyOne") "Apply a single hint"
                     [".hs"] [CtxPoint] []
 
-      :& buildCommand applyAllCmd Proxy "Apply all hints to the file"
+      :& buildCommand applyAllCmd (Proxy :: Proxy "applyAll") "Apply all hints to the file"
                      [".hs"] [CtxFile] []
 
       :& RNil

--- a/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
+++ b/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
@@ -29,11 +29,11 @@ applyRefactDescriptor = PluginDescriptor
   , pdUIOverview = "apply-refact applies refactorings specified by the refact package. It is currently integrated into hlint to enable the automatic application of suggestions."
     , pdCommands =
 
-        buildCommand applyOneCmd (Proxy :: Proxy "applyOne") "Apply a single hint"
-                    [".hs"] [CtxPoint] []
+        buildCommand' applyOneCmd (Proxy :: Proxy "applyOne") "Apply a single hint"
+                    [".hs"] (SCtxPoint :& RNil) RNil
 
-      :& buildCommand applyAllCmd (Proxy :: Proxy "applyAll") "Apply all hints to the file"
-                     [".hs"] [CtxFile] []
+      :& buildCommand' applyAllCmd (Proxy :: Proxy "applyAll") "Apply all hints to the file"
+                     [".hs"] (SCtxFile :& RNil) RNil
 
       :& RNil
   , pdExposedServices = []

--- a/hie-base/Haskell/Ide/Engine/PluginTypes.hs
+++ b/hie-base/Haskell/Ide/Engine/PluginTypes.hs
@@ -37,6 +37,7 @@ module Haskell.Ide.Engine.PluginTypes
   -- * Commands
   , CommandDescriptor(..)
   , UntaggedCommandDescriptor
+  , TaggedCommandDescriptor
   , ExtendedCommandDescriptor(..)
   , CommandName
   , PluginName
@@ -82,6 +83,7 @@ import           Data.Singletons.Prelude
 import           Data.Singletons.TH
 import qualified Data.Text as T
 import           Data.Typeable
+import           Data.Vinyl
 import           GHC.Generics
 import           GHC.TypeLits
 
@@ -176,6 +178,8 @@ data CommandDescriptor cxts descs = CommandDesc
 
 -- | Type synonym for a 'CommandDescriptor' that uses simple lists
 type UntaggedCommandDescriptor = CommandDescriptor [AcceptedContext] [ParamDescription]
+
+type TaggedCommandDescriptor cxts tags = CommandDescriptor (Rec SAcceptedContext cxts) (Rec SParamDescription tags)
 
 data ExtendedCommandDescriptor =
   ExtendedCommandDescriptor UntaggedCommandDescriptor

--- a/hie-base/Haskell/Ide/Engine/PluginTypes/Singletons.hs
+++ b/hie-base/Haskell/Ide/Engine/PluginTypes/Singletons.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Haskell.Ide.Engine.PluginTypes.Singletons where
+
+import Control.Applicative
+import Data.Aeson
+import Data.Singletons.Prelude
+import Data.Singletons.TH
+import GHC.Generics
+import GHC.TypeLits
+
+-- | Indicates the type of a parameter. Plugin authors should use the
+-- singleton version `SParamType` which requires prefixing the
+-- constructors with an /S/
+data ParamType = PtText | PtFile | PtPos
+            deriving (Eq,Ord,Show,Read,Bounded,Enum)
+
+-- | Indicates whether a parameter is required or optional. Plugin
+-- atuhors should use the singleton version `SParamRequired` which
+-- requires prefixing constructors with an /S/
+data ParamRequired = Required | Optional deriving (Eq,Ord,Show,Read,Bounded,Enum)
+
+-- | Define what context will be accepted from the frontend for the
+-- specific command. Matches up to corresponding values for
+-- CommandContext. Plugin authors should use the singleton version
+-- `SAcceptedContext` which requires prefixing the constructors with
+-- an /S/
+data AcceptedContext
+  = CtxNone        -- ^ No context required, global command
+  | CtxFile        -- ^ Works on a whole file
+  | CtxPoint       -- ^ A single (Line,Col) in a specific file
+  | CtxRegion      -- ^ A region within a specific file
+  | CtxCabalTarget -- ^ Works on a specific cabal target
+  | CtxProject     -- ^ Works on a the whole project
+  deriving (Eq,Ord,Show,Read,Bounded,Enum,Generic)
+
+$(genSingletons [''ParamType, ''ParamRequired, ''AcceptedContext])
+
+-- | Only used via DataKinds. The first symbol represents the param
+-- name and the second the param help text.
+data ParamDescType = ParamDescType Symbol Symbol ParamType ParamRequired
+
+-- | Singleton version of `ParamDescription`
+data SParamDescription (t :: ParamDescType) where
+        SParamDesc ::
+            (KnownSymbol pName, KnownSymbol pHelp) =>
+            Proxy pName ->
+              Proxy pHelp ->
+                SParamType pType ->
+                  SParamRequired pRequired ->
+                    SParamDescription ('ParamDescType pName pHelp pType pRequired)
+
+instance ToJSON ParamType where
+  toJSON PtText = String "text"
+  toJSON PtFile = String "file"
+  toJSON PtPos  = String "pos"
+
+instance FromJSON ParamType where
+  parseJSON (String "text") = pure PtText
+  parseJSON (String "file") = pure PtFile
+  parseJSON (String "pos")  = pure PtPos
+  parseJSON _               = empty
+
+instance ToJSON AcceptedContext where
+  toJSON CtxNone = String "none"
+  toJSON CtxPoint = String "point"
+  toJSON CtxRegion = String "region"
+  toJSON CtxFile = String "file"
+  toJSON CtxCabalTarget = String "cabal_target"
+  toJSON CtxProject = String "project"
+
+instance FromJSON AcceptedContext where
+  parseJSON (String "none") = pure CtxNone
+  parseJSON (String "point") = pure CtxPoint
+  parseJSON (String "region") = pure CtxRegion
+  parseJSON (String "file") = pure CtxFile
+  parseJSON (String "cabal_target") = pure CtxCabalTarget
+  parseJSON (String "project") = pure CtxProject
+  parseJSON _ = empty

--- a/hie-base/hie-base.cabal
+++ b/hie-base/hie-base.cabal
@@ -20,5 +20,7 @@ library
                      , containers
                      , text
                      , unordered-containers
+                     , singletons
+                     , vinyl
   ghc-options:         -Wall
   default-language:    Haskell2010

--- a/hie-base/hie-base.cabal
+++ b/hie-base/hie-base.cabal
@@ -14,6 +14,7 @@ cabal-version:       >=1.10
 library
   exposed-modules:
                        Haskell.Ide.Engine.PluginTypes
+                       Haskell.Ide.Engine.PluginTypes.Singletons
                        Haskell.Ide.Engine.SemanticTypes
   build-depends:       base >= 4.7 && < 5
                      , aeson

--- a/hie-docs-generator/src/Examples.hs
+++ b/hie-docs-generator/src/Examples.hs
@@ -12,7 +12,7 @@ import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.Transport.JsonStdio
 import           Options
 
-jsonStdioExample :: PluginId -> CommandDescriptor -> WireRequest
+jsonStdioExample :: PluginId -> UntaggedCommandDescriptor -> WireRequest
 jsonStdioExample pluginId (CommandDesc{cmdName = name,cmdContexts = contexts,cmdAdditionalParams = cmdParams}) =
   WireReq wireCmd (M.union contextUnion additionalParams)
   where wireCmd = pluginId <> ":" <> name

--- a/hie-docs-generator/src/Main.hs
+++ b/hie-docs-generator/src/Main.hs
@@ -68,7 +68,7 @@ pluginDocPath pluginId =
   reader $
   \(O.Config _ prefix) -> prefix </> "plugins" </> T.unpack pluginId <.> "rst"
 
-pluginDoc :: (PluginId,PluginDescriptor) -> T.Text
+pluginDoc :: (PluginId,UntaggedPluginDescriptor) -> T.Text
 pluginDoc (pluginId,PluginDescriptor{pdCommands = commands}) =
   T.unlines ([pluginId
              ,T.replicate (T.length pluginId)

--- a/hie-docs-generator/src/Main.hs
+++ b/hie-docs-generator/src/Main.hs
@@ -78,7 +78,7 @@ pluginDoc (pluginId,PluginDescriptor{pdCommands = commands}) =
              commandDocs)
   where commandDocs = map (commandDoc pluginId) commands
 
-commandDoc :: PluginId -> Command -> T.Text
+commandDoc :: PluginId -> UntaggedCommand -> T.Text
 commandDoc pluginId (cmdDesc -> cmddesc@(CommandDesc{cmdName = name,cmdUiDescription = desc})) =
   T.unlines $
   ["   .. hie:command:: " <> name

--- a/hie-docs-generator/src/Options.hs
+++ b/hie-docs-generator/src/Options.hs
@@ -24,9 +24,9 @@ config =
 pluginList :: Plugins
 pluginList =
   Map.fromList
-    [("applyrefact",applyRefactDescriptor)
-    ,("eg2",example2Descriptor)
-    ,("egasync",exampleAsyncDescriptor)
-    ,("ghcmod",ghcmodDescriptor)
-    ,("hare",hareDescriptor)
-    ,("base",baseDescriptor)]
+    [("applyrefact",untagPluginDescriptor applyRefactDescriptor)
+    ,("eg2",untagPluginDescriptor example2Descriptor)
+    ,("egasync",untagPluginDescriptor exampleAsyncDescriptor)
+    ,("ghcmod",untagPluginDescriptor ghcmodDescriptor)
+    ,("hare",untagPluginDescriptor hareDescriptor)
+    ,("base",untagPluginDescriptor baseDescriptor)]

--- a/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
+++ b/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
@@ -25,8 +25,10 @@ exampleAsyncDescriptor = PluginDescriptor
   , pdUIOverview = "An example HIE plugin using multiple/async processes"
   , pdCommands =
 
-         buildCommand (longRunningCmdSync Cmd1) (Proxy :: Proxy "cmd1") "Long running synchronous command" [] [CtxNone] []
-      :& buildCommand (longRunningCmdSync Cmd2) (Proxy :: Proxy "cmd2") "Long running synchronous command" [] [CtxNone] []
+         buildCommand' (longRunningCmdSync Cmd1) (Proxy :: Proxy "cmd1")
+                       "Long running synchronous command" [] (SCtxNone :& RNil) RNil
+      :& buildCommand' (longRunningCmdSync Cmd2) (Proxy :: Proxy "cmd2")
+                       "Long running synchronous command" [] (SCtxNone :& RNil) RNil
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
+++ b/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
 module Haskell.Ide.ExamplePluginAsync where
@@ -6,26 +7,26 @@ import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
 import           Control.Monad.IO.Class
 import           Control.Monad.STM
+import qualified Data.Map as Map
+import           Data.Monoid
+import qualified Data.Text as T
 import           Haskell.Ide.Engine.ExtensibleState
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
-import           Data.Monoid
-import qualified Data.Map as Map
-import qualified Data.Text as T
 
 -- ---------------------------------------------------------------------
 
-exampleAsyncDescriptor :: PluginDescriptor
+exampleAsyncDescriptor :: TaggedPluginDescriptor '["cmd1","cmd2"]
 exampleAsyncDescriptor = PluginDescriptor
   {
     pdUIShortName = "Async Example"
   , pdUIOverview = "An example HIE plugin using multiple/async processes"
   , pdCommands =
-      [
-        buildCommand (longRunningCmdSync Cmd1) "cmd1" "Long running synchronous command" [] [CtxNone] []
-      , buildCommand (longRunningCmdSync Cmd2) "cmd2" "Long running synchronous command" [] [CtxNone] []
-      ]
+
+         buildCommand (longRunningCmdSync Cmd1) Proxy "Long running synchronous command" [] [CtxNone] []
+      :& buildCommand (longRunningCmdSync Cmd2) Proxy "Long running synchronous command" [] [CtxNone] []
+      :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []
   }

--- a/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
+++ b/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 module Haskell.Ide.ExamplePluginAsync where
 
 import           Control.Concurrent
@@ -17,15 +18,15 @@ import           Haskell.Ide.Engine.PluginUtils
 
 -- ---------------------------------------------------------------------
 
-exampleAsyncDescriptor :: TaggedPluginDescriptor '["cmd1","cmd2"]
+exampleAsyncDescriptor :: TaggedPluginDescriptor _
 exampleAsyncDescriptor = PluginDescriptor
   {
     pdUIShortName = "Async Example"
   , pdUIOverview = "An example HIE plugin using multiple/async processes"
   , pdCommands =
 
-         buildCommand (longRunningCmdSync Cmd1) Proxy "Long running synchronous command" [] [CtxNone] []
-      :& buildCommand (longRunningCmdSync Cmd2) Proxy "Long running synchronous command" [] [CtxNone] []
+         buildCommand (longRunningCmdSync Cmd1) (Proxy :: Proxy "cmd1") "Long running synchronous command" [] [CtxNone] []
+      :& buildCommand (longRunningCmdSync Cmd2) (Proxy :: Proxy "cmd2") "Long running synchronous command" [] [CtxNone] []
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
+++ b/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
@@ -24,11 +24,10 @@ exampleAsyncDescriptor = PluginDescriptor
     pdUIShortName = "Async Example"
   , pdUIOverview = "An example HIE plugin using multiple/async processes"
   , pdCommands =
-
-         buildCommand' (longRunningCmdSync Cmd1) (Proxy :: Proxy "cmd1")
-                       "Long running synchronous command" [] (SCtxNone :& RNil) RNil
-      :& buildCommand' (longRunningCmdSync Cmd2) (Proxy :: Proxy "cmd2")
-                       "Long running synchronous command" [] (SCtxNone :& RNil) RNil
+         buildCommand (longRunningCmdSync Cmd1) (Proxy :: Proxy "cmd1")
+                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil
+      :& buildCommand (longRunningCmdSync Cmd2) (Proxy :: Proxy "cmd2")
+                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -1,32 +1,32 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
 module Haskell.Ide.ExamplePlugin2 where
 
-import Haskell.Ide.Engine.PluginDescriptor
-import Haskell.Ide.Engine.PluginUtils
-
+import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.PluginUtils
 import           Control.Monad.IO.Class
-import           Data.Monoid
 import qualified Data.Map as Map
+import           Data.Monoid
 import qualified Data.Text as T
 
 -- ---------------------------------------------------------------------
 
-example2Descriptor :: PluginDescriptor
+example2Descriptor :: TaggedPluginDescriptor '["sayHello","sayHelloTo"]
 example2Descriptor = PluginDescriptor
   {
     pdUIShortName = "Hello World"
   , pdUIOverview = "An example of writing an HIE plugin"
   , pdCommands =
-      [
-        buildCommand sayHelloCmd "sayHello" "say hello" [] [CtxNone] []
-      , buildCommand sayHelloToCmd "sayHelloTo"
-                       "say hello to the passed in param"
-                       []
-                       [CtxNone]
-                       [RP "name" "the name to greet" PtText]
 
-      ]
+         buildCommand sayHelloCmd Proxy "say hello" [] [CtxNone] []
+      :& buildCommand sayHelloToCmd Proxy
+                         "say hello to the passed in param"
+                         []
+                         [CtxNone]
+                         [RP "name" "the name to greet" PtText]
+
+      :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []
   }

--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -19,12 +19,12 @@ example2Descriptor = PluginDescriptor
     pdUIShortName = "Hello World"
   , pdUIOverview = "An example of writing an HIE plugin"
   , pdCommands =
-         buildCommand' sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] (SCtxNone :& RNil) RNil
-      :& buildCommand' sayHelloToCmd (Proxy :: Proxy "sayHelloTo")
+         buildCommand sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] (SCtxNone :& RNil) RNil
+      :& buildCommand sayHelloToCmd (Proxy :: Proxy "sayHelloTo")
                           "say hello to the passed in param"
                           []
                           (SCtxNone :& RNil)
-                          (  SRP (Proxy :: Proxy "name") (Proxy :: Proxy "the name to greet") SPtText
+                          (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the name to greet") SPtText SRequired
                           :& RNil)
 
       :& RNil

--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
 module Haskell.Ide.ExamplePlugin2 where
@@ -12,15 +13,15 @@ import qualified Data.Text as T
 
 -- ---------------------------------------------------------------------
 
-example2Descriptor :: TaggedPluginDescriptor '["sayHello","sayHelloTo"]
+example2Descriptor :: TaggedPluginDescriptor _
 example2Descriptor = PluginDescriptor
   {
     pdUIShortName = "Hello World"
   , pdUIOverview = "An example of writing an HIE plugin"
   , pdCommands =
 
-         buildCommand sayHelloCmd Proxy "say hello" [] [CtxNone] []
-      :& buildCommand sayHelloToCmd Proxy
+         buildCommand sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] [CtxNone] []
+      :& buildCommand sayHelloToCmd (Proxy :: Proxy "sayHelloTo")
                          "say hello to the passed in param"
                          []
                          [CtxNone]

--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -19,13 +19,13 @@ example2Descriptor = PluginDescriptor
     pdUIShortName = "Hello World"
   , pdUIOverview = "An example of writing an HIE plugin"
   , pdCommands =
-
-         buildCommand sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] [CtxNone] []
-      :& buildCommand sayHelloToCmd (Proxy :: Proxy "sayHelloTo")
-                         "say hello to the passed in param"
-                         []
-                         [CtxNone]
-                         [RP "name" "the name to greet" PtText]
+         buildCommand' sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] (SCtxNone :& RNil) RNil
+      :& buildCommand' sayHelloToCmd (Proxy :: Proxy "sayHelloTo")
+                          "say hello to the passed in param"
+                          []
+                          (SCtxNone :& RNil)
+                          (  SRP (Proxy :: Proxy "name") (Proxy :: Proxy "the name to greet") SPtText
+                          :& RNil)
 
       :& RNil
   , pdExposedServices = []

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -35,23 +35,23 @@ ghcmodDescriptor = PluginDescriptor
 \in editors. It strives to offer most of the features one has come to expect \
 \from modern IDEs in any editor."
   , pdCommands =
-         buildCommand' checkCmd (Proxy :: Proxy "check") "check a file for GHC warnings and errors"
+         buildCommand checkCmd (Proxy :: Proxy "check") "check a file for GHC warnings and errors"
                        [".hs",".lhs"] (SCtxFile :& RNil) RNil
 
-      :& buildCommand' lintCmd (Proxy :: Proxy "lint")  "Check files using `hlint'"
+      :& buildCommand lintCmd (Proxy :: Proxy "lint")  "Check files using `hlint'"
                      [".hs",".lhs"] (SCtxFile :& RNil) RNil
 
-      :& buildCommand' findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
+      :& buildCommand findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
                      [".hs",".lhs"] (SCtxProject :& RNil)
-                     (  SRP (Proxy :: Proxy "symbol") (Proxy :: Proxy "The SYMBOL to look up") SPtText
+                     (  SParamDesc (Proxy :: Proxy "symbol") (Proxy :: Proxy "The SYMBOL to look up") SPtText SRequired
                      :& RNil)
 
-      :& buildCommand' infoCmd (Proxy :: Proxy "info") "Look up an identifier in the context of FILE (like ghci's `:info')"
+      :& buildCommand infoCmd (Proxy :: Proxy "info") "Look up an identifier in the context of FILE (like ghci's `:info')"
                      [".hs",".lhs"] (SCtxFile :& RNil)
-                     (  SRP (Proxy :: Proxy "expr") (Proxy :: Proxy "The EXPR to provide info on") SPtText
+                     (  SParamDesc (Proxy :: Proxy "expr") (Proxy :: Proxy "The EXPR to provide info on") SPtText SRequired
                      :& RNil)
 
-      :& buildCommand' typeCmd (Proxy :: Proxy "type") "Get the type of the expression under (LINE,COL)"
+      :& buildCommand typeCmd (Proxy :: Proxy "type") "Get the type of the expression under (LINE,COL)"
                      [".hs",".lhs"] (SCtxPoint :& RNil) RNil
 
       :& RNil

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -35,20 +35,24 @@ ghcmodDescriptor = PluginDescriptor
 \in editors. It strives to offer most of the features one has come to expect \
 \from modern IDEs in any editor."
   , pdCommands =
-         buildCommand checkCmd (Proxy :: Proxy "check") "check a file for GHC warnings and errors"
-                      [".hs",".lhs"] [CtxFile] []
+         buildCommand' checkCmd (Proxy :: Proxy "check") "check a file for GHC warnings and errors"
+                       [".hs",".lhs"] (SCtxFile :& RNil) RNil
 
-      :& buildCommand lintCmd (Proxy :: Proxy "lint")  "Check files using `hlint'"
-                     [".hs",".lhs"] [CtxFile] []
+      :& buildCommand' lintCmd (Proxy :: Proxy "lint")  "Check files using `hlint'"
+                     [".hs",".lhs"] (SCtxFile :& RNil) RNil
 
-      :& buildCommand findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
-                     [".hs",".lhs"] [CtxProject] [RP "symbol" "The SYMBOL to look up" PtText]
+      :& buildCommand' findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
+                     [".hs",".lhs"] (SCtxProject :& RNil)
+                     (  SRP (Proxy :: Proxy "symbol") (Proxy :: Proxy "The SYMBOL to look up") SPtText
+                     :& RNil)
 
-      :& buildCommand infoCmd (Proxy :: Proxy "info") "Look up an identifier in the context of FILE (like ghci's `:info')"
-                     [".hs",".lhs"] [CtxFile] [RP "expr" "The EXPR to provide info on" PtText]
+      :& buildCommand' infoCmd (Proxy :: Proxy "info") "Look up an identifier in the context of FILE (like ghci's `:info')"
+                     [".hs",".lhs"] (SCtxFile :& RNil)
+                     (  SRP (Proxy :: Proxy "expr") (Proxy :: Proxy "The EXPR to provide info on") SPtText
+                     :& RNil)
 
-      :& buildCommand typeCmd (Proxy :: Proxy "type") "Get the type of the expression under (LINE,COL)"
-                     [".hs",".lhs"] [CtxPoint] []
+      :& buildCommand' typeCmd (Proxy :: Proxy "type") "Get the type of the expression under (LINE,COL)"
+                     [".hs",".lhs"] (SCtxPoint :& RNil) RNil
 
       :& RNil
   , pdExposedServices = []

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -26,7 +27,7 @@ import           System.FilePath
 
 -- ---------------------------------------------------------------------
 
-ghcmodDescriptor :: TaggedPluginDescriptor '["check","lint","find","info","type"]
+ghcmodDescriptor :: TaggedPluginDescriptor _
 ghcmodDescriptor = PluginDescriptor
   {
     pdUIShortName = "ghc-mod"
@@ -34,19 +35,19 @@ ghcmodDescriptor = PluginDescriptor
 \in editors. It strives to offer most of the features one has come to expect \
 \from modern IDEs in any editor."
   , pdCommands =
-         buildCommand checkCmd Proxy "check a file for GHC warnings and errors"
+         buildCommand checkCmd (Proxy :: Proxy "check") "check a file for GHC warnings and errors"
                       [".hs",".lhs"] [CtxFile] []
 
-      :& buildCommand lintCmd Proxy "Check files using `hlint'"
+      :& buildCommand lintCmd (Proxy :: Proxy "lint")  "Check files using `hlint'"
                      [".hs",".lhs"] [CtxFile] []
 
-      :& buildCommand findCmd Proxy "List all modules that define SYMBOL"
+      :& buildCommand findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
                      [".hs",".lhs"] [CtxProject] [RP "symbol" "The SYMBOL to look up" PtText]
 
-      :& buildCommand infoCmd Proxy "Look up an identifier in the context of FILE (like ghci's `:info')"
+      :& buildCommand infoCmd (Proxy :: Proxy "info") "Look up an identifier in the context of FILE (like ghci's `:info')"
                      [".hs",".lhs"] [CtxFile] [RP "expr" "The EXPR to provide info on" PtText]
 
-      :& buildCommand typeCmd Proxy "Get the type of the expression under (LINE,COL)"
+      :& buildCommand typeCmd (Proxy :: Proxy "type") "Get the type of the expression under (LINE,COL)"
                      [".hs",".lhs"] [CtxPoint] []
 
       :& RNil

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -1,25 +1,25 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
 module Haskell.Ide.HaRePlugin where
 
 import           Control.Monad.IO.Class
 import qualified Data.Text as T
-import           Data.Vinyl
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.SemanticTypes
 import           Language.Haskell.Refact.HaRe
 
 
+import qualified Exception as G
 import qualified Language.Haskell.GhcMod as GM
 import qualified Language.Haskell.GhcMod.Monad as GM
-import           System.FilePath
 import           System.Directory
-import qualified Exception as G
+import           System.FilePath
 
 -- ---------------------------------------------------------------------
 
-hareDescriptor :: PluginDescriptor
+hareDescriptor :: TaggedPluginDescriptor '["demote","dupdef","iftocase","liftonelevel","lifttotoplevel","rename"]
 hareDescriptor = PluginDescriptor
   {
     pdUIShortName = "HaRe"
@@ -28,26 +28,25 @@ hareDescriptor = PluginDescriptor
 \operate in a safe way, by first writing new files with proposed changes, and \
 \only swapping these with the originals when the change is accepted. "
     , pdCommands =
-      [
-        buildCommand demoteCmd "demote" "Move a definition one level down"
+        buildCommand demoteCmd Proxy "Move a definition one level down"
                     [".hs"] [CtxPoint] []
 
-      , buildCommand dupdefCmd "dupdef" "Duplicate a definition"
+      :& buildCommand dupdefCmd Proxy "Duplicate a definition"
                      [".hs"] [CtxPoint] [RP "name" "the new name" PtText]
 
-      , buildCommand iftocaseCmd "iftocase" "Converts an if statement to a case statement"
+      :& buildCommand iftocaseCmd Proxy "Converts an if statement to a case statement"
                      [".hs"] [CtxRegion] []
 
-      , buildCommand liftonelevelCmd "liftonelevel" "Move a definition one level up from where it is now"
+      :& buildCommand liftonelevelCmd Proxy "Move a definition one level up from where it is now"
                      [".hs"] [CtxPoint] []
 
-      , buildCommand lifttotoplevelCmd "lifttotoplevel" "Move a definition to the top level from where it is now"
+      :& buildCommand lifttotoplevelCmd Proxy "Move a definition to the top level from where it is now"
                      [".hs"] [CtxPoint] []
 
-      , buildCommand renameCmd "rename" "rename a variable or type"
+      :& buildCommand renameCmd Proxy "rename a variable or type"
                      [".hs"] [CtxPoint] [RP "name" "the new name" PtText]
 
-      ]
+      :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []
   }

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -29,23 +29,27 @@ hareDescriptor = PluginDescriptor
 \operate in a safe way, by first writing new files with proposed changes, and \
 \only swapping these with the originals when the change is accepted. "
     , pdCommands =
-        buildCommand demoteCmd (Proxy :: Proxy "demote") "Move a definition one level down"
-                    [".hs"] [CtxPoint] []
+        buildCommand' demoteCmd (Proxy :: Proxy "demote") "Move a definition one level down"
+                    [".hs"] (SCtxPoint :& RNil) RNil
 
-      :& buildCommand dupdefCmd (Proxy :: Proxy "dupdef") "Duplicate a definition"
-                     [".hs"] [CtxPoint] [RP "name" "the new name" PtText]
+      :& buildCommand' dupdefCmd (Proxy :: Proxy "dupdef") "Duplicate a definition"
+                     [".hs"] (SCtxPoint :& RNil)
+                     (  SRP (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText
+                     :& RNil)
 
-      :& buildCommand iftocaseCmd (Proxy :: Proxy "iftocase") "Converts an if statement to a case statement"
-                     [".hs"] [CtxRegion] []
+      :& buildCommand' iftocaseCmd (Proxy :: Proxy "iftocase") "Converts an if statement to a case statement"
+                     [".hs"] (SCtxRegion :& RNil) RNil
 
-      :& buildCommand liftonelevelCmd (Proxy :: Proxy "liftonelevel") "Move a definition one level up from where it is now"
-                     [".hs"] [CtxPoint] []
+      :& buildCommand' liftonelevelCmd (Proxy :: Proxy "liftonelevel") "Move a definition one level up from where it is now"
+                     [".hs"] (SCtxPoint :& RNil) RNil
 
-      :& buildCommand lifttotoplevelCmd (Proxy :: Proxy "lifttotoplevel") "Move a definition to the top level from where it is now"
-                     [".hs"] [CtxPoint] []
+      :& buildCommand' lifttotoplevelCmd (Proxy :: Proxy "lifttotoplevel") "Move a definition to the top level from where it is now"
+                     [".hs"] (SCtxPoint :& RNil) RNil
 
-      :& buildCommand renameCmd (Proxy :: Proxy "rename") "rename a variable or type"
-                     [".hs"] [CtxPoint] [RP "name" "the new name" PtText]
+      :& buildCommand' renameCmd (Proxy :: Proxy "rename") "rename a variable or type"
+                     [".hs"] (SCtxPoint :& RNil)
+                     (  SRP (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText
+                     :& RNil)
 
       :& RNil
   , pdExposedServices = []

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -29,26 +29,26 @@ hareDescriptor = PluginDescriptor
 \operate in a safe way, by first writing new files with proposed changes, and \
 \only swapping these with the originals when the change is accepted. "
     , pdCommands =
-        buildCommand' demoteCmd (Proxy :: Proxy "demote") "Move a definition one level down"
+        buildCommand demoteCmd (Proxy :: Proxy "demote") "Move a definition one level down"
                     [".hs"] (SCtxPoint :& RNil) RNil
 
-      :& buildCommand' dupdefCmd (Proxy :: Proxy "dupdef") "Duplicate a definition"
+      :& buildCommand dupdefCmd (Proxy :: Proxy "dupdef") "Duplicate a definition"
                      [".hs"] (SCtxPoint :& RNil)
-                     (  SRP (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText
+                     (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText SRequired
                      :& RNil)
 
-      :& buildCommand' iftocaseCmd (Proxy :: Proxy "iftocase") "Converts an if statement to a case statement"
+      :& buildCommand iftocaseCmd (Proxy :: Proxy "iftocase") "Converts an if statement to a case statement"
                      [".hs"] (SCtxRegion :& RNil) RNil
 
-      :& buildCommand' liftonelevelCmd (Proxy :: Proxy "liftonelevel") "Move a definition one level up from where it is now"
+      :& buildCommand liftonelevelCmd (Proxy :: Proxy "liftonelevel") "Move a definition one level up from where it is now"
                      [".hs"] (SCtxPoint :& RNil) RNil
 
-      :& buildCommand' lifttotoplevelCmd (Proxy :: Proxy "lifttotoplevel") "Move a definition to the top level from where it is now"
+      :& buildCommand lifttotoplevelCmd (Proxy :: Proxy "lifttotoplevel") "Move a definition to the top level from where it is now"
                      [".hs"] (SCtxPoint :& RNil) RNil
 
-      :& buildCommand' renameCmd (Proxy :: Proxy "rename") "rename a variable or type"
+      :& buildCommand renameCmd (Proxy :: Proxy "rename") "rename a variable or type"
                      [".hs"] (SCtxPoint :& RNil)
-                     (  SRP (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText
+                     (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText SRequired
                      :& RNil)
 
       :& RNil

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
@@ -19,7 +20,7 @@ import           System.FilePath
 
 -- ---------------------------------------------------------------------
 
-hareDescriptor :: TaggedPluginDescriptor '["demote","dupdef","iftocase","liftonelevel","lifttotoplevel","rename"]
+hareDescriptor :: TaggedPluginDescriptor _
 hareDescriptor = PluginDescriptor
   {
     pdUIShortName = "HaRe"
@@ -28,22 +29,22 @@ hareDescriptor = PluginDescriptor
 \operate in a safe way, by first writing new files with proposed changes, and \
 \only swapping these with the originals when the change is accepted. "
     , pdCommands =
-        buildCommand demoteCmd Proxy "Move a definition one level down"
+        buildCommand demoteCmd (Proxy :: Proxy "demote") "Move a definition one level down"
                     [".hs"] [CtxPoint] []
 
-      :& buildCommand dupdefCmd Proxy "Duplicate a definition"
+      :& buildCommand dupdefCmd (Proxy :: Proxy "dupdef") "Duplicate a definition"
                      [".hs"] [CtxPoint] [RP "name" "the new name" PtText]
 
-      :& buildCommand iftocaseCmd Proxy "Converts an if statement to a case statement"
+      :& buildCommand iftocaseCmd (Proxy :: Proxy "iftocase") "Converts an if statement to a case statement"
                      [".hs"] [CtxRegion] []
 
-      :& buildCommand liftonelevelCmd Proxy "Move a definition one level up from where it is now"
+      :& buildCommand liftonelevelCmd (Proxy :: Proxy "liftonelevel") "Move a definition one level up from where it is now"
                      [".hs"] [CtxPoint] []
 
-      :& buildCommand lifttotoplevelCmd Proxy "Move a definition to the top level from where it is now"
+      :& buildCommand lifttotoplevelCmd (Proxy :: Proxy "lifttotoplevel") "Move a definition to the top level from where it is now"
                      [".hs"] [CtxPoint] []
 
-      :& buildCommand renameCmd Proxy "rename a variable or type"
+      :& buildCommand renameCmd (Proxy :: Proxy "rename") "rename a variable or type"
                      [".hs"] [CtxPoint] [RP "name" "the new name" PtText]
 
       :& RNil

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -135,7 +135,7 @@ data Command desc = forall a. (ValidResponse a) => Command
   }
 
 type TaggedCommand cxts tags
-  = Command (CommandDescriptor (Rec SAcceptedContext cxts) (Rec SParamDescription tags))
+  = Command (TaggedCommandDescriptor cxts tags)
 type UntaggedCommand = Command UntaggedCommandDescriptor
 
 instance Show desc => Show (Command desc) where

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -33,6 +33,7 @@ library
                      , monad-control
                      , monad-logger
                      , mtl
+                     , singletons
                      , text
                      , time
                      , transformers

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
@@ -10,7 +11,6 @@ import           Data.List
 import qualified Data.Map as Map
 import           Data.Monoid
 import qualified Data.Text as T
-import           Data.Vinyl
 import           Development.GitRev (gitCommitCount)
 import           Distribution.System (buildArch)
 import           Distribution.Text (display)
@@ -22,27 +22,27 @@ import           Prelude hiding (log)
 
 -- ---------------------------------------------------------------------
 
-baseDescriptor :: PluginDescriptor
+baseDescriptor :: TaggedPluginDescriptor '["version","plugins","commands","commandDetail"]
 baseDescriptor = PluginDescriptor
   {
     pdUIShortName = "HIE Base"
   , pdUIOverview = "Commands for HIE itself, "
   , pdCommands =
-      [
-        buildCommand versionCmd "version" "return HIE version"
+
+        buildCommand versionCmd Proxy "return HIE version"
                         [] [CtxNone] []
 
-      , buildCommand pluginsCmd "plugins" "list available plugins"
-                         [] [CtxNone] []
+      :& buildCommand pluginsCmd Proxy "list available plugins"
+                          [] [CtxNone] []
 
-      , buildCommand commandsCmd "commands" "list available commands for a given plugin"
-                        [] [CtxNone] [RP "plugin" "the plugin name" PtText]
+      :& buildCommand commandsCmd Proxy "list available commands for a given plugin"
+                         [] [CtxNone] [RP "plugin" "the plugin name" PtText]
 
-      , buildCommand commandDetailCmd "commandDetail" "list parameters required for a given command"
-                        [] [CtxNone] [RP "plugin"  "the plugin name"  PtText
-                                     ,RP "command" "the command name" PtText]
+      :& buildCommand commandDetailCmd Proxy "list parameters required for a given command"
+                         [] [CtxNone] [RP "plugin"  "the plugin name"  PtText
+                                      ,RP "command" "the command name" PtText]
 
-      ]
+      :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []
   }

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -30,19 +30,22 @@ baseDescriptor = PluginDescriptor
   , pdUIOverview = "Commands for HIE itself, "
   , pdCommands =
 
-        buildCommand versionCmd (Proxy :: Proxy "version") "return HIE version"
-                        [] [CtxNone] []
+        buildCommand' versionCmd (Proxy :: Proxy "version") "return HIE version"
+                         [] (SCtxNone :& RNil) RNil
 
-      :& buildCommand pluginsCmd (Proxy :: Proxy "plugins") "list available plugins"
-                          [] [CtxNone] []
+      :& buildCommand' pluginsCmd (Proxy :: Proxy "plugins") "list available plugins"
+                           [] (SCtxNone :& RNil) RNil
 
-      :& buildCommand commandsCmd (Proxy :: Proxy "commands") "list available commands for a given plugin"
-                         [] [CtxNone] [RP "plugin" "the plugin name" PtText]
+      :& buildCommand' commandsCmd (Proxy :: Proxy "commands") "list available commands for a given plugin"
+                          [] (SCtxNone :& RNil)
+                             (  SRP (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText
+                             :& RNil)
 
-      :& buildCommand commandDetailCmd (Proxy :: Proxy "commandDetail") "list parameters required for a given command"
-                         [] [CtxNone] [RP "plugin"  "the plugin name"  PtText
-                                      ,RP "command" "the command name" PtText]
-
+      :& buildCommand' commandDetailCmd (Proxy :: Proxy "commandDetail") "list parameters required for a given command"
+                          [] (SCtxNone :& RNil)
+                          (  SRP (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText
+                          :& SRP (Proxy :: Proxy "command") (Proxy :: Proxy "the command name") SPtText
+                          :& RNil)
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE GADTs #-}
@@ -22,23 +23,23 @@ import           Prelude hiding (log)
 
 -- ---------------------------------------------------------------------
 
-baseDescriptor :: TaggedPluginDescriptor '["version","plugins","commands","commandDetail"]
+baseDescriptor :: TaggedPluginDescriptor _
 baseDescriptor = PluginDescriptor
   {
     pdUIShortName = "HIE Base"
   , pdUIOverview = "Commands for HIE itself, "
   , pdCommands =
 
-        buildCommand versionCmd Proxy "return HIE version"
+        buildCommand versionCmd (Proxy :: Proxy "version") "return HIE version"
                         [] [CtxNone] []
 
-      :& buildCommand pluginsCmd Proxy "list available plugins"
+      :& buildCommand pluginsCmd (Proxy :: Proxy "plugins") "list available plugins"
                           [] [CtxNone] []
 
-      :& buildCommand commandsCmd Proxy "list available commands for a given plugin"
+      :& buildCommand commandsCmd (Proxy :: Proxy "commands") "list available commands for a given plugin"
                          [] [CtxNone] [RP "plugin" "the plugin name" PtText]
 
-      :& buildCommand commandDetailCmd Proxy "list parameters required for a given command"
+      :& buildCommand commandDetailCmd (Proxy :: Proxy "commandDetail") "list parameters required for a given command"
                          [] [CtxNone] [RP "plugin"  "the plugin name"  PtText
                                       ,RP "command" "the command name" PtText]
 

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -29,23 +29,19 @@ baseDescriptor = PluginDescriptor
     pdUIShortName = "HIE Base"
   , pdUIOverview = "Commands for HIE itself, "
   , pdCommands =
-
-        buildCommand' versionCmd (Proxy :: Proxy "version") "return HIE version"
-                         [] (SCtxNone :& RNil) RNil
-
-      :& buildCommand' pluginsCmd (Proxy :: Proxy "plugins") "list available plugins"
-                           [] (SCtxNone :& RNil) RNil
-
-      :& buildCommand' commandsCmd (Proxy :: Proxy "commands") "list available commands for a given plugin"
-                          [] (SCtxNone :& RNil)
-                             (  SRP (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText
-                             :& RNil)
-
-      :& buildCommand' commandDetailCmd (Proxy :: Proxy "commandDetail") "list parameters required for a given command"
-                          [] (SCtxNone :& RNil)
-                          (  SRP (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText
-                          :& SRP (Proxy :: Proxy "command") (Proxy :: Proxy "the command name") SPtText
-                          :& RNil)
+        buildCommand versionCmd (Proxy :: Proxy "version") "return HIE version"
+                        [] (SCtxNone :& RNil) RNil
+      :& buildCommand pluginsCmd (Proxy :: Proxy "plugins") "list available plugins"
+                          [] (SCtxNone :& RNil) RNil
+      :& buildCommand commandsCmd (Proxy :: Proxy "commands") "list available commands for a given plugin"
+                         [] (SCtxNone :& RNil)
+                            (  SParamDesc (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText SRequired
+                            :& RNil)
+      :& buildCommand commandDetailCmd (Proxy :: Proxy "commandDetail") "list parameters required for a given command"
+                         [] (SCtxNone :& RNil)
+                         (  SParamDesc (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText SRequired
+                         :& SParamDesc (Proxy :: Proxy "command") (Proxy :: Proxy "the command name") SPtText SRequired
+                         :& RNil)
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []
@@ -116,7 +112,7 @@ version =
 
 -- ---------------------------------------------------------------------
 
-replPluginInfo :: Plugins -> Map.Map T.Text (T.Text,Command)
+replPluginInfo :: Plugins -> Map.Map T.Text (T.Text,UntaggedCommand)
 replPluginInfo plugins = Map.fromList commands
   where
     commands = concatMap extractCommands $ Map.toList plugins

--- a/src/Haskell/Ide/Engine/Console.hs
+++ b/src/Haskell/Ide/Engine/Console.hs
@@ -84,7 +84,7 @@ descriptorHelp pn cd = ["Plugin '" <> pn <> "'"] ++ r
     descriptors = map cmdDesc (pdCommands cd)
     r = concatMap describeDescriptor descriptors
 
-describeDescriptor :: CommandDescriptor -> [T.Text]
+describeDescriptor :: UntaggedCommandDescriptor -> [T.Text]
 describeDescriptor d =
   [ "  command '" <> (cmdName d) <> "'"
   , "    " <> cmdUiDescription d
@@ -92,7 +92,7 @@ describeDescriptor d =
 
 -- ---------------------------------------------------------------------
 
-convertToParams :: CommandDescriptor -> [T.Text] -> ParamMap
+convertToParams :: UntaggedCommandDescriptor -> [T.Text] -> ParamMap
 convertToParams cmd ss = Map.fromList $ map (\(k,v) -> (k,convertParam k v)) $  map splitOnColon ss
   where
     possibleParams = cmdAdditionalParams cmd ++ (concatMap contextMapping $ cmdContexts cmd)

--- a/src/Haskell/Ide/Engine/Console.hs
+++ b/src/Haskell/Ide/Engine/Console.hs
@@ -78,7 +78,7 @@ helpStr plugins = T.unlines $
 pluginHelp :: Plugins -> [T.Text]
 pluginHelp plugins = concatMap (\(k,v) -> descriptorHelp k v) $ Map.toList plugins
 
-descriptorHelp :: PluginId -> PluginDescriptor -> [T.Text]
+descriptorHelp :: PluginId -> UntaggedPluginDescriptor -> [T.Text]
 descriptorHelp pn cd = ["Plugin '" <> pn <> "'"] ++ r
   where
     descriptors = map cmdDesc (pdCommands cd)

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -87,7 +87,7 @@ data IDEResponseRef = forall a .(ValidResponse a) => IDEResponseRef (IdeResponse
 pluginCache :: Plugins -> Map.Map (T.Text,T.Text) Command
 pluginCache = Map.fromList . concatMap go . Map.toList
   where
-    go :: (T.Text, PluginDescriptor) -> [((T.Text, T.Text), Command)]
+    go :: (T.Text, UntaggedPluginDescriptor) -> [((T.Text, T.Text), Command)]
     go (pn, (PluginDescriptor _ _ cmds _ _)) =
       map (\cmd -> ((pn,cmdName (cmdDesc cmd)),cmd)) cmds
 

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -84,10 +84,10 @@ doDispatch plugins creq = do
 data IDEResponseRef = forall a .(ValidResponse a) => IDEResponseRef (IdeResponse a)
 
 -- TODO: perhaps use this in IdeState instead
-pluginCache :: Plugins -> Map.Map (T.Text,T.Text) Command
+pluginCache :: Plugins -> Map.Map (T.Text,T.Text) UntaggedCommand
 pluginCache = Map.fromList . concatMap go . Map.toList
   where
-    go :: (T.Text, UntaggedPluginDescriptor) -> [((T.Text, T.Text), Command)]
+    go :: (T.Text, UntaggedPluginDescriptor) -> [((T.Text, T.Text), UntaggedCommand)]
     go (pn, (PluginDescriptor _ _ cmds _ _)) =
       map (\cmd -> ((pn,cmdName (cmdDesc cmd)),cmd)) cmds
 
@@ -95,7 +95,7 @@ pluginCache = Map.fromList . concatMap go . Map.toList
 
 -- |Return list of valid contexts for the given 'CommandDescriptor' and
 -- 'IdeRequest'
-validateContexts :: forall a .(ValidResponse a) => CommandDescriptor -> IdeRequest -> Either (IdeResponse a) [AcceptedContext]
+validateContexts :: forall a .(ValidResponse a) => UntaggedCommandDescriptor -> IdeRequest -> Either (IdeResponse a) [AcceptedContext]
 validateContexts cd req = r
   where
     (errs,oks) = partitionEithers $ map (\c -> validContext c (ideParams req)) $ cmdContexts cd
@@ -125,8 +125,8 @@ checkParams pds params = mapEithers checkOne pds
   where
     checkOne :: forall a .(ValidResponse a)
              => ParamDescription -> Either (IdeResponse a) ()
-    checkOne (OP pn _ph pt) = checkParamOP pn pt
-    checkOne (RP pn _ph pt) = checkParamRP pn pt
+    checkOne (ParamDesc pn _ph pt Optional) = checkParamOP pn pt
+    checkOne (ParamDesc pn _ph pt Required) = checkParamRP pn pt
 
     checkParamOP :: forall a .(ValidResponse a)
                  => ParamId -> ParamType -> Either (IdeResponse a) ()

--- a/src/Haskell/Ide/Engine/Transport/JsonHttp.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonHttp.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -19,12 +21,15 @@ import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Proxy
 import           Data.Text
+import qualified Data.Text as T
 import           GHC.Generics
+import           GHC.TypeLits
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.Types
 import           Network.Wai
 import           Network.Wai.Handler.Warp
 import           Servant
+import           Servant.Server.Internal
 
 -- | A greet message data type
 newtype Greet = Greet { _msg :: Text }
@@ -33,20 +38,47 @@ newtype Greet = Greet { _msg :: Text }
 instance FromJSON Greet
 instance ToJSON Greet
 
--- API specification
-type HieApi =
-       "req" :> Capture "plugin" Text
-             :> Capture "command" CommandName
-             :> QueryParam "rid" Int -- optional request id
-             :> ReqBody '[JSON] ParamMap
-             :> Post '[JSON] (IdeResponse Object)
+data PluginType = PluginType Symbol [Symbol]
 
-  :<|> "eg" :> Get '[JSON] IdeRequest
-  -- GET /eg returns
-  --  {"ideParams":{},"ideCommand":"version","ideContext":{"ctxEndPos":null,"ctxCabal":null,"ctxStartPos":null,"ctxFile":null}}
+type PluginList = '[ 'PluginType "applyrefact" '["applyOne","applyAll"]
+                   , 'PluginType "eg2" '["sayHello","sayHelloTo"]
+                   , 'PluginType "egasync" '["cmd1","cmd2"]
+                   , 'PluginType "ghcmod" '["check","lint","find","info","type"]
+                   , 'PluginType "hare" '["demote","dupdef","iftocase"
+                                         ,"liftonelevel","lifttotoplevel","rename"]
+                   , 'PluginType "base" '["version","plugins","commands","commandDetail"]]
 
+type PluginRoute (s::Symbol) r = "req" :> s :> r
 
-testApi :: Proxy HieApi
+type CommandRoute (s :: Symbol) =
+     s :>
+     QueryParam "rid" Int :>
+     ReqBody '[JSON] ParamMap :>
+     Post '[JSON] (IdeResponse Object)
+
+type family PluginRoutes list where
+  PluginRoutes ('PluginType name cmds ': xs)
+     = (PluginRoute name (CommandRoutes cmds)) :<|> PluginRoutes xs
+  PluginRoutes '[] = "eg" :> Get '[JSON] IdeRequest
+
+type family PluginRoutesTest list where
+  PluginRoutesTest ('PluginType name cmds ': xs)
+     = (PluginRoute name (CommandRoutes cmds)) :<|> PluginRoutesTest xs
+  PluginRoutesTest '[] = "eg" :> Get '[JSON] IdeRequest
+
+type family CommandRoutes list where
+  CommandRoutes '[] = Fail
+  CommandRoutes (cmd ': cmds) = CommandRoute cmd :<|> CommandRoutes cmds
+
+data Fail = Fail
+
+instance HasServer Fail where
+
+  type ServerT Fail m = Fail
+
+  route _ _ _ f = f (failWith NotFound)
+
+testApi :: Proxy (PluginRoutes PluginList)
 testApi = Proxy
 
 -- Server-side handlers.
@@ -55,19 +87,59 @@ testApi = Proxy
 -- that represents the API, are glued together using :<|>.
 --
 -- Each handler runs in the 'ExceptT ServantErr IO' monad.
-server :: TChan ChannelRequest ->  TChan ChannelResponse -> Server HieApi
-server cin cout = hieH
-              :<|> egH
 
-  where
-        hieH plugin command mrid reqVal = do
-          let rid = fromMaybe 1 mrid
-          liftIO $ atomically $ writeTChan cin (CReq plugin rid (IdeRequest command reqVal) cout)
-          rsp <- liftIO $ atomically $ readTChan cout
-          return (coutResp rsp)
-          -- return (IdeResponseOk (String $ pack $ show r))
+class HieServer (list :: [PluginType]) where
+  hieServer :: Proxy list
+            -> TChan ChannelRequest
+            -> TChan ChannelResponse
+            -> Server (PluginRoutesTest list)
 
-        egH = return (IdeRequest ("version"::Text) Map.empty)
+instance HieServer '[] where
+  hieServer _ _ _ = return (IdeRequest ("version"::Text) Map.empty)
+
+instance (KnownSymbol plugin,CommandServer cmds,HieServer xs) => HieServer ('PluginType plugin cmds ': xs) where
+  hieServer _ cin cout =
+    pluginHandler :<|> hieServer (Proxy :: Proxy xs) cin cout
+    where pluginHandler
+            :: Server (PluginRoute plugin (CommandRoutes cmds))
+          pluginHandler =
+            cmdServer (Proxy :: Proxy plugin)
+                      (Proxy :: Proxy cmds)
+                      cin
+                      cout
+
+class CommandServer (list :: [Symbol]) where
+  cmdServer :: KnownSymbol plugin
+            => Proxy plugin
+            -> Proxy list
+            -> TChan ChannelRequest
+            -> TChan ChannelResponse
+            -> Server (CommandRoutes list)
+
+instance CommandServer '[] where
+  cmdServer _ _ _ _ = Fail
+
+instance (KnownSymbol x,CommandServer xs) => CommandServer (x ': xs) where
+  cmdServer plugin _ cin cout =
+    pluginHandler :<|> (cmdServer plugin (Proxy :: Proxy xs) cin cout)
+    where pluginHandler
+            :: Server (CommandRoute x)
+          pluginHandler mrid reqVal =
+            do let rid = fromMaybe 1 mrid
+               liftIO $
+                 atomically $
+                 writeTChan
+                   cin
+                   (CReq (T.pack $ symbolVal plugin)
+                         rid
+                         (IdeRequest (T.pack $ symbolVal (Proxy :: Proxy x))
+                                     reqVal)
+                         cout)
+               rsp <- liftIO $ atomically $ readTChan cout
+               return (coutResp rsp)
+
+server :: TChan ChannelRequest ->  TChan ChannelResponse -> Server (PluginRoutes PluginList)
+server cin cout = hieServer (Proxy :: Proxy PluginList) cin cout
 
 -- Turn the server into a WAI app. 'serve' is provided by servant,
 -- more precisely by the Servant.Server module.

--- a/src/Haskell/Ide/Engine/Transport/JsonHttp.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonHttp.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE PatternSynonyms #-}
@@ -28,11 +27,11 @@ import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Proxy
 import           Data.Singletons.Prelude hiding ((:>))
-{-import           Data.Text-}
 import qualified Data.Text as T
 import           GHC.Generics
 import           GHC.TypeLits
 import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.Transport.JsonHttp.Undecidable
 import           Haskell.Ide.Engine.Types
 import           Network.Wai
 import           Network.Wai.Handler.Warp
@@ -83,16 +82,6 @@ type CommandRoute (name :: Symbol) (params :: [ParamDescType]) =
    QueryParam "rid" Int :>
    ReqBody '[JSON] (TaggedMap params) :>
    Post '[JSON] (IdeResponse Object)
-
-type family CommandParams cxts params :: [ParamDescType] where
-  CommandParams cxts params = ConcatMap ContextMappingFun cxts :++ params
-
--- | Defunctionalization TODO: We might be able to use the singletons
--- promotion stuff for that but I (cocreature) haven’t figured that
--- out yet
-data ContextMappingFun :: (TyFun AcceptedContext [ParamDescType]) -> *
-
-type instance Apply ContextMappingFun a = ContextMapping a
 
 type family PluginRoutes (list :: [PluginType]) where
   PluginRoutes ('PluginType name cmds ': xs)

--- a/src/Haskell/Ide/Engine/Transport/JsonHttp/Undecidable.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonHttp/Undecidable.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+
+module Haskell.Ide.Engine.Transport.JsonHttp.Undecidable where
+
+import Data.Singletons.Prelude
+import Haskell.Ide.Engine.PluginDescriptor
+
+data ContextMappingFun :: (TyFun AcceptedContext [ParamDescType]) -> *
+
+type instance Apply ContextMappingFun a = ContextMapping a
+
+type family CommandParams cxts params :: [ParamDescType] where
+  CommandParams cxts params = ConcatMap ContextMappingFun cxts :++ params

--- a/src/Haskell/Ide/Engine/Utils.hs
+++ b/src/Haskell/Ide/Engine/Utils.hs
@@ -39,14 +39,14 @@ paramNameCollisions plugins =
   concatMap (\(plId, plDesc) ->
     concatMap (paramNameCollisionsForCmd plId . cmdDesc) (pdCommands plDesc)) (Map.toList plugins)
 
-paramNameCollisionsForCmd :: PluginId -> CommandDescriptor -> [ParamCollision]
+paramNameCollisionsForCmd :: PluginId -> UntaggedCommandDescriptor -> [ParamCollision]
 paramNameCollisionsForCmd plId cmdDescriptor =
   let collidingParamNames = findCollidingParamNames cmdDescriptor
       collisionSources = map (\param -> ParamCollision plId (cmdName cmdDescriptor) param (paramsByName cmdDescriptor param)) collidingParamNames
    in collisionSources
 
 -- |Find all the parameters within the CommandDescriptor that goes by the given ParamName
-paramsByName :: CommandDescriptor -> ParamName -> [ParamOccurence]
+paramsByName :: UntaggedCommandDescriptor -> ParamName -> [ParamOccurence]
 paramsByName cmdDescriptor paramName =
   let matchingParamName param = pName param == paramName
       additionalParams = map AdditionalParam $ filter matchingParamName (cmdAdditionalParams cmdDescriptor)
@@ -58,7 +58,7 @@ paramsByName cmdDescriptor paramName =
       cmdContextParamsWithCollisions = map (uncurry ContextParam) $ filter (\(param, _) -> matchingParamName param) cmdContextParams
    in additionalParams ++ cmdContextParamsWithCollisions
 
-findCollidingParamNames :: CommandDescriptor -> [ParamName]
+findCollidingParamNames :: UntaggedCommandDescriptor -> [ParamName]
 findCollidingParamNames cmdDescriptor =
   let cmdContextPNames = nub $ concatMap (map pName . contextMapping) (cmdContexts cmdDescriptor) -- collisions within AcceptedContext should not count
       additionalPNames = map pName (cmdAdditionalParams cmdDescriptor)

--- a/test/ApplyRefactPluginSpec.hs
+++ b/test/ApplyRefactPluginSpec.hs
@@ -33,7 +33,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: Plugins
-testPlugins = Map.fromList [("applyrefact",applyRefactDescriptor)]
+testPlugins = Map.fromList [("applyrefact",untagPluginDescriptor applyRefactDescriptor)]
 
 -- TODO: break this out into a TestUtils file
 dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -241,7 +241,7 @@ dispatcherSpec = do
       rc2 <- atomically $ readTChan chan
       rc1 `shouldBe` (CResp { couPlugin = "test"
                             , coutReqId = 2
-                            , coutResp = IdeResponseOk (HM.fromList [("ok",String "asyncCmd2 sent strobe")])})
+                            , coutResp = IdeResponseOk (HM.fromList [("ok",String "asyncCmd2 sending strobe")])})
       rc2 `shouldBe` (CResp { couPlugin = "test"
                             , coutReqId = 1
                             , coutResp = IdeResponseOk (HM.fromList [("ok",String "asyncCmd1 got strobe")])})
@@ -321,8 +321,8 @@ asyncCmd1 ch = CmdAsync $ \f _ctxs _ -> do
 asyncCmd2 :: TChan () -> CommandFunc T.Text
 asyncCmd2 ch  = CmdAsync $ \f _ctxs _ -> do
   _ <- liftIO $ forkIO $ do
+    f (IdeResponseOk "asyncCmd2 sending strobe")
     atomically $ writeTChan ch ()
-    f (IdeResponseOk "asyncCmd2 sent strobe")
   return ()
 
 -- ---------------------------------------------------------------------

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -276,14 +276,14 @@ testDescriptor chSync = PluginDescriptor
                                                  , OP "fileo" "help" PtFile
                                                  , OP "poso"  "help" PtPos
                                                  ]
-      , mkAsyncCmdWithContext (asyncCmd1 chSync) (Proxy :: Proxy "cmdasync1") [CtxNone] []
-      , mkAsyncCmdWithContext (asyncCmd2 chSync) (Proxy :: Proxy "cmdasync2") [CtxNone] []
+      , mkAsyncCmdWithContext (asyncCmd1 chSync) "cmdasync1" [CtxNone] []
+      , mkAsyncCmdWithContext (asyncCmd2 chSync) "cmdasync2" [CtxNone] []
       ]
   , pdExposedServices = []
   , pdUsedServices    = []
   }
 
-mkCmdWithContext :: CommandName -> [AcceptedContext] -> [ParamDescription] -> Command
+mkCmdWithContext :: CommandName -> [AcceptedContext] -> [ParamDescription] -> UntaggedCommand
 mkCmdWithContext n cts pds =
         Command
           { cmdDesc = CommandDesc
@@ -297,9 +297,16 @@ mkCmdWithContext n cts pds =
           , cmdFunc = CmdSync $ \ctxs _ -> return (IdeResponseOk (T.pack $ "result:ctxs=" ++ show ctxs))
           }
 
-mkAsyncCmdWithContext :: (ValidResponse a, KnownSymbol s) => CommandFunc a -> Proxy s -> [AcceptedContext] -> [ParamDescription] -> Command
+mkAsyncCmdWithContext :: (ValidResponse a) => CommandFunc a -> CommandName -> [AcceptedContext] -> [ParamDescription] -> UntaggedCommand
 mkAsyncCmdWithContext cf n cts pds =
-        let Vinyl.Const cmd = buildCommand cf n "description" [] cts pds in cmd
+  Command {cmdDesc =
+             CommandDesc {cmdName = n
+                         ,cmdUiDescription = "description"
+                         ,cmdFileExtensions = []
+                         ,cmdContexts = cts
+                         ,cmdAdditionalParams = pds
+                         ,cmdReturnType = "Text"}
+          ,cmdFunc = cf}
 
 -- ---------------------------------------------------------------------
 

--- a/test/ExamplePluginAsyncSpec.hs
+++ b/test/ExamplePluginAsyncSpec.hs
@@ -55,4 +55,4 @@ examplePluginAsyncSpec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: Plugins
-testPlugins = Map.fromList [("test",exampleAsyncDescriptor)]
+testPlugins = Map.fromList [("test",untagPluginDescriptor exampleAsyncDescriptor)]

--- a/test/ExtensibleStateSpec.hs
+++ b/test/ExtensibleStateSpec.hs
@@ -54,7 +54,7 @@ extensibleStateSpec = do
 testPlugins :: TChan () -> Plugins
 testPlugins chSync = Map.fromList [("test",testDescriptor chSync)]
 
-testDescriptor :: TChan () -> PluginDescriptor
+testDescriptor :: TChan () -> UntaggedPluginDescriptor
 testDescriptor chSync = PluginDescriptor
   {
     pdUIShortName = "testDescriptor"

--- a/test/ExtensibleStateSpec.hs
+++ b/test/ExtensibleStateSpec.hs
@@ -88,7 +88,7 @@ instance ExtensionClass MyState1 where
 -- ---------------------------------------------------------------------
 
 mkCmdWithContext ::(ValidResponse a)
-                 => CommandFunc a -> CommandName -> [AcceptedContext] -> [ParamDescription] -> Command
+                 => CommandFunc a -> CommandName -> [AcceptedContext] -> [ParamDescription] -> UntaggedCommand
 mkCmdWithContext cmd n cts pds =
         Command
           { cmdDesc = CommandDesc

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -37,7 +37,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: Plugins
-testPlugins = Map.fromList [("ghcmod",ghcmodDescriptor)]
+testPlugins = Map.fromList [("ghcmod",untagPluginDescriptor ghcmodDescriptor)]
 
 -- TODO: break this out into a TestUtils file
 dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -35,7 +35,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: Plugins
-testPlugins = Map.fromList [("hare",hareDescriptor)]
+testPlugins = Map.fromList [("hare",untagPluginDescriptor hareDescriptor)]
 
 -- TODO: break this out into a TestUtils file
 dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -39,7 +39,7 @@ jsonSpec = do
     prop "[Text]" (propertyValidRoundtrip :: [Text] -> Bool)
     prop "()" (propertyValidRoundtrip :: () -> Bool)
     prop "Aeson.Object" (propertyValidRoundtrip :: Object -> Bool)
-    prop "CommandDescriptor" (propertyValidRoundtrip :: CommandDescriptor -> Bool)
+    prop "CommandDescriptor" (propertyValidRoundtrip :: UntaggedCommandDescriptor -> Bool)
     prop "ExtendedCommandDescriptor" (propertyValidRoundtrip :: ExtendedCommandDescriptor -> Bool)
     prop "IdePlugins" (propertyValidRoundtrip :: IdePlugins -> Bool)
     prop "TypeInfo" (propertyValidRoundtrip :: TypeInfo -> Bool)
@@ -52,7 +52,7 @@ jsonSpec = do
     prop "AcceptedContext" (propertyJsonRoundtrip :: AcceptedContext -> Bool)
     prop "ParamType" (propertyJsonRoundtrip :: ParamType -> Bool)
     prop "ParamDescription" (propertyJsonRoundtrip :: ParamDescription -> Bool)
-    prop "CommandDescriptor" (propertyJsonRoundtrip :: CommandDescriptor -> Bool)
+    prop "CommandDescriptor" (propertyJsonRoundtrip :: UntaggedCommandDescriptor -> Bool)
     prop "Service" (propertyJsonRoundtrip :: Service -> Bool)
     prop "IdeRequest" (propertyJsonRoundtrip :: IdeRequest -> Bool)
     prop "IdeErrorCode" (propertyJsonRoundtrip :: IdeErrorCode -> Bool)
@@ -72,7 +72,7 @@ instance Arbitrary Value where
     s <- arbitrary
     return $ String s
 
-instance Arbitrary CommandDescriptor where
+instance Arbitrary UntaggedCommandDescriptor where
   arbitrary = CommandDesc
     <$> arbitrary
     <*> arbitrary
@@ -109,7 +109,7 @@ instance Arbitrary UntaggedPluginDescriptor where
 smallList :: Gen a -> Gen [a]
 smallList = resize 3 . listOf
 
-instance Arbitrary Command where
+instance Arbitrary UntaggedCommand where
   arbitrary = Command <$> arbitrary <*> pure (CmdAsync (\_ _ _ -> return ())::CommandFunc Text)
 
 -- | Sufficient for tests

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -97,7 +97,7 @@ instance Arbitrary ParamDescription where
 instance Arbitrary Service where
   arbitrary = Service <$> arbitrary
 
-instance Arbitrary PluginDescriptor where
+instance Arbitrary UntaggedPluginDescriptor where
   arbitrary = PluginDescriptor <$>
               arbitrary <*>
               arbitrary <*>
@@ -113,7 +113,7 @@ instance Arbitrary Command where
   arbitrary = Command <$> arbitrary <*> pure (CmdAsync (\_ _ _ -> return ())::CommandFunc Text)
 
 -- | Sufficient for tests
-instance Eq PluginDescriptor where
+instance Eq UntaggedPluginDescriptor where
   a == b = show a == show b
 
 instance Arbitrary ParamValP where

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -27,62 +27,70 @@ pluginUtilsSpec = do
       fmap pdeCollisions (validatePlugins pluginsWithCollisions) `shouldBe` Just
             [ ParamCollision "plugin1" "cmd1" "file"
               [ AdditionalParam
-                  RP
+                  ParamDesc
                     { pName = "file"
                     , pHelp = "shoud collide"
                     , pType = PtText
+                    , pRequired = Required
                     }
               , ContextParam fileParam CtxRegion
               ]
             , ParamCollision "plugin1" "cmd2" "end_pos"
               [ AdditionalParam
-                  RP
+                  ParamDesc
                     { pName = "end_pos"
                     , pHelp = "shoud collide"
                     , pType = PtText
+                    , pRequired = Required
                     }
               , ContextParam endPosParam CtxRegion
               ]
             , ParamCollision "plugin1" "cmd3" "a"
               [ AdditionalParam
-                  RP
+                  ParamDesc
                     { pName = "a"
                     , pHelp = "shoud collide"
                     , pType = PtText
+                    , pRequired = Required
                     }
               , AdditionalParam
-                  OP
+                  ParamDesc
                     { pName = "a"
                     , pHelp = "shoud collide"
                     , pType = PtText
+                    , pRequired = Optional
                     }
               , AdditionalParam
-                  OP
+                  ParamDesc
                     { pName = "a"
                     , pHelp = "shoud collide"
                     , pType = PtText
+                    , pRequired = Optional
                     }
               ]
               , ParamCollision "plugin1" "cmd3" "b"
                 [ AdditionalParam
-                    RP
+                    ParamDesc
                       { pName = "b"
                       , pHelp = "shoud collide"
                       , pType = PtText
+                      , pRequired = Required
                       }
                 , AdditionalParam
-                    RP
+                    ParamDesc
                       { pName = "b"
                       , pHelp = "shoud collide"
                       , pType = PtText
+                      , pRequired = Required
                       }
                 ]
             , ParamCollision "plugin2" "cmd1" "file"
               [ AdditionalParam
-                  RP
+                  ParamDesc
                     { pName = "file"
                     , pHelp = "shoud collide"
                     , pType = PtText
+                    , pRequired = Required
                     }
               , ContextParam fileParam CtxRegion
               , ContextParam fileParam CtxPoint
@@ -94,22 +102,22 @@ pluginUtilsSpec = do
             "Error: Parameter name collision in plugin description\n"++
             "Parameter names must be unique for each command. The following collisions were found:\n" ++
             "In \"plugin1\":\"cmd1\" the parameter \"file\" is defined in:\n" ++
-            "    cmdAdditionalParams = RP {pName = \"file\", pHelp = \"shoud collide\", pType = PtText}\n"++
-            "    cmdContexts = [CtxRegion]: RP {pName = \"file\", pHelp = \"a file name\", pType = PtFile}\n"++
+            "    cmdAdditionalParams = ParamDesc {pName = \"file\", pHelp = \"shoud collide\", pType = PtText, pRequired = Required}\n"++
+            "    cmdContexts = [CtxRegion]: ParamDesc {pName = \"file\", pHelp = \"a file name\", pType = PtFile, pRequired = Required}\n"++
             "In \"plugin1\":\"cmd2\" the parameter \"end_pos\" is defined in:\n"++
-            "    cmdAdditionalParams = RP {pName = \"end_pos\", pHelp = \"shoud collide\", pType = PtText}\n"++
-            "    cmdContexts = [CtxRegion]: RP {pName = \"end_pos\", pHelp = \"end line and col\", pType = PtPos}\n"++
+            "    cmdAdditionalParams = ParamDesc {pName = \"end_pos\", pHelp = \"shoud collide\", pType = PtText, pRequired = Required}\n"++
+            "    cmdContexts = [CtxRegion]: ParamDesc {pName = \"end_pos\", pHelp = \"end line and col\", pType = PtPos, pRequired = Required}\n"++
             "In \"plugin1\":\"cmd3\" the parameter \"a\" is defined in:\n"++
-            "    cmdAdditionalParams = RP {pName = \"a\", pHelp = \"shoud collide\", pType = PtText}\n"++
-            "    cmdAdditionalParams = OP {pName = \"a\", pHelp = \"shoud collide\", pType = PtText}\n"++
-            "    cmdAdditionalParams = OP {pName = \"a\", pHelp = \"shoud collide\", pType = PtText}\n"++
+            "    cmdAdditionalParams = ParamDesc {pName = \"a\", pHelp = \"shoud collide\", pType = PtText, pRequired = Required}\n"++
+            "    cmdAdditionalParams = ParamDesc {pName = \"a\", pHelp = \"shoud collide\", pType = PtText, pRequired = Optional}\n"++
+            "    cmdAdditionalParams = ParamDesc {pName = \"a\", pHelp = \"shoud collide\", pType = PtText, pRequired = Optional}\n"++
             "In \"plugin1\":\"cmd3\" the parameter \"b\" is defined in:\n"++
-            "    cmdAdditionalParams = RP {pName = \"b\", pHelp = \"shoud collide\", pType = PtText}\n"++
-            "    cmdAdditionalParams = RP {pName = \"b\", pHelp = \"shoud collide\", pType = PtText}\n"++
+            "    cmdAdditionalParams = ParamDesc {pName = \"b\", pHelp = \"shoud collide\", pType = PtText, pRequired = Required}\n"++
+            "    cmdAdditionalParams = ParamDesc {pName = \"b\", pHelp = \"shoud collide\", pType = PtText, pRequired = Required}\n"++
             "In \"plugin2\":\"cmd1\" the parameter \"file\" is defined in:\n"++
-            "    cmdAdditionalParams = RP {pName = \"file\", pHelp = \"shoud collide\", pType = PtText}\n"++
-            "    cmdContexts = [CtxRegion]: RP {pName = \"file\", pHelp = \"a file name\", pType = PtFile}\n"++
-            "    cmdContexts = [CtxPoint]: RP {pName = \"file\", pHelp = \"a file name\", pType = PtFile}\n"
+            "    cmdAdditionalParams = ParamDesc {pName = \"file\", pHelp = \"shoud collide\", pType = PtText, pRequired = Required}\n"++
+            "    cmdContexts = [CtxRegion]: ParamDesc {pName = \"file\", pHelp = \"a file name\", pType = PtFile, pRequired = Required}\n"++
+            "    cmdContexts = [CtxPoint]: ParamDesc {pName = \"file\", pHelp = \"a file name\", pType = PtFile, pRequired = Required}\n"
           )
 
 
@@ -127,19 +135,22 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                           , cmdContexts = [CtxRegion] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
                           , cmdAdditionalParams =
                             [
-                              RP
+                              ParamDesc
                                 { pName = "file"
                                 , pHelp = "shoud collide"
                                 , pType = PtText
+                                , pRequired = Required
                                 }
-                            , RP
+                            , ParamDesc
                                 { pName = "uniqueParamName1"
                                 , pHelp = "shoud not collide"
                                 , pType = PtText
+                                , pRequired = Required
                                 }
                             ]
                           }
-            , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
+            , cmdFunc = CmdSync $ \_ _ ->
+                return (IdeResponseOk ("" :: T.Text) :: IdeResponse T.Text)
             }
         , Command
             { cmdDesc = CommandDesc
@@ -150,58 +161,65 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                           , cmdContexts = [CtxRegion]
                           , cmdAdditionalParams =
                             [
-                              RP
+                              ParamDesc
                                 { pName = "end_pos"
                                 , pHelp = "shoud collide"
                                 , pType = PtText
+                                , pRequired = Required
                                 }
-                            , OP
+                            , ParamDesc
                                 { pName = "uniqueParamName1"
                                 , pHelp = "shoud not collide"
                                 , pType = PtText
+                                , pRequired = Optional
                                 }
                             ]
                           }
             , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
             }
-            , Command
-                { cmdDesc = CommandDesc
-                              { cmdName = "cmd3"
-                              , cmdUiDescription = ""
-                              , cmdFileExtensions = []
-                              , cmdReturnType = ""
-                              , cmdContexts = [] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
-                              , cmdAdditionalParams =
-                                [
-                                  RP
-                                    { pName = "a"
-                                    , pHelp = "shoud collide"
-                                    , pType = PtText
-                                    }
-                                , OP
-                                    { pName = "a"
-                                    , pHelp = "shoud collide"
-                                    , pType = PtText
-                                    }
-                                , OP
-                                    { pName = "a"
-                                    , pHelp = "shoud collide"
-                                    , pType = PtText
-                                    }
-                                , RP
-                                  { pName = "b"
-                                  , pHelp = "shoud collide"
-                                  , pType = PtText
-                                  }
-                                , RP
-                                  { pName = "b"
-                                  , pHelp = "shoud collide"
-                                  , pType = PtText
-                                  }
-                                ]
+        , Command
+            { cmdDesc = CommandDesc
+                          { cmdName = "cmd3"
+                          , cmdUiDescription = ""
+                          , cmdFileExtensions = []
+                          , cmdReturnType = ""
+                          , cmdContexts = [] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
+                          , cmdAdditionalParams =
+                            [
+                              ParamDesc
+                                { pName = "a"
+                                , pHelp = "shoud collide"
+                                , pType = PtText
+                                , pRequired = Required
+                                }
+                            , ParamDesc
+                                { pName = "a"
+                                , pHelp = "shoud collide"
+                                , pType = PtText
+                                , pRequired = Optional
+                                }
+                            , ParamDesc
+                                { pName = "a"
+                                , pHelp = "shoud collide"
+                                , pType = PtText
+                                , pRequired = Optional
+                                }
+                            , ParamDesc
+                              { pName = "b"
+                              , pHelp = "shoud collide"
+                              , pType = PtText
+                              , pRequired = Required
                               }
-                , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
-                }
+                            , ParamDesc
+                              { pName = "b"
+                              , pHelp = "shoud collide"
+                              , pType = PtText
+                              , pRequired = Required
+                              }
+                            ]
+                          }
+            , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
+            }
         ]
       , pdExposedServices = []
       , pdUsedServices    = []
@@ -221,38 +239,41 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                               , cmdContexts = [CtxRegion, CtxPoint] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
                               , cmdAdditionalParams =
                                 [
-                                  RP
+                                  ParamDesc
                                     { pName = "file"
                                     , pHelp = "shoud collide"
                                     , pType = PtText
+                                    , pRequired = Required
                                     }
-                                , RP
+                                , ParamDesc
                                     { pName = "uniqueParamName1"
                                     , pHelp = "shoud not collide"
                                     , pType = PtText
+                                    , pRequired = Required
                                     }
                                 ]
                               }
                 , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
                 }
             , Command
-              { cmdDesc = CommandDesc
-                            { cmdName = "cmd2"
-                            , cmdUiDescription = ""
-                            , cmdFileExtensions = []
-                            , cmdReturnType = ""
-                            , cmdContexts = [] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
-                            , cmdAdditionalParams =
-                              [
-                                RP
-                                  { pName = "uniqueParamName1"
-                                  , pHelp = "shoud not collide"
-                                  , pType = PtText
-                                  }
-                              ]
-                            }
-              , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
-              }
+                { cmdDesc = CommandDesc
+                              { cmdName = "cmd2"
+                              , cmdUiDescription = ""
+                              , cmdFileExtensions = []
+                              , cmdReturnType = ""
+                              , cmdContexts = [] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
+                              , cmdAdditionalParams =
+                                [
+                                  ParamDesc
+                                    { pName = "uniqueParamName1"
+                                    , pHelp = "shoud not collide"
+                                    , pType = PtText
+                                    , pRequired = Required
+                                    }
+                                ]
+                              }
+               , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
+               }
             ]
           , pdExposedServices = []
           , pdUsedServices    = []
@@ -283,37 +304,43 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
     ]
 
 
+
 pluginsWithoutCollisions :: Plugins
 pluginsWithoutCollisions = Map.fromList [("plugin1", PluginDescriptor
     {
       pdCommands =
         [
-          Command
-            { cmdDesc = CommandDesc
-                          { cmdName = "cmd1"
-                          , cmdUiDescription = "description"
-                          , cmdFileExtensions = []
-                          , cmdReturnType = ""
-                          , cmdContexts = [CtxRegion, CtxPoint] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
-                          , cmdAdditionalParams =
-                            [
-                              RP
-                                { pName = "uniqueParamName1"
-                                , pHelp = "shoud not collide"
-                                , pType = PtText
-                                }
-                            , RP
-                                { pName = "uniqueParamName2"
-                                , pHelp = "shoud not collide"
-                                , pType = PtText
-                                }
-                            ]
-                          }
-            , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
-            }
+           testCommand
         ]
       , pdExposedServices = []
       , pdUsedServices    = []
       , pdUIShortName     = ""
       , pdUIOverview      = ""
     })]
+  where func :: CommandFunc T.Text
+        func = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
+        testCommand = Command
+                        { cmdDesc = CommandDesc
+                                      { cmdName = "cmd1"
+                                      , cmdUiDescription = "description"
+                                      , cmdFileExtensions = []
+                                      , cmdReturnType = ""
+                                      , cmdContexts = [CtxRegion, CtxPoint] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
+                                      , cmdAdditionalParams =
+                                        [
+                                          ParamDesc
+                                            { pName = "uniqueParamName1"
+                                            , pHelp = "shoud not collide"
+                                            , pType = PtText
+                                            , pRequired = Required
+                                            }
+                                        , ParamDesc
+                                            { pName = "uniqueParamName2"
+                                            , pHelp = "shoud not collide"
+                                            , pType = PtText
+                                            , pRequired = Required
+                                            }
+                                        ]
+                                      } :: UntaggedCommandDescriptor
+                        , cmdFunc = func
+                        }

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -310,37 +310,34 @@ pluginsWithoutCollisions = Map.fromList [("plugin1", PluginDescriptor
     {
       pdCommands =
         [
-           testCommand
+           Command
+             { cmdDesc = CommandDesc
+                           { cmdName = "cmd1"
+                           , cmdUiDescription = "description"
+                           , cmdFileExtensions = []
+                           , cmdReturnType = ""
+                           , cmdContexts = [CtxRegion, CtxPoint] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
+                           , cmdAdditionalParams =
+                             [
+                               ParamDesc
+                                 { pName = "uniqueParamName1"
+                                 , pHelp = "shoud not collide"
+                                 , pType = PtText
+                                 , pRequired = Required
+                                 }
+                             , ParamDesc
+                                 { pName = "uniqueParamName2"
+                                 , pHelp = "shoud not collide"
+                                 , pType = PtText
+                                 , pRequired = Required
+                                 }
+                             ]
+                           } :: UntaggedCommandDescriptor
+             , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
+             }
         ]
       , pdExposedServices = []
       , pdUsedServices    = []
       , pdUIShortName     = ""
       , pdUIOverview      = ""
     })]
-  where func :: CommandFunc T.Text
-        func = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
-        testCommand = Command
-                        { cmdDesc = CommandDesc
-                                      { cmdName = "cmd1"
-                                      , cmdUiDescription = "description"
-                                      , cmdFileExtensions = []
-                                      , cmdReturnType = ""
-                                      , cmdContexts = [CtxRegion, CtxPoint] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
-                                      , cmdAdditionalParams =
-                                        [
-                                          ParamDesc
-                                            { pName = "uniqueParamName1"
-                                            , pHelp = "shoud not collide"
-                                            , pType = PtText
-                                            , pRequired = Required
-                                            }
-                                        , ParamDesc
-                                            { pName = "uniqueParamName2"
-                                            , pHelp = "shoud not collide"
-                                            , pType = PtText
-                                            , pRequired = Required
-                                            }
-                                        ]
-                                      } :: UntaggedCommandDescriptor
-                        , cmdFunc = func
-                        }


### PR DESCRIPTION
This is more of a POC than finished code, but hopefully it can help to start a discussion if we want to move in that direction.

Now let me explain my motivation for doing this:

In the current state servant knows pretty much nothing about our api. All it knows is that there are two routes, but it doesn’t know which plugins exists. That means that all the nice stuff servant brings us, like auto generated bindings is pretty much useless. In particular I played around with `servant-swagger` which works but the documentation it generates is useless for that exact reason (pinging @tobiasgwaaler since he wanted to work on that).

With this approach we get at least the plugins and the commands correctly documented although we can and probably should take this further so the parameters a command receives are also somewhere on the typelevel so that servant-swagger can just pick them up and use them instead of saying that it needs an `object`.

Another cool idea would be to reuse that same type to generate the documentation and possibly also for the json stdio although I’m less sure how useful it is there. In general the servant approach seems to be to declare the API once and then generate the rest from it which I kinda like. @rvion might be interested in that since we wanted to go for code generation. Afaik there is not yet a python backend for servant but as soon as someone adds that you should be able to get bindings for the http backend for free.

Now to the downsides:

- It adds complexity (although it was a lot of fun :)), I don’t have a problem with that but it might scare off beginners.
- We now have three places where we have lists of plugins (`PluginList` and `pluginList` once in the documentation generator and once here). Even worse we have an additional list of command names here. Not sure how much effort we should put into fixing that until we have figured out #25 (which we can hopefully do rather soon). An upside of duplicating the command names is that at least for the servant backend (and once we use that type for the other backends also there) it allows selectively disabling certain commands.  However I can’t come up with a reason why you would want to do that right now.