### PR TITLE
Add ide-backend plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ before_install:
 install:
 - "./travis_long stack +RTS -N2 -RTS setup"
 - "./travis_long stack build --only-snapshot"
+- "./travis_long stack install ide-backend-server"
+- "export PATH=\"${HOME}/.local/bin\":${PATH}"
 script:
 - "./travis_long stack +RTS -N1 -RTS build"
 - "./travis_long stack +RTS -N1 -RTS build --test"

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -50,6 +50,7 @@ import           Haskell.Ide.ExamplePlugin2
 import           Haskell.Ide.ExamplePluginAsync
 import           Haskell.Ide.GhcModPlugin
 import           Haskell.Ide.HaRePlugin
+import           Haskell.Ide.IdeBackend
 
 -- ---------------------------------------------------------------------
 
@@ -62,6 +63,7 @@ taggedPlugins =
   :& Plugin (Proxy :: Proxy "ghcmod") ghcmodDescriptor
   :& Plugin (Proxy :: Proxy "hare") hareDescriptor
   :& Plugin (Proxy :: Proxy "base") baseDescriptor
+  :& Plugin (Proxy :: Proxy "ide-backend") idebackendDescriptor
   :& RNil
 
 recProxy :: Rec f t -> Proxy t

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -83,6 +83,7 @@ executable hie
                      , hie-example-plugin2
                      , hie-ghc-mod
                      , hie-hare
+                     , hie-ide-backend
                      , hie-plugin-api
                      , monad-logger
                      , optparse-applicative

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -100,13 +100,13 @@ test-suite haskell-ide-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
-  other-modules:
-                       ApplyRefactPluginSpec
+  other-modules:       ApplyRefactPluginSpec
                        DispatcherSpec
                        ExamplePluginAsyncSpec
                        ExtensibleStateSpec
                        GhcModPluginSpec
                        HaRePluginSpec
+                       IdeBackendPluginSpec
                        JsonStdioSpec
                        JsonSpec
                        UtilsSpec
@@ -122,6 +122,7 @@ test-suite haskell-ide-test
                      , hie-apply-refact
                      , hie-base
                      , hie-eg-plugin-async
+                     , hie-ide-backend
                      , hie-ghc-mod
                      , hie-hare
                      , hie-plugin-api

--- a/hie-ide-backend/Haskell/Ide/IdeBackend.hs
+++ b/hie-ide-backend/Haskell/Ide/IdeBackend.hs
@@ -1,0 +1,168 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
+module Haskell.Ide.IdeBackend where
+
+import           Control.Concurrent
+import           Control.Concurrent.STM
+import           Control.Monad.IO.Class
+import           Data.Aeson
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+import           Haskell.Ide.Engine.ExtensibleState
+import           Haskell.Ide.Engine.MonadFunctions
+import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.PluginUtils
+import           Haskell.Ide.Engine.SemanticTypes
+import           IdeSession
+import           IdeSession.Util.Logger
+import           Language.Haskell.GhcMod.Cradle
+import           Language.Haskell.GhcMod.GhcPkg
+import           Language.Haskell.GhcMod.Monad.Types hiding (liftIO)
+import           Language.Haskell.GhcMod.Types hiding (liftIO,ModuleName)
+import           System.FilePath
+import           System.Log.FastLogger
+
+idebackendDescriptor :: TaggedPluginDescriptor _
+idebackendDescriptor = PluginDescriptor
+  {
+    pdUIShortName = "ide-backend"
+  , pdUIOverview = "HIE plugin for ide-backend"
+  , pdCommands =
+         buildCommand typeCmd (Proxy :: Proxy "type") "type" [".hs"] (SCtxRegion :& RNil) RNil
+      :& RNil
+  , pdExposedServices = []
+  , pdUsedServices    = []
+  }
+
+typeCmd :: CommandFunc TypeInfo
+typeCmd =
+  CmdAsync $
+  \resp _ctxs req ->
+    case getParams (IdFile "file" :& IdPos "start_pos" :& IdPos "end_pos" :&
+                    RNil)
+                   req of
+      Left err -> liftIO $ resp err
+      Right (ParamFile filename :& ParamPos startPos :& ParamPos endPos :& RNil) ->
+        do SubProcess cin cout _tid <- ensureProcessRunning filename
+           liftIO $
+             atomically $
+             writeTChan cin
+                        (Type filename startPos endPos)
+           response <- liftIO $ atomically $ readTChan cout
+           case response of
+             TypeResp typeinfo -> liftIO $ resp (IdeResponseOk typeinfo)
+             ErrorResp error' -> liftIO $ resp
+               (IdeResponseError (IdeError PluginError error' Null))
+      Right _ ->
+        liftIO . resp $
+        IdeResponseError
+          (IdeError InternalError
+                    "IdeBackendPlugin.typesCmd: ghc’s exhaustiveness checker is broken"
+                    Null)
+
+instance ExtensionClass AsyncPluginState where
+  initialValue = APS Nothing
+
+data AsyncPluginState = APS (Maybe SubProcess)
+
+data WorkerCmd = Type T.Text Pos Pos deriving (Show)
+
+data IdeBackendResponse = TypeResp TypeInfo | ErrorResp T.Text
+
+data SubProcess = SubProcess
+  { spChIn    :: TChan WorkerCmd
+  , spChOut   :: TChan IdeBackendResponse
+  , spProcess :: ThreadId
+  }
+
+ensureProcessRunning :: T.Text -> IdeM SubProcess
+ensureProcessRunning filename = do
+  (APS v) <- get -- from extensible state
+  case v of
+    Nothing -> do
+      -- Get the required packagedbs from ghc-mod
+      -- This won’t be necessary once we switch to one hie instance per project
+      cradle' <- findCradle' (takeDirectory (T.unpack filename))
+      pkgdbs <- gmeLocal (\(GhcModEnv opts _) -> GhcModEnv opts cradle') getPackageDbStack
+      cin  <- liftIO $ atomically newTChan
+      cout <- liftIO $ atomically newTChan
+      tid  <- liftIO $ forkIO (workerProc pkgdbs cin cout)
+      let v' = SubProcess cin cout tid
+      put (APS (Just v')) -- into extensible state
+      return v'
+    Just v' -> return v'
+
+logFunc :: LogFunc
+logFunc _loc _source level logStr = logOtherm level (T.decodeUtf8 $ fromLogStr logStr)
+
+workerProc :: [GhcPkgDb] -> TChan WorkerCmd -> TChan IdeBackendResponse -> IO ()
+workerProc pkgdbs cin cout =
+  do session <-
+       initSessionWithCallbacks
+         (IdeCallbacks logFunc)
+         (defaultSessionInitParams {sessionInitTargets = TargetsInclude []})
+         (defaultSessionConfig {configLocalWorkingDir = Nothing
+                               ,configLog = debugm
+                               ,configPackageDBStack = (GlobalPackageDB:) $ map convPkgDb pkgdbs})
+     updateSession session
+                   (updateCodeGeneration True)
+                   (debugm . show)
+     let loop :: Int -> IO ()
+         loop cnt =
+           do debugm "workerProc:top of loop"
+              req <- liftIO $ atomically $ readTChan cin
+              debugm $ "workerProc loop:got:" ++ show req
+              case req of
+                Type file startPos endPos ->
+                  do liftIO $
+                       handleTypeInfo session cout file startPos endPos
+                     loop (cnt + 1)
+     loop 1
+
+convPkgDb :: GhcPkgDb -> PackageDB
+convPkgDb GlobalDb = GlobalPackageDB
+convPkgDb UserDb = UserPackageDB
+convPkgDb (PackageDb db) = SpecificPackageDB db
+
+ignoreStatus :: Monad m => a -> m ()
+ignoreStatus = const (return ())
+
+handleTypeInfo :: IdeSession
+               -> TChan IdeBackendResponse
+               -> T.Text
+               -> Pos
+               -> Pos
+               -> IO ()
+handleTypeInfo session cout file (startLine,startCol) (endLine,endCol) =
+  do updateSession session
+                   (updateTargets (TargetsInclude . pure $ T.unpack file))
+                   (debugm . show)
+     errors <- getSourceErrors session
+     case errors of
+       (_:_) -> atomically . writeTChan cout $ ErrorResp (T.pack $ show errors)
+       [] ->
+         do filemap <- getFileMap session
+            expTypes <- getExpTypes session
+            case filemap (T.unpack file) of
+              Nothing ->
+                atomically . writeTChan cout $ ErrorResp "No module found"
+              Just mod' ->
+                case expTypes (moduleName mod')
+                              SourceSpan {spanFilePath = T.unpack file
+                                         ,spanFromLine = startLine
+                                         ,spanToLine = endLine
+                                         ,spanFromColumn = startCol
+                                         ,spanToColumn = endCol} of
+                  ts ->
+                    atomically . writeTChan cout . TypeResp . TypeInfo $
+                    map toTypeResult ts
+  where toTypeResult
+          :: (SourceSpan,T.Text) -> TypeResult
+        toTypeResult (SourceSpan{..},t) =
+          TypeResult {trStart = (spanFromLine,spanFromColumn)
+                     ,trEnd = (spanToLine,spanToColumn)
+                     ,trText = t}

--- a/hie-ide-backend/Setup.hs
+++ b/hie-ide-backend/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/hie-ide-backend/hie-ide-backend.cabal
+++ b/hie-ide-backend/hie-ide-backend.cabal
@@ -1,0 +1,31 @@
+name:                hie-ide-backend
+version:             0.1.0.0
+synopsis:            HIE ide-backend example
+license:             BSD3
+license-file:        ../LICENSE
+author:              Many,TBD when we release
+maintainer:          alan.zimm@gmail.com (for now)
+copyright:           2015 TBD
+category:            Web
+build-type:          Simple
+-- extra-source-files:
+cabal-version:       >=1.10
+
+library
+  exposed-modules:     Haskell.Ide.IdeBackend
+  build-depends:       aeson
+                     , base >= 4.7 && < 5
+                     , containers
+                     , fast-logger
+                     , filepath
+                     , ghc-mod
+                     , hie-base
+                     , hie-plugin-api
+                     , ide-backend
+                     , ide-backend-common
+                     , stm
+                     , text
+                     , transformers
+                     , vinyl
+  ghc-options:         -Wall
+  default-language:    Haskell2010

--- a/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
@@ -11,6 +11,7 @@ module Haskell.Ide.Engine.MonadFunctions
   , setLogTimeFormat
   , logm
   , debugm
+  , logOtherm
   ) where
 
 import           Control.Monad.IO.Class
@@ -41,6 +42,9 @@ debugm s = do
   liftIO $ logDebugN $ T.pack s
   flushLog
 
+logOtherm :: MonadIO m => LogLevel -> T.Text -> m ()
+logOtherm level s = do liftIO $ logOtherN level s
+                       flushLog
 -- ---------------------------------------------------------------------
 
 -- instance MonadLoggerIO IO where

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-01-06
+resolver: nightly-2016-01-08
 packages:
 - .
 - hie-apply-refact
@@ -9,6 +9,7 @@ packages:
 - hie-ghc-mod
 - hie-hare
 - hie-docs-generator
+- hie-ide-backend
 - location:
     git: https://github.com/kazu-yamamoto/ghc-mod.git
     commit: b9bd4ebf77b22d2d9061d647d7799ddcc7c51228

--- a/test/IdeBackendPluginSpec.hs
+++ b/test/IdeBackendPluginSpec.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE OverloadedStrings #-}
+module IdeBackendPluginSpec where
+
+import           Control.Concurrent.STM.TChan
+import           Control.Exception
+import           Control.Monad.STM
+import           Data.Aeson
+import qualified Data.HashMap.Strict as H
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import           Haskell.Ide.Engine.Dispatcher
+import           Haskell.Ide.Engine.Monad
+import           Haskell.Ide.Engine.MonadFunctions
+import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.SemanticTypes
+import           Haskell.Ide.Engine.Types
+import           Haskell.Ide.IdeBackend
+import           System.Directory
+import           System.FilePath
+
+import           Test.Hspec
+
+-- ---------------------------------------------------------------------
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "ide-backend plugin" idebackendSpec
+
+-- ---------------------------------------------------------------------
+
+testPlugins :: Plugins
+testPlugins = Map.fromList [("ide-backend",untagPluginDescriptor idebackendDescriptor)]
+
+-- TODO: break this out into a TestUtils file
+dispatchRequest :: IdeRequest -> IO (Maybe (IdeResponse Object))
+dispatchRequest req = do
+  testChan <- atomically newTChan
+  let cr = CReq "ide-backend" 1 req testChan
+  r <- withStdoutLogging $ runIdeM (IdeState Map.empty Map.empty) (doDispatch testPlugins cr)
+  return r
+
+-- ---------------------------------------------------------------------
+
+idebackendSpec :: Spec
+idebackendSpec =
+  do describe "ide-backend plugin commands" $
+       do cwd <- runIO $ getCurrentDirectory
+          it "runs the type command, incorrect params" $
+            do let req =
+                     IdeRequest
+                       "type"
+                       (Map.fromList
+                          [("file"
+                           ,ParamFileP
+                              (T.pack $
+                               cwd </> "test/testdata/FileWithWarning.hs"))])
+               r <- dispatchRequest req
+               r `shouldBe`
+                 Just (IdeResponseFail
+                         (IdeError {ideCode = MissingParameter
+                                   ,ideMessage = "need `end_pos` parameter"
+                                   ,ideInfo = String "end_pos"}))
+          -- ---------------------------------
+          it "runs the type command, correct params" $
+            do let req =
+                     IdeRequest
+                       "type"
+                       (Map.fromList
+                          [("file"
+                           ,ParamFileP
+                              (T.pack $ cwd </> "test/testdata/HaReRename.hs"))
+                          ,("start_pos",ParamPosP (5,9))
+                          ,("end_pos",ParamPosP (5,9))])
+               r <- dispatchRequest req
+               r `shouldBe`
+                 Just (IdeResponseOk
+                         (H.fromList
+                            ["type_info" .=
+                             toJSON [TypeResult (5,9)
+                                                      (5,10)
+                                                      "Int"
+                                          ,TypeResult (5,9)
+                                                      (5,14)
+                                                      "Int"]]))


### PR DESCRIPTION
There are a few things here:
* It doesn’t work properly if you call it on 2 files from different projects. Given that #161 will limit hie to only deal with one project at a time anyway, I would prefer to leave it like this and instead spend the time on #161.
* I only added the type command, there is nothing stopping as from adding more commands, I just wanted to start somewhere.
* A lot of this stuff is very similar to the things in `ExamplePluginAsync`. It would probably make sense to create an `hie-plugin-utils` package containing things which are not directly relevant to `hie` itself but can be reused by plugin authors.

Also I just realized that I forgot the tests, I’ll hopefully add those later this evening.

Pinging @mgsloan since he seemed to be interested in an `ide-backend` plugin.
