### PR TITLE
Bump deps and adapt to new apis

### DIFF
--- a/hie-apply-refact/hie-apply-refact.cabal
+++ b/hie-apply-refact/hie-apply-refact.cabal
@@ -18,6 +18,7 @@ library
                      , apply-refact
                      , containers
                      , directory
+                     , either
                      , extra
                      , filepath
                      , ghc-mod

--- a/hie-base/Haskell/Ide/Engine/PluginTypes.hs
+++ b/hie-base/Haskell/Ide/Engine/PluginTypes.hs
@@ -213,7 +213,7 @@ data IdeErrorCode
 data IdeError = IdeError
  { ideCode    :: IdeErrorCode -- ^ The error code
  , ideMessage :: T.Text       -- ^ A human readable message
- , ideInfo    :: Maybe Value  -- ^ Additional information
+ , ideInfo    :: Value  -- ^ Additional information
  }
  deriving (Show,Read,Eq,Generic)
 
@@ -291,7 +291,7 @@ instance ValidResponse CommandDescriptor where
 instance ValidResponse IdePlugins where
   jsWrite (IdePlugins m) = H.fromList ["plugins" .= H.fromList
                 ( map (uncurry (.=))
-                $ Map.assocs m)]
+                $ Map.assocs m :: [Pair])]
   jsRead v = do
     ps <- v .: "plugins"
     liftM (IdePlugins . Map.fromList) $ mapM (\(k,vp) -> do
@@ -378,7 +378,7 @@ instance FromJSON IdeError where
  parseJSON (Object v) = IdeError
    <$> v .:  "code"
    <*> v .:  "msg"
-   <*> v .:? "info"
+   <*> v .:  "info"
  parseJSON _ = empty
 
 

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -3,6 +3,7 @@
 module Haskell.Ide.HaRePlugin where
 
 import           Control.Monad.IO.Class
+import           Data.Aeson
 import qualified Data.Text as T
 import           Data.Vinyl
 import           Haskell.Ide.Engine.PluginDescriptor
@@ -61,7 +62,7 @@ demoteCmd  = CmdSync $ \_ctxs req ->
     Right (ParamFile fileName :& ParamPos pos :& RNil) ->
       runHareCommand fileName "demote" (\s o f -> demote s o f pos)
     Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.demoteCmd: ghc’s exhaustiveness checker is broken" Nothing)
+      "HaRePlugin.demoteCmd: ghc’s exhaustiveness checker is broken" Null)
 
 -- demote :: RefactSettings -> GM.Options -> FilePath -> SimpPos -> IO [FilePath]
 
@@ -74,7 +75,7 @@ dupdefCmd = CmdSync $ \_ctxs req ->
     Right (ParamFile fileName :& ParamPos pos :& ParamText name :& RNil) ->
       runHareCommand fileName "duplicateDef" (\s o f -> duplicateDef s o f (T.unpack name) pos)
     Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.dupdefCmd: ghc’s exhaustiveness checker is broken" Nothing)
+      "HaRePlugin.dupdefCmd: ghc’s exhaustiveness checker is broken" Null)
 
 -- duplicateDef :: RefactSettings -> GM.Options -> FilePath -> String -> SimpPos -> IO [FilePath]
 
@@ -87,7 +88,7 @@ iftocaseCmd = CmdSync $ \_ctxs req ->
     Right (ParamFile fileName :& ParamPos start :& ParamPos end :& RNil) ->
       runHareCommand fileName "ifToCase" (\s o f -> ifToCase s o f start end)
     Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.ifToCaseCmd: ghc’s exhaustiveness checker is broken" Nothing)
+      "HaRePlugin.ifToCaseCmd: ghc’s exhaustiveness checker is broken" Null)
 
 -- ifToCase :: RefactSettings -> GM.Options -> FilePath -> SimpPos -> SimpPos -> IO [FilePath]
 
@@ -100,7 +101,7 @@ liftonelevelCmd = CmdSync $ \_ctxs req ->
     Right (ParamFile fileName :& ParamPos pos :& RNil) ->
       runHareCommand fileName "liftOneLevel" (\s o f -> liftOneLevel s o f pos)
     Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.liftOneLevel: ghc’s exhaustiveness checker is broken" Nothing)
+      "HaRePlugin.liftOneLevel: ghc’s exhaustiveness checker is broken" Null)
 
 -- liftOneLevel :: RefactSettings -> GM.Options -> FilePath -> SimpPos -> IO [FilePath]
 
@@ -113,7 +114,7 @@ lifttotoplevelCmd = CmdSync $ \_ctxs req ->
     Right (ParamFile fileName :& ParamPos pos :& RNil) ->
       runHareCommand fileName "liftToTopLevel" (\s o f -> liftToTopLevel s o f pos)
     Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.liftToTopLevel: ghc’s exhaustiveness checker is broken" Nothing)
+      "HaRePlugin.liftToTopLevel: ghc’s exhaustiveness checker is broken" Null)
 
 -- liftToTopLevel :: RefactSettings -> GM.Options -> FilePath -> SimpPos -> IO [FilePath]
 
@@ -126,7 +127,7 @@ renameCmd = CmdSync $ \_ctxs req ->
     Right (ParamFile fileName :& ParamPos pos :& ParamText name :& RNil) ->
       runHareCommand fileName "rename" (\s o f -> rename s o f (T.unpack name) pos)
     Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.renameCmd: ghc’s exhaustiveness checker is broken" Nothing)
+      "HaRePlugin.renameCmd: ghc’s exhaustiveness checker is broken" Null)
 
 -- rename :: RefactSettings -> Options -> FilePath -> String -> SimpPos -> IO [FilePath]
 
@@ -167,7 +168,7 @@ runHareCommand fp name cmd = do
                 liftIO $ setCurrentDirectory old
                 case res of
                   Left err -> return $ IdeResponseFail (IdeError PluginError
-                                (T.pack $ name ++ ": " ++ show err) Nothing)
+                                (T.pack $ name ++ ": " ++ show err) Null)
                   Right fs -> do
                     r <- liftIO $ makeRefactorResult fs
                     return (IdeResponseOk r)

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -77,7 +77,7 @@ mapEithers _ _ = Right []
 missingParameter :: forall r. (ValidResponse r) => ParamId -> IdeResponse r
 missingParameter param = IdeResponseFail (IdeError MissingParameter
             ("need `" <> param <> "` parameter")
-            (Just $ toJSON param))
+            (toJSON param))
 
 -- |Incorrect parameter error
 incorrectParameter :: forall r a b. (ValidResponse r,Show a,Show b)
@@ -86,8 +86,8 @@ incorrectParameter name expected value = IdeResponseFail
     (IdeError IncorrectParameterType
     ("got wrong parameter type for `" <> name <> "`, expected: " <>
       T.pack (show expected) <>" , got:" <> T.pack (show value))
-    (Just $ object ["param" .= toJSON name,"expected".= toJSON (show expected),
-      "value" .= toJSON (show value)]))
+    (object ["param" .= toJSON name,"expected".= toJSON (show expected),
+     "value" .= toJSON (show value)]))
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -67,7 +67,7 @@ commandsCmd = CmdSync $ \_ req -> do
         Nothing -> return $ IdeResponseFail $ IdeError
           { ideCode = UnknownPlugin
           , ideMessage = "Can't find plugin:" <> p
-          , ideInfo = Just $ toJSON p
+          , ideInfo = toJSON p
           }
         Just pl -> return $ IdeResponseOk $ map (cmdName . cmdDesc) (pdCommands pl)
     Just x -> return $ incorrectParameter "plugin" ("ParamText"::String) x
@@ -82,19 +82,19 @@ commandDetailCmd = CmdSync $ \_ req -> do
         Nothing -> return $ IdeResponseError $ IdeError
           { ideCode = UnknownPlugin
           , ideMessage = "Can't find plugin:" <> p
-          , ideInfo = Just $ toJSON p
+          , ideInfo = toJSON p
           }
         Just pl -> case find (\cmd -> command == (cmdName $ cmdDesc cmd) ) (pdCommands pl) of
           Nothing -> return $ IdeResponseError $ IdeError
             { ideCode = UnknownCommand
             , ideMessage = "Can't find command:" <> command
-            , ideInfo = Just $ toJSON command
+            , ideInfo = toJSON command
             }
           Just detail -> return $ IdeResponseOk (ExtendedCommandDescriptor (cmdDesc detail) p)
     Right _ -> return $ IdeResponseError $ IdeError
       { ideCode = InternalError
       , ideMessage = "commandDetailCmd: ghc’s exhaustiveness checker is broken"
-      , ideInfo = Nothing
+      , ideInfo = Null
       }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -54,7 +54,7 @@ doDispatch plugins creq = do
       return $ Just $ IdeResponseError $ IdeError
         { ideCode = UnknownPlugin
         , ideMessage = "No plugin found for:" <> cinPlugin creq
-        , ideInfo = Just $ toJSON $ cinPlugin creq
+        , ideInfo = toJSON $ cinPlugin creq
         }
     Just desc -> do
       let pn  = cinPlugin creq
@@ -66,7 +66,7 @@ doDispatch plugins creq = do
           return $ Just $ IdeResponseError $ IdeError
             { ideCode = UnknownCommand
             , ideMessage = "No such command:" <> ideCommand req
-            , ideInfo = Just $ toJSON $ ideCommand req
+            , ideInfo = toJSON $ ideCommand req
             }
         Just (Command cdesc cfunc) -> do
           case validateContexts cdesc req of
@@ -105,7 +105,7 @@ validateContexts cd req = r
       ([], []) -> Left $ IdeResponseFail $ IdeError
         { ideCode = InvalidContext
         , ideMessage = T.pack ("no valid context found, expecting one of:" ++ show (cmdContexts cd))
-        , ideInfo = Nothing
+        , ideInfo = Null
         }
       (ctxs, _) ->
         case checkParams (cmdAdditionalParams cd) (ideParams req) of

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -9,7 +9,7 @@ import           Control.Applicative
 import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
 import           Control.Lens (view)
--- import           Control.Logging
+import           Data.Aeson
 import           Control.Monad.IO.Class
 import           Control.Monad.STM
 import           Control.Monad.State.Strict
@@ -51,7 +51,7 @@ parseToJsonPipe cin cout cid =
          do let rsp =
                   CResp "" cid $
                   IdeResponseError
-                    (IdeError ParseError (T.pack $ show decodeErr) Nothing)
+                    (IdeError ParseError (T.pack $ show decodeErr) Null)
             liftIO $ debugm $ "jsonStdioTransport:parse error:" ++ show decodeErr
             liftIO $ atomically $ writeTChan cout rsp
        Right req ->

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-01-05
+resolver: nightly-2016-01-06
 packages:
 - .
 - hie-apply-refact
@@ -17,5 +17,4 @@ packages:
     git: https://github.com/mpickering/apply-refact.git
     commit: 402458652844c1a0f42b15123e0ceff761919415
   extra-dep: true
-extra-deps:
-- hlint-1.9.26
+extra-deps: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,4 @@
-#resolver: lts-3.11
-# Nightly has ghc-mod/cabal-helper, not in lts yet
-resolver: nightly-2015-12-11
+resolver: nightly-2016-01-05
 packages:
 - .
 - hie-apply-refact
@@ -11,21 +9,13 @@ packages:
 - hie-ghc-mod
 - hie-hare
 - hie-docs-generator
-# - ../ghci-ng
 - location:
     git: https://github.com/kazu-yamamoto/ghc-mod.git
     commit: b9bd4ebf77b22d2d9061d647d7799ddcc7c51228
-    # commit: bff86be69f556f80a8dcd9dd42774ab77cb00eba
   extra-dep: true
 - location:
-    git: https://github.com/alanz/hlint.git
-    commit: e32f4d3cf32d15003e54d4f42afae7bf06b50168
-  extra-dep: true
-- location:
-    git: https://github.com/alanz/apply-refact.git
-    commit: ba98a2902e5333519e60d38803f30f82c44eaffc
+    git: https://github.com/mpickering/apply-refact.git
+    commit: 402458652844c1a0f42b15123e0ceff761919415
   extra-dep: true
 extra-deps:
- - HaRe-0.8.2.1
- - rosezipper-0.2
- - syz-0.2.0.0
+- hlint-1.9.26

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -55,7 +55,7 @@ dispatcherSpec = do
       let req = IdeRequest "cmd2" (Map.fromList [])
           cr = CReq "test" 1 req chan
       r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch (testPlugins chSync) cr)
-      r `shouldBe` Just (IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `file` parameter", ideInfo = Just (String "file")}))
+      r `shouldBe` Just (IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `file` parameter", ideInfo = String "file"}))
 
     -- ---------------------------------
 
@@ -144,7 +144,7 @@ dispatcherSpec = do
       r `shouldBe`
         Just (IdeResponseFail (IdeError { ideCode = MissingParameter
                                         , ideMessage = "need `file` parameter"
-                                        , ideInfo = Just (String "file")}))
+                                        , ideInfo = String "file"}))
 
   -- -----------------------------------
 
@@ -180,7 +180,7 @@ dispatcherSpec = do
                (IdeError
                  { ideCode = IncorrectParameterType
                  , ideMessage = "got wrong parameter type for `txt`, expected: PtText , got:ParamValP {unParamValP = ParamFile \"a\"}"
-                 , ideInfo = Just (Object (HM.fromList [("value",String "ParamValP {unParamValP = ParamFile \"a\"}"),("param",String "txt"),("expected",String "PtText")]))}))
+                 , ideInfo = Object (HM.fromList [("value",String "ParamValP {unParamValP = ParamFile \"a\"}"),("param",String "txt"),("expected",String "PtText")])}))
 
 
 
@@ -212,11 +212,11 @@ dispatcherSpec = do
         Just (IdeResponseFail
               (IdeError { ideCode = IncorrectParameterType
                         , ideMessage = "got wrong parameter type for `fileo`, expected: PtFile , got:ParamValP {unParamValP = ParamText \"f\"}"
-                        , ideInfo = Just (Object (HM.fromList [("value"
-                                                            ,String "ParamValP {unParamValP = ParamText \"f\"}")
-                                                           ,("param"
-                                                            ,String "fileo")
-                                                            ,("expected",String "PtFile")]))}))
+                        , ideInfo = Object (HM.fromList [("value"
+                                                      ,String "ParamValP {unParamValP = ParamText \"f\"}")
+                                                     ,("param"
+                                                      ,String "fileo")
+                                                      ,("expected",String "PtFile")])}))
 
   -- -----------------------------------
 

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -87,7 +87,7 @@ ghcmodSpec = do
     it "runs the type command, incorrect params" $ do
       let req = IdeRequest "type" (Map.fromList [("file", ParamFileP "./test/testdata/FileWithWarning.hs")])
       r <- dispatchRequest req
-      r `shouldBe` Just (IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `start_pos` parameter", ideInfo = Just (String "start_pos")}))
+      r `shouldBe` Just (IdeResponseFail (IdeError {ideCode = MissingParameter, ideMessage = "need `start_pos` parameter", ideInfo = String "start_pos"}))
 
     -- ---------------------------------
 

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -80,7 +80,7 @@ hareSpec = do
       r <- dispatchRequest req
       r `shouldBe` Just (IdeResponseFail
                       (IdeError { ideCode = PluginError
-                                , ideMessage = "rename: \"Invalid cursor position!\"", ideInfo = Nothing}))
+                                , ideMessage = "rename: \"Invalid cursor position!\"", ideInfo = Null}))
 
     -- ---------------------------------
 


### PR DESCRIPTION
There are two minor changes here:
- I adapted the ApplyRefactPlugin to the new hlint api.
- I slightly changed the encoding of `IdeError`. Previously we had a Maybe Value which causes issues with the new aeson (I haven’t looked into why we didn’t run into it with the old version) since both `Nothing` and `Just Null` are encoded to `Null` so we no longer have an isomorphism. Since we already have a `Null` value in `Value` and I don’t think we need the distinction here, this is now just a `Value`.