### PR TITLE
Recreate buffers if they have been killed

### DIFF
--- a/elisp/hie.el
+++ b/elisp/hie.el
@@ -47,7 +47,7 @@
 
 (defun hie-process-filter (process input)
   (let ((prev-buffer (current-buffer)))
-    (with-current-buffer hie-process-buffer
+    (hie-with-process-buffer hie-process-buffer
       (let ((point (point)))
         (insert input)
         (save-excursion
@@ -111,7 +111,7 @@ running this function does nothing."
     (setq hie-process-buffer nil)))
 
 (defun hie-log (&rest args)
-  (with-current-buffer hie-log-buffer
+  (hie-with-log-buffer hie-log-buffer
     (goto-char (point-max))
     (insert (apply #'format args)
               "\n")))
@@ -172,6 +172,14 @@ association lists and count on HIE to use default values there."
     (message
      (format "Error extracting type from type-info response: %s"
              type-info))))
+
+(defmacro hie-with-log-buffer (&rest body)
+  `(progn (setq hie-log-buffer (get-buffer-create "*hie-log*"))
+          (with-current-buffer hie-log-buffer ,@body)))
+
+(defmacro hie-with-process-buffer (&rest body)
+  `(progn (setq hie-process-buffer (get-buffer-create "*hie-process*"))
+          (with-current-buffer hie-process-buffer ,@body)))
 
 (defmacro hie-with-refactor-buffer (&rest body)
   `(progn (setq hie-refactor-buffer (get-buffer-create "*hie-refactor*"))

--- a/elisp/tests/hie-tests.el
+++ b/elisp/tests/hie-tests.el
@@ -250,6 +250,18 @@ http://debbugs.gnu.org/cgi/bugreport.cgi?bug=15990."
      (should (equal "\nmain = putStrLn \"hello\"\n\nfoo_renamed :: Int -> Int\nfoo_renamed x = x + 3\n\n"
                     refactored-string)))))
 
+(hie-define-test
+ hie-can-log-if-buffer-is-killed
 
+ (hie-log "Testing log buffer")
+ (kill-buffer "*hie-log*")
+ (hie-log "Testing after killing the log buffer"))
+
+(hie-define-test
+ hie-can-still-process-if-buffer-is-killed
+
+ (hie-process-filter nil "{")
+ (kill-buffer "*hie-process*")
+ (hie-process-filter nil "}"))
 
 ;;; hie-tests.el ends here


### PR DESCRIPTION
This should recreate the `*hie-log*` and `*hie-process*` buffers if they are
used after they have been killed.

Fixes #121 