### PR TITLE
ghc-mod 5.5

### DIFF
--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -18,7 +18,6 @@ import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.SemanticTypes
 import qualified Language.Haskell.GhcMod as GM
-import qualified Language.Haskell.GhcMod.Find as GM
 import qualified Language.Haskell.GhcMod.Types as GM
 
 -- ---------------------------------------------------------------------

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -8,28 +8,18 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Haskell.Ide.GhcModPlugin where
 
-import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Data.Either
-import           Data.Function
-import           Data.List
-import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.Read as T
 import           Data.Vinyl
 import qualified Exception as G
-import qualified GHC as G
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.SemanticTypes
 import qualified Language.Haskell.GhcMod as GM
-import qualified Language.Haskell.GhcMod.Gap as GM
-import qualified Language.Haskell.GhcMod.Monad as GM
+import qualified Language.Haskell.GhcMod.Find as GM
 import qualified Language.Haskell.GhcMod.Types as GM
-import qualified Language.Haskell.GhcMod.Utils as GM
-import qualified Name as G
-import           System.Directory
-import           System.FilePath
 
 -- ---------------------------------------------------------------------
 
@@ -97,44 +87,15 @@ checkCmd = CmdSync $ \_ctxs req -> do
 
 -- ---------------------------------------------------------------------
 
--- | Extracted from ghc-mod
-getGlobalSymbolTable :: GM.LightGhc [(GM.Symbol, [GM.ModuleString])]
-getGlobalSymbolTable = do
-  df  <- G.getSessionDynFlags
-  let mods = GM.listVisibleModules df
-  moduleInfos <- mapM G.getModuleInfo mods
-  return $ collectModules
-         $ extractBindings `concatMap` (moduleInfos `zip` mods)
-
--- | Extracted from ghc-mod
-extractBindings :: (Maybe G.ModuleInfo, G.Module)
-                -> [(GM.Symbol, GM.ModuleString)]
-extractBindings (Nothing,  _)   = []
-extractBindings (Just inf, mdl) =
-  map (\name -> (G.getOccString name, modStr)) names
-  where
-    names  = G.modInfoExports inf
-    modStr = GM.ModuleString $ GM.moduleNameString $ G.moduleName mdl
-
--- | Extracted from ghc-mod
-collectModules :: [(GM.Symbol, GM.ModuleString)]
-               -> [(GM.Symbol, [GM.ModuleString])]
-collectModules = map tieup . groupBy ((==) `on` fst) . sort
-  where
-    tieup x = (head (map fst x), map snd x)
-
 -- | Runs the find command from the given directory, for the given symbol
 findCmd :: CommandFunc ModuleList
 findCmd = CmdSync $ \_ctxs req -> do
-  case getParams (IdFile "dir" :& IdText "symbol" :& RNil) req of
+  case getParams (IdText "symbol" :& RNil) req of
     Left err -> return err
-    Right (ParamFile dirName :& ParamText symbol :& RNil) -> do
-      runGhcModCommand
-        (do -- adapted from ghc-mod find command, which launches the executable again
-            symbolTable <- M.fromAscList <$> GM.runGmPkgGhc getGlobalSymbolTable
-            let f = M.findWithDefault ([]::[GM.ModuleString]) (T.unpack symbol) symbolTable
-            return $ ModuleList $ map (T.pack . GM.getModuleString) f
-        )
+    Right (ParamText symbol :& RNil) -> do
+      runGhcModCommand $
+        (ModuleList . map (T.pack . GM.getModuleString)) <$> GM.findSymbol' (T.unpack symbol)
+
 
       -- return (IdeResponseOk "Placholder:Need to debug this in ghc-mod, returns 'does not exist (No such file or directory)'")
     Right _ -> return $ IdeResponseError (IdeError InternalError

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -37,10 +37,10 @@ ghcmodDescriptor = PluginDescriptor
       :& buildCommand lintCmd (Proxy :: Proxy "lint")  "Check files using `hlint'"
                      [".hs",".lhs"] (SCtxFile :& RNil) RNil
 
-      :& buildCommand findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
-                     [".hs",".lhs"] (SCtxProject :& RNil)
-                     (  SParamDesc (Proxy :: Proxy "symbol") (Proxy :: Proxy "The SYMBOL to look up") SPtText SRequired
-                     :& RNil)
+      -- :& buildCommand findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
+      --                [".hs",".lhs"] (SCtxProject :& RNil)
+      --                (  SParamDesc (Proxy :: Proxy "symbol") (Proxy :: Proxy "The SYMBOL to look up") SPtText SRequired
+      --                :& RNil)
 
       :& buildCommand infoCmd (Proxy :: Proxy "info") "Look up an identifier in the context of FILE (like ghci's `:info')"
                      [".hs",".lhs"] (SCtxFile :& RNil)
@@ -87,19 +87,20 @@ checkCmd = CmdSync $ \_ctxs req -> do
 
 -- ---------------------------------------------------------------------
 
--- | Runs the find command from the given directory, for the given symbol
-findCmd :: CommandFunc ModuleList
-findCmd = CmdSync $ \_ctxs req -> do
-  case getParams (IdText "symbol" :& RNil) req of
-    Left err -> return err
-    Right (ParamText symbol :& RNil) -> do
-      runGhcModCommand $
-        (ModuleList . map (T.pack . GM.getModuleString)) <$> GM.findSymbol' (T.unpack symbol)
+-- Disabled until ghc-mod no longer needs to launch a separate executable
+-- -- | Runs the find command from the given directory, for the given symbol
+-- findCmd :: CommandFunc ModuleList
+-- findCmd = CmdSync $ \_ctxs req -> do
+--   case getParams (IdText "symbol" :& RNil) req of
+--     Left err -> return err
+--     Right (ParamText symbol :& RNil) -> do
+--       runGhcModCommand $
+--         (ModuleList . map (T.pack . GM.getModuleString)) <$> GM.findSymbol' (T.unpack symbol)
 
 
-      -- return (IdeResponseOk "Placholder:Need to debug this in ghc-mod, returns 'does not exist (No such file or directory)'")
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "GhcModPlugin.findCmd: ghc’s exhaustiveness checker is broken" Null)
+--       -- return (IdeResponseOk "Placholder:Need to debug this in ghc-mod, returns 'does not exist (No such file or directory)'")
+--     Right _ -> return $ IdeResponseError (IdeError InternalError
+--       "GhcModPlugin.findCmd: ghc’s exhaustiveness checker is broken" Null)
 
 -- ---------------------------------------------------------------------
 

--- a/hie-hare/hie-hare.cabal
+++ b/hie-hare/hie-hare.cabal
@@ -27,6 +27,8 @@ library
                      , ghc-mod
                      , hie-base
                      , hie-plugin-api
+                     , monad-control >= 1.0 && < 1.1
+                     , mtl >= 2.2 && < 2.3
                      , text
                      , transformers
                      , vinyl >= 0.5 && < 0.6

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
@@ -20,14 +21,15 @@ import           Control.Exception
 import           Data.Aeson
 import           Data.Algorithm.Diff
 import           Data.Algorithm.DiffOutput
+import           Data.Bifunctor
+import qualified Data.Map as Map
 import           Data.Monoid
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import           Data.Vinyl
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.SemanticTypes
-import qualified Data.Map as Map
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
 import           Prelude hiding (log)
 import           System.FilePath
 
@@ -118,8 +120,5 @@ fileInfo tfileName =
 
 catchException :: (IO t) -> IO (Either String t)
 catchException f = do
-  res <- handle handler (f >>= \r -> return $ Right r)
-  return res
-  where
-    handler:: SomeException -> IO (Either String t)
-    handler e = return (Left (show e))
+  res <- try f
+  pure (first (\(e :: SomeException) -> show e) res)

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -14,7 +14,6 @@ module Haskell.Ide.Engine.PluginUtils
   , missingParameter
   , incorrectParameter
   , fileInfo
-  , catchException
   ) where
 
 import           Control.Exception
@@ -117,8 +116,3 @@ fileInfo tfileName =
   let sfileName = T.unpack tfileName
       dir = takeDirectory sfileName
   in (dir,sfileName)
-
-catchException :: (IO t) -> IO (Either String t)
-catchException f = do
-  res <- try f
-  pure (first (\(e :: SomeException) -> show e) res)

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -16,11 +16,9 @@ module Haskell.Ide.Engine.PluginUtils
   , fileInfo
   ) where
 
-import           Control.Exception
 import           Data.Aeson
 import           Data.Algorithm.Diff
 import           Data.Algorithm.DiffOutput
-import           Data.Bifunctor
 import qualified Data.Map as Map
 import           Data.Monoid
 import qualified Data.Text as T

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -37,11 +37,11 @@ import           System.FilePath
 
 -- |If all the listed params are present in the request resturn their values,
 -- else return an error message.
-getParams :: forall r ts. (ValidResponse r) =>
+getParams :: (ValidResponse r) =>
   Rec TaggedParamId ts -> IdeRequest -> Either (IdeResponse r) (Rec ParamVal ts)
 getParams params req = go params
   where
-    go :: forall r ts. (ValidResponse r) =>
+    go :: (ValidResponse r) =>
       Rec TaggedParamId ts -> Either (IdeResponse r) (Rec ParamVal ts)
     go RNil = Right RNil
     go (x:&xs) = case go xs of

--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -13,6 +13,7 @@ data GlobalOpts = GlobalOpts
   , optLogFile :: Maybe String
   , optPort :: Port
   , optHttp :: Bool
+  , projectRoot :: Maybe String
   } deriving (Show)
 
 globalOptsParser :: Parser GlobalOpts
@@ -47,3 +48,8 @@ globalOptsParser = GlobalOpts
   <*> flag False True
        ( long "http"
        <> help "Enable the webinterface")
+  <*> (optional $ strOption
+       ( long "project-root"
+      <> short 'r'
+      <> metavar "PROJECTROOT"
+      <> help "Root directory of project, defaults to cwd"))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-01-08
+resolver: nightly-2016-01-14
 packages:
 - .
 - hie-apply-refact
@@ -12,12 +12,16 @@ packages:
 - hie-docs-generator
 - hie-ide-backend
 - location:
-    git: https://github.com/kazu-yamamoto/ghc-mod.git
-    commit: b9bd4ebf77b22d2d9061d647d7799ddcc7c51228
-  extra-dep: true
-- location:
     git: https://github.com/mpickering/apply-refact.git
     commit: 402458652844c1a0f42b15123e0ceff761919415
+  extra-dep: true
+- location:
+    git: https://github.com/DanielG/ghc-mod.git
+    commit: 54fe4a0edbdddfbdc2acc43edde2b061ca5b399b
+  extra-dep: true
+- location:
+    git: https://github.com/alanz/HaRe.git
+    commit: dd8701705c6388ae79be0ec2a00c70a708454242
   extra-dep: true
 extra-deps:
   - ghc-dump-tree-0.2.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,8 +16,8 @@ packages:
     commit: 402458652844c1a0f42b15123e0ceff761919415
   extra-dep: true
 - location:
-    git: https://github.com/DanielG/ghc-mod.git
-    commit: 54fe4a0edbdddfbdc2acc43edde2b061ca5b399b
+    git: https://github.com/cocreature/ghc-mod.git
+    commit: 76d0ff306fc500132120eff9dfb26834f15cbf23
   extra-dep: true
 - location:
     git: https://github.com/alanz/HaRe.git

--- a/stack.yaml
+++ b/stack.yaml
@@ -16,12 +16,12 @@ packages:
     commit: 402458652844c1a0f42b15123e0ceff761919415
   extra-dep: true
 - location:
-    git: https://github.com/cocreature/ghc-mod.git
-    commit: 76d0ff306fc500132120eff9dfb26834f15cbf23
+    git: https://github.com/DanielG/ghc-mod.git
+    commit: 54fe4a0edbdddfbdc2acc43edde2b061ca5b399b
   extra-dep: true
 - location:
-    git: https://github.com/alanz/HaRe.git
-    commit: dd8701705c6388ae79be0ec2a00c70a708454242
+    git: https://github.com/cocreature/HaRe.git
+    commit: 318841c2c125de60a4db9de75d108841651db410
   extra-dep: true
 extra-deps:
   - ghc-dump-tree-0.2.0.0

--- a/stack_test.yaml
+++ b/stack_test.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-01-06
+resolver: nightly-2016-01-14
 packages:
 - .
 - hie-apply-refact
@@ -12,12 +12,16 @@ packages:
 - hie-docs-generator
 - hie-ide-backend
 - location:
-    git: https://github.com/kazu-yamamoto/ghc-mod.git
-    commit: b9bd4ebf77b22d2d9061d647d7799ddcc7c51228
-  extra-dep: true
-- location:
     git: https://github.com/mpickering/apply-refact.git
     commit: 402458652844c1a0f42b15123e0ceff761919415
+  extra-dep: true
+- location:
+    git: https://github.com/DanielG/ghc-mod.git
+    commit: 54fe4a0edbdddfbdc2acc43edde2b061ca5b399b
+  extra-dep: true
+- location:
+    git: https://github.com/alanz/HaRe.git
+    commit: dd8701705c6388ae79be0ec2a00c70a708454242
   extra-dep: true
 extra-deps:
   - ghc-dump-tree-0.2.0.0

--- a/stack_test.yaml
+++ b/stack_test.yaml
@@ -16,8 +16,8 @@ packages:
     commit: 402458652844c1a0f42b15123e0ceff761919415
   extra-dep: true
 - location:
-    git: https://github.com/DanielG/ghc-mod.git
-    commit: 54fe4a0edbdddfbdc2acc43edde2b061ca5b399b
+    git: https://github.com/cocreature/ghc-mod.git
+    commit: 76d0ff306fc500132120eff9dfb26834f15cbf23
   extra-dep: true
 - location:
     git: https://github.com/alanz/HaRe.git

--- a/stack_test.yaml
+++ b/stack_test.yaml
@@ -16,12 +16,12 @@ packages:
     commit: 402458652844c1a0f42b15123e0ceff761919415
   extra-dep: true
 - location:
-    git: https://github.com/cocreature/ghc-mod.git
-    commit: 76d0ff306fc500132120eff9dfb26834f15cbf23
+    git: https://github.com/DanielG/ghc-mod.git
+    commit: 54fe4a0edbdddfbdc2acc43edde2b061ca5b399b
   extra-dep: true
 - location:
-    git: https://github.com/alanz/HaRe.git
-    commit: dd8701705c6388ae79be0ec2a00c70a708454242
+    git: https://github.com/cocreature/HaRe.git
+    commit: 318841c2c125de60a4db9de75d108841651db410
   extra-dep: true
 extra-deps:
   - ghc-dump-tree-0.2.0.0

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -68,10 +68,10 @@ ghcmodSpec = do
 
     -- ---------------------------------
 
-    it "runs the find command" $ do
-      let req = IdeRequest "find" (Map.fromList [("dir", ParamFileP "."),("symbol", ParamTextP "Show")])
-      r <- dispatchRequest req
-      r `shouldBe` Just (IdeResponseOk (H.fromList ["modules" .= ["GHC.Show"::String,"Prelude","Test.Hspec.Discover","Text.Show"]]))
+    -- it "runs the find command" $ do
+    --   let req = IdeRequest "find" (Map.fromList [("dir", ParamFileP "."),("symbol", ParamTextP "Show")])
+    --   r <- dispatchRequest req
+    --   r `shouldBe` Just (IdeResponseOk (H.fromList ["modules" .= ["GHC.Show"::String,"Prelude","Test.Hspec.Discover","Text.Show"]]))
 
 
     -- ---------------------------------


### PR DESCRIPTION
Now the cwd is only changed at startup, which means that every cabal
project requires it’s own hie instance.

This is not finished, but I thought that it might be easier to fix the remaining issues if we have something to look at.

In particular HaRe needs to expose functions that work in `GhcModT` instead of trying to setup it’s own ghc-mod session since that no longer works with ghc-mod 5.5.

Also the ide bindings need to be updated. They simply need to pass in the directory with the cabal file or any subdirectory of that (ghc-mod figures the root out in that case). They can either do that by starting `hie` with the correct cwd or by using `-r projectdir`. On the emacs front we can probably simply abuse haskell-mode’s session management to have one `hie` instance per project.