### PR TITLE
TCP transport

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -35,8 +35,10 @@ import           Haskell.Ide.Engine.Options
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.Transport.JsonHttp
 import           Haskell.Ide.Engine.Transport.JsonStdio
+import           Haskell.Ide.Engine.Transport.JsonTcp
 import           Haskell.Ide.Engine.Types
 import           Haskell.Ide.Engine.Utils
+import           Network.Simple.TCP
 import           Options.Applicative.Simple
 import qualified Paths_haskell_ide_engine as Meta
 import           System.Directory
@@ -141,6 +143,8 @@ run opts = do
     when (optHttp opts) $
       void $ forkIO (jsonHttpListener (recProxy taggedPlugins) cin (optPort opts))
 
+    when (optTcp opts) $
+      void $ forkIO (jsonTcpTransport (optOneShot opts) cin HostAny (show $ optTcpPort opts))
     -- Can have multiple listeners, each using a different transport protocol, so
     -- long as they can pass through a ChannelRequest
     if (optConsole opts)

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -26,6 +26,8 @@ library
                        Haskell.Ide.Engine.Transport.JsonHttp
                        Haskell.Ide.Engine.Transport.JsonHttp.Undecidable
                        Haskell.Ide.Engine.Transport.JsonStdio
+                       Haskell.Ide.Engine.Transport.JsonTcp
+                       Haskell.Ide.Engine.Transport.Pipes
                        Haskell.Ide.Engine.Types
                        Haskell.Ide.Engine.Utils
   other-modules:       Paths_haskell_ide_engine
@@ -48,12 +50,14 @@ library
                      , monad-control
                      , monad-logger
                      , mtl
+                     , network-simple
                      , optparse-applicative
                      , optparse-simple >= 0.0.3
                      , pipes
                      , pipes-aeson
                      , pipes-attoparsec >= 0.5
                      , pipes-bytestring
+                     , pipes-network
                      , pipes-parse
                      , servant-server
                      , singletons
@@ -90,6 +94,7 @@ executable hie
                      , hie-hare
                      , hie-plugin-api
                      , monad-logger
+                     , network-simple
                      , optparse-applicative
                      , optparse-simple
                      , stm

--- a/hie-docs-generator/src/Examples.hs
+++ b/hie-docs-generator/src/Examples.hs
@@ -4,7 +4,7 @@ module Examples where
 import qualified Data.Map as M
 import           Data.Monoid
 import           Haskell.Ide.Engine.PluginDescriptor
-import           Haskell.Ide.Engine.Transport.JsonStdio
+import           Haskell.Ide.Engine.Transport.Pipes
 
 jsonStdioExample :: PluginId -> UntaggedCommandDescriptor -> WireRequest
 jsonStdioExample pluginId (CommandDesc{cmdName = name,cmdContexts = contexts,cmdAdditionalParams = cmdParams}) =

--- a/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
@@ -17,7 +17,6 @@ module Haskell.Ide.Engine.MonadFunctions
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import qualified Data.Text as T
-import           Haskell.Ide.Engine.Monad()
 import           Prelude hiding (log)
 import Control.Exception.Lifted
 import Control.Monad

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -19,7 +19,6 @@ import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.Types
-import           Language.Haskell.GhcMod.Error
 
 -- ---------------------------------------------------------------------
 
@@ -136,29 +135,29 @@ validContext ctx params =
 
 -- |If all listed 'ParamDescripion' values are present return a Right, else
 -- return an error.
-checkParams :: forall a .(ValidResponse a) => [ParamDescription] -> ParamMap -> Either (IdeResponse a) [()]
+checkParams :: (ValidResponse a) => [ParamDescription] -> ParamMap -> Either (IdeResponse a) [()]
 checkParams pds params = mapEithers checkOne pds
   where
-    checkOne :: forall a .(ValidResponse a)
+    checkOne :: (ValidResponse a)
              => ParamDescription -> Either (IdeResponse a) ()
     checkOne (ParamDesc pn _ph pt Optional) = checkParamOP pn pt
     checkOne (ParamDesc pn _ph pt Required) = checkParamRP pn pt
 
-    checkParamOP :: forall a .(ValidResponse a)
+    checkParamOP :: (ValidResponse a)
                  => ParamId -> ParamType -> Either (IdeResponse a) ()
     checkParamOP pn pt =
       case Map.lookup pn params of
         Nothing -> Right ()
         Just p  -> checkParamMatch pn pt p
 
-    checkParamRP :: forall a .(ValidResponse a)
+    checkParamRP :: (ValidResponse a)
                  => ParamId -> ParamType -> Either (IdeResponse a) ()
     checkParamRP pn pt =
       case Map.lookup pn params of
         Nothing -> Left $ missingParameter pn
         Just p  -> checkParamMatch pn pt p
 
-    checkParamMatch :: forall a .(ValidResponse a)
+    checkParamMatch :: (ValidResponse a)
                     => T.Text -> ParamType -> ParamValP -> Either (IdeResponse a) ()
     checkParamMatch pn' pt' p' =
       if paramMatches pt' p'

--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -13,6 +13,8 @@ data GlobalOpts = GlobalOpts
   , optLogFile :: Maybe String
   , optPort :: Port
   , optHttp :: Bool
+  , optTcp :: Bool
+  , optTcpPort :: Port
   , projectRoot :: Maybe String
   } deriving (Show)
 
@@ -48,6 +50,14 @@ globalOptsParser = GlobalOpts
   <*> flag False True
        ( long "http"
        <> help "Enable the webinterface")
+  <*> flag False True
+       ( long "tcp"
+       <> help "Enable the tcp transport")
+  <*> option
+       auto
+       ( long "tcp-port"
+       <> help "Port to use for tcp interface"
+       <> value 8002)
   <*> (optional $ strOption
        ( long "project-root"
       <> short 'r'

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -5,27 +5,16 @@
 
 module Haskell.Ide.Engine.Transport.JsonStdio where
 
-import           Control.Applicative
 import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
-import           Control.Lens (view)
-import           Data.Aeson
 import           Control.Monad.IO.Class
 import           Control.Monad.STM
-import           Control.Monad.State.Strict
-import qualified Data.Attoparsec.ByteString as AB
-import qualified Data.Attoparsec.ByteString.Char8 as AB
-import qualified Data.ByteString.Char8 as B
+import           Data.Aeson
 import qualified Data.ByteString.Lazy as BL
 import           Data.Char
-import qualified Data.Map as Map
-import qualified Data.Text as T
-import           Haskell.Ide.Engine.MonadFunctions
-import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.Transport.Pipes
 import           Haskell.Ide.Engine.Types
 import qualified Pipes as P
-import qualified Pipes.Aeson as PAe
-import qualified Pipes.Attoparsec as PA
 import qualified Pipes.ByteString as PB
 import qualified Pipes.Prelude as P
 import           System.IO
@@ -38,30 +27,6 @@ jsonStdioTransport oneShot cin = do
   _ <- forkIO $ P.runEffect (parseFrames PB.stdin P.>-> parseToJsonPipe oneShot cin cout 1)
   P.runEffect (tchanProducer oneShot cout P.>-> encodePipe P.>-> jsonConsumer)
 
-parseToJsonPipe
-  :: Bool
-  -> TChan ChannelRequest
-  -> TChan ChannelResponse
-  -> Int
-  -> P.Consumer (Either PAe.DecodingError WireRequest) IO ()
-parseToJsonPipe oneShot cin cout cid =
-  do parseRes <- P.await
-     case parseRes of
-       Left decodeErr ->
-         do let rsp =
-                  CResp "" cid $
-                  IdeResponseError
-                    (IdeError ParseError (T.pack $ show decodeErr) Null)
-            liftIO $ debugm $ "jsonStdioTransport:parse error:" ++ show decodeErr
-            liftIO $ atomically $ writeTChan cout rsp
-       Right req ->
-         do liftIO $ atomically $ writeTChan cin (wireToChannel cout cid req)
-     unless oneShot $
-         parseToJsonPipe False
-                         cin
-                         cout
-                         (cid + 1)
-
 jsonConsumer :: P.Consumer Value IO ()
 jsonConsumer =
   do val <- P.await
@@ -69,109 +34,7 @@ jsonConsumer =
      liftIO $ BL.putStr (BL.singleton $ fromIntegral (ord '\STX'))
      jsonConsumer
 
-tchanProducer :: MonadIO m => Bool -> TChan a -> P.Producer a m ()
-tchanProducer oneShot chan = do
-  val <- liftIO $ atomically $ readTChan chan
-  P.yield val
-  unless oneShot $ tchanProducer False chan
-
-encodePipe :: P.Pipe ChannelResponse Value IO ()
-encodePipe = P.map (toJSON . channelToWire)
-
-parseFrames
-  :: forall m.
-     Monad m
-  => P.Producer B.ByteString m ()
-  -> P.Producer (Either PAe.DecodingError WireRequest) m ()
-parseFrames prod0 = do
-  -- if there are no more bytes, we just return ()
-  (isEmpty, prod1) <- lift $ runStateT PB.isEndOfBytes prod0
-  if isEmpty then return () else go prod1
-  where
-    -- ignore inputs consisting only of space
-    terminatedJSON :: AB.Parser (Maybe Value)
-    terminatedJSON = (fmap Just $ json' <* AB.many' AB.space <* AB.endOfInput)
-                 <|> (AB.many' AB.space *> pure Nothing)
-    -- endOfInput: we want to be sure that the given
-    -- parser consumes the entirety of the given input
-    go :: P.Producer B.ByteString m ()
-       -> P.Producer (Either PAe.DecodingError WireRequest) m ()
-    go prod = do
-       let splitProd :: P.Producer B.ByteString m (P.Producer B.ByteString m ())
-           splitProd = view (PB.break (== fromIntegral (ord '\STX'))) prod
-       (maybeRet, leftoverProd) <- lift $ runStateT (PA.parse terminatedJSON) splitProd
-       case maybeRet of
-         Nothing -> return ()
-         Just (ret) -> do
-           let maybeWrappedRet :: Maybe (Either PAe.DecodingError WireRequest)
-               maybeWrappedRet = case ret of
-                                             Left parseErr -> pure $ Left $ PAe.AttoparsecError parseErr
-                                             Right (Just a) -> case fromJSON a of
-                                                                 Error err -> pure $ Left $ PAe.FromJSONError err
-                                                                 Success wireReq -> pure $ Right wireReq
-                                             Right Nothing -> Nothing
-           case maybeWrappedRet of
-             Just wrappedRet -> P.yield wrappedRet
-             Nothing -> return ()
-           -- leftoverProd is guaranteed to be empty by the use of A8.endOfInput in ap1
-           newProd <- lift $ P.runEffect (leftoverProd P.>-> P.drain)
-           -- recur into parseFrames to parse the next line, drop the leading '\n'
-           parseFrames (PB.drop (1::Int) newProd)
-
 
 -- to help with type inference
 printTest :: (MonadIO m) => P.Consumer' [Int] m r
 printTest = P.print
-
--- ---------------------------------------------------------------------
-
-wireToChannel :: TChan ChannelResponse -> RequestId -> WireRequest -> ChannelRequest
-wireToChannel cout ri wr =
-  CReq
-    { cinPlugin = plugin
-    , cinReqId = ri
-    , cinReq = IdeRequest
-                 { ideCommand = T.tail command
-                 , ideParams  = params wr
-                 }
-    , cinReplyChan = cout
-    }
-    where
-      (plugin,command) = T.break (==':') (cmd wr)
-
--- ---------------------------------------------------------------------
-
-channelToWire :: ChannelResponse -> WireResponse
-channelToWire cr = WireResp $ toJSON $ coutResp cr
-
--- ---------------------------------------------------------------------
-
-data WireRequest = WireReq
-  { cmd     :: T.Text -- ^combination of PluginId ":" CommandName
-  , params  :: ParamMap
-  } deriving (Show,Eq)
-
-instance ToJSON WireRequest where
-    toJSON wr = object
-                [ "cmd" .= cmd wr
-                , "params" .= params wr
-                ]
-
-
-instance FromJSON WireRequest where
-    parseJSON = withObject "WireRequest" $ \v ->
-      WireReq <$>
-      v .: "cmd" <*>
-      v .:? "params" .!= Map.empty
-
--- ---------------------------------------------------------------------
-
-data WireResponse = WireResp Value
-                  deriving (Show,Eq)
-
-instance ToJSON WireResponse where
-    toJSON (WireResp val) = val
-
-
-instance FromJSON WireResponse where
-    parseJSON p = return $ WireResp p

--- a/src/Haskell/Ide/Engine/Transport/JsonTcp.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonTcp.hs
@@ -1,0 +1,25 @@
+module Haskell.Ide.Engine.Transport.JsonTcp where
+
+import           Control.Concurrent
+import           Control.Concurrent.STM.TChan
+import           Control.Monad.STM
+import           Haskell.Ide.Engine.Transport.Pipes
+import           Haskell.Ide.Engine.Types
+import qualified Pipes as P
+import           Pipes.Network.TCP.Safe
+
+jsonTcpTransport :: Bool -> TChan ChannelRequest -> HostPreference -> ServiceName -> IO ()
+jsonTcpTransport oneShot cin host service =
+  do cout <- atomically $ newTChan :: IO (TChan ChannelResponse)
+     runSafeT $
+       serve host service $
+       \(socket,_addr) ->
+         do let producer = fromSocket socket 4096
+                consumer = toSocket socket
+            _ <-
+              forkIO $
+              P.runEffect
+                (parseFrames producer P.>-> parseToJsonPipe oneShot cin cout 1)
+            P.runEffect
+              (tchanProducer oneShot cout P.>-> encodePipe P.>-> serializePipe P.>->
+               consumer)

--- a/src/Haskell/Ide/Engine/Transport/Pipes.hs
+++ b/src/Haskell/Ide/Engine/Transport/Pipes.hs
@@ -1,0 +1,149 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Haskell.Ide.Engine.Transport.Pipes
+  (parseToJsonPipe
+  ,WireRequest(..)
+  ,encodePipe
+  ,tchanProducer
+  ,parseFrames
+  ) where
+
+import           Control.Applicative
+import           Control.Concurrent.STM.TChan
+import           Control.Lens (view)
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Control.Monad.STM
+import           Control.Monad.State.Strict
+import           Data.Aeson
+import qualified Data.Attoparsec.ByteString as AB
+import           Data.Attoparsec.ByteString.Char8 (space)
+import           Data.Char
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import           Haskell.Ide.Engine.MonadFunctions
+import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.Types
+import qualified Pipes as P
+import qualified Pipes.Aeson as PAe
+import qualified Pipes.Attoparsec as PA
+import qualified Pipes.ByteString as PB
+import qualified Pipes.Prelude as P
+
+parseToJsonPipe
+  :: Bool
+  -> TChan ChannelRequest
+  -> TChan ChannelResponse
+  -> Int
+  -> P.Consumer (Either PAe.DecodingError WireRequest) IO ()
+parseToJsonPipe oneShot cin cout cid =
+  do parseRes <- P.await
+     case parseRes of
+       Left decodeErr ->
+         do let rsp =
+                  CResp "" cid $
+                  IdeResponseError
+                    (IdeError ParseError (T.pack $ show decodeErr) Null)
+            liftIO $ debugm $ "jsonStdioTransport:parse error:" ++ show decodeErr
+            liftIO $ atomically $ writeTChan cout rsp
+       Right req ->
+         do liftIO $ atomically $ writeTChan cin (wireToChannel cout cid req)
+     unless oneShot $
+         parseToJsonPipe False
+                         cin
+                         cout
+                         (cid + 1)
+
+wireToChannel :: TChan ChannelResponse -> RequestId -> WireRequest -> ChannelRequest
+wireToChannel cout ri wr =
+  CReq
+    { cinPlugin = plugin
+    , cinReqId = ri
+    , cinReq = IdeRequest
+                 { ideCommand = T.tail command
+                 , ideParams  = params wr
+                 }
+    , cinReplyChan = cout
+    }
+    where
+      (plugin,command) = T.break (==':') (cmd wr)
+
+data WireRequest = WireReq
+  { cmd     :: T.Text -- ^combination of PluginId ":" CommandName
+  , params  :: ParamMap
+  } deriving (Show,Eq)
+
+instance ToJSON WireRequest where
+    toJSON wr = object
+                [ "cmd" .= cmd wr
+                , "params" .= params wr
+                ]
+
+
+instance FromJSON WireRequest where
+    parseJSON = withObject "WireRequest" $ \v ->
+      WireReq <$>
+      v .: "cmd" <*>
+      v .:? "params" .!= Map.empty
+
+tchanProducer :: MonadIO m => Bool -> TChan a -> P.Producer a m ()
+tchanProducer oneShot chan = do
+  val <- liftIO $ atomically $ readTChan chan
+  P.yield val
+  unless oneShot $ tchanProducer False chan
+
+encodePipe :: P.Pipe ChannelResponse Value IO ()
+encodePipe = P.map (toJSON . channelToWire)
+
+channelToWire :: ChannelResponse -> WireResponse
+channelToWire cr = WireResp $ toJSON $ coutResp cr
+
+data WireResponse = WireResp Value
+                  deriving (Show,Eq)
+
+instance ToJSON WireResponse where
+    toJSON (WireResp val) = val
+
+
+instance FromJSON WireResponse where
+    parseJSON p = return $ WireResp p
+
+parseFrames
+  :: forall m.
+     Monad m
+  => P.Producer PB.ByteString m ()
+  -> P.Producer (Either PAe.DecodingError WireRequest) m ()
+parseFrames prod0 = do
+  -- if there are no more bytes, we just return ()
+  (isEmpty, prod1) <- lift $ runStateT PB.isEndOfBytes prod0
+  if isEmpty then return () else go prod1
+  where
+    -- ignore inputs consisting only of space
+    terminatedJSON :: AB.Parser (Maybe Value)
+    terminatedJSON = (fmap Just $ json' <* AB.many' space <* AB.endOfInput)
+                 <|> (AB.many' space *> pure Nothing)
+    -- endOfInput: we want to be sure that the given
+    -- parser consumes the entirety of the given input
+    go :: P.Producer PB.ByteString m ()
+       -> P.Producer (Either PAe.DecodingError WireRequest) m ()
+    go prod = do
+       let splitProd :: P.Producer PB.ByteString m (P.Producer PB.ByteString m ())
+           splitProd = view (PB.break (== fromIntegral (ord '\STX'))) prod
+       (maybeRet, leftoverProd) <- lift $ runStateT (PA.parse terminatedJSON) splitProd
+       case maybeRet of
+         Nothing -> return ()
+         Just (ret) -> do
+           let maybeWrappedRet :: Maybe (Either PAe.DecodingError WireRequest)
+               maybeWrappedRet = case ret of
+                                             Left parseErr -> pure $ Left $ PAe.AttoparsecError parseErr
+                                             Right (Just a) -> case fromJSON a of
+                                                                 Error err -> pure $ Left $ PAe.FromJSONError err
+                                                                 Success wireReq -> pure $ Right wireReq
+                                             Right Nothing -> Nothing
+           case maybeWrappedRet of
+             Just wrappedRet -> P.yield wrappedRet
+             Nothing -> return ()
+           -- leftoverProd is guaranteed to be empty by the use of A8.endOfInput in ap1
+           newProd <- lift $ P.runEffect (leftoverProd P.>-> P.drain)
+           -- recur into parseFrames to parse the next line, drop the leading '\n'
+           parseFrames (PB.drop (1::Int) newProd)

--- a/test/JsonStdioSpec.hs
+++ b/test/JsonStdioSpec.hs
@@ -4,6 +4,7 @@ module JsonStdioSpec where
 import           Data.Aeson
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.Transport.JsonStdio
+import           Haskell.Ide.Engine.Transport.Pipes
 
 import qualified Data.Map as Map
 


### PR DESCRIPTION
Most of the stuff we use for stdio transport can be completely reused for the tcp transport, so I moved that to a separate module.

Regarding tests, I am aware that I didn’t add tests. I took a look at the stdio tests and they don’t actually test the transport but only test the encoding and decoding (which is shared between stdio and tcp). Ofc we could build hie, launch it as a separate process and then actually test the tcp transport and the stdio transport, but I wasn’t sure if it’s worth the trouble.