### PR TITLE
One shot invocation

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -129,9 +129,8 @@ run opts = do
     -- Can have multiple listeners, each using a different transport protocol, so
     -- long as they can pass through a ChannelRequest
     if (optConsole opts)
-       -- then replListener plugins cin
        then consoleListener plugins cin
-       else jsonStdioTransport cin
+       else jsonStdioTransport (optOneShot opts) cin
 
     -- At least one needs to be launched, othewise a threadDelay with a large
     -- number should be given. Or some other waiting action.

--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -5,6 +5,10 @@ import Options.Applicative.Simple
 
 data GlobalOpts = GlobalOpts
   { optConsole :: Bool
+  , optOneShot :: Bool
+      -- ^ Run one command and then exit. No attempt to cleanly shut down any
+      -- other processes that may be running, as a result off the plugin init
+      -- process.
   , optDebugOn :: Bool
   , optLogFile :: Maybe String
   , optPort :: Port
@@ -18,6 +22,10 @@ globalOptsParser = GlobalOpts
       <> long "repl"
       <> short 'c'
       <> help "Run a console REPL for simple testing"
+       )
+  <*> switch
+       ( long "one-shot"
+      <> help "Run a single command and then exit. Applies to stdio transport only, initially."
        )
   <*> switch
        ( long "debug"

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -57,9 +57,7 @@ parseToJsonPipe oneShot cin cout cid =
             liftIO $ atomically $ writeTChan cout rsp
        Right req ->
          do liftIO $ atomically $ writeTChan cin (wireToChannel cout cid req)
-     if oneShot
-       then return ()
-       else
+     unless oneShot $
          parseToJsonPipe False
                          cin
                          cout
@@ -76,9 +74,7 @@ tchanProducer :: MonadIO m => Bool -> TChan a -> P.Producer a m ()
 tchanProducer oneShot chan = do
   val <- liftIO $ atomically $ readTChan chan
   P.yield val
-  if oneShot
-    then return ()
-    else tchanProducer False chan
+  unless oneShot $ tchanProducer False chan
 
 encodePipe :: P.Pipe ChannelResponse A.Value IO ()
 encodePipe = P.map (A.toJSON . channelToWire)

--- a/test/JsonStdioSpec.hs
+++ b/test/JsonStdioSpec.hs
@@ -52,3 +52,7 @@ jsonSpec = do
       (decode "{\"params\":{\"name\":{\"text\":\"foo\"}},\
                \\"cmd\":\"eg2:helloTo\"}")
          `shouldBe` (Just wr)
+
+  describe "Processes one command only in --one-shot mode" $ do
+    it "exits after recieving one message, and sending one reply" $ do
+      pendingWith "write this test"


### PR DESCRIPTION
Invoking `hie` with the `--one-shot` flag in JSON/stdio mode will process one command only and then exit