### PR TITLE
Save modified buffer when calling hie commands

### DIFF
--- a/elisp/hie.el
+++ b/elisp/hie.el
@@ -412,9 +412,9 @@ association lists and count on HIE to use default values there."
           args))
         (context (hie-get-context))
         (topdir (hie-session-cabal-dir (hie-session)))
-        (safety (hie-plugin-command-safety (intern plugin) command hie-plugins)))
+        (save (hie-plugin-command-save (intern plugin) command hie-plugins)))
 
-    (maybe-save-buffers topdir safety)
+    (maybe-save-buffers topdir save)
 
     ;; First check to see if there are any modified buffers for this project
     (hie-post-message
@@ -487,22 +487,18 @@ association lists and count on HIE to use default values there."
                  commands))
               command-names))))
 
-(defun* hie-plugin-command-safety (plugin name list)
+(defun* hie-plugin-command-save (plugin name list)
   (dolist (l (cdr (assoc plugin list)))
     (let ((name-cons (assoc 'name l))
-          (safety-cons (assoc 'safety l)))
+          (save-cons (assoc 'save l)))
       (when (and name-cons
                  (string-equal (cdr name-cons) name)
-                 safety-cons)
-        (return-from hie-plugin-command-safety (cdr safety-cons))))))
+                 save-cons)
+        (return-from hie-plugin-command-save (cdr save-cons))))))
 
-(defun maybe-save-buffers (topdir safety)
+(defun maybe-save-buffers (topdir save)
   (cond
-   ((and (string= "change_current" safety)
-         (buffer-modified-p))
-    (when (y-or-n-p "Buffer has been modified, would you like to save?")
-      (save-buffer)))
-   ((string= "change_all" safety)
+   ((string= "save_all" save)
     (when (-any (lambda (buffer)
                   (and (buffer-file-name buffer)
                        (buffer-modified-p buffer)

--- a/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
+++ b/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
@@ -32,10 +32,10 @@ applyRefactDescriptor = PluginDescriptor
     , pdCommands =
 
         buildCommand applyOneCmd (Proxy :: Proxy "applyOne") "Apply a single hint"
-                   [".hs"] (SCtxPoint :& RNil) RNil ChangeCurrent
+                   [".hs"] (SCtxPoint :& RNil) RNil SaveAll
 
       :& buildCommand applyAllCmd (Proxy :: Proxy "applyAll") "Apply all hints to the file"
-                   [".hs"] (SCtxFile :& RNil) RNil ChangeCurrent
+                   [".hs"] (SCtxFile :& RNil) RNil SaveAll
 
       :& RNil
   , pdExposedServices = []

--- a/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
+++ b/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
@@ -32,10 +32,10 @@ applyRefactDescriptor = PluginDescriptor
     , pdCommands =
 
         buildCommand applyOneCmd (Proxy :: Proxy "applyOne") "Apply a single hint"
-                   [".hs"] (SCtxPoint :& RNil) RNil
+                   [".hs"] (SCtxPoint :& RNil) RNil ChangeCurrent
 
       :& buildCommand applyAllCmd (Proxy :: Proxy "applyAll") "Apply all hints to the file"
-                   [".hs"] (SCtxFile :& RNil) RNil
+                   [".hs"] (SCtxFile :& RNil) RNil ChangeCurrent
 
       :& RNil
   , pdExposedServices = []

--- a/hie-base/Haskell/Ide/Engine/PluginTypes.hs
+++ b/hie-base/Haskell/Ide/Engine/PluginTypes.hs
@@ -552,3 +552,4 @@ instance FromJSON Safety where
   parseJSON "safe" = return Safe
   parseJSON "change_current" = return ChangeCurrent
   parseJSON "change_all" = return ChangeAll
+  parseJSON x            = typeMismatch "Safety" x

--- a/hie-base/Haskell/Ide/Engine/PluginTypes.hs
+++ b/hie-base/Haskell/Ide/Engine/PluginTypes.hs
@@ -37,7 +37,7 @@ module Haskell.Ide.Engine.PluginTypes
   , PluginName
   , ValidResponse(..)
   , ReturnType
-  , Safety(..)
+  , Save(..)
 
   -- * Interface types
   , IdeRequest(..)
@@ -138,11 +138,11 @@ data CommandDescriptor cxts descs = CommandDesc
   , cmdContexts         :: !cxts -- TODO: should this be a non empty list? or should empty list imply CtxNone.
   , cmdAdditionalParams :: !descs
   , cmdReturnType       :: !ReturnType
-  , cmdSafety           :: !Safety
+  , cmdSave             :: !Save
   } deriving (Show,Eq,Generic)
 
-data Safety = Safe | ChangeCurrent | ChangeAll deriving (Show, Eq, Generic)
-instance ToSchema Safety
+data Save = SaveNone | SaveAll deriving (Show, Eq, Generic)
+instance ToSchema Save
 
 -- | Type synonym for a 'CommandDescriptor' that uses simple lists
 type UntaggedCommandDescriptor = CommandDescriptor [AcceptedContext] [ParamDescription]
@@ -166,7 +166,7 @@ instance ValidResponse ExtendedCommandDescriptor where
       , "additional_params" .= cmdAdditionalParams cmdDescriptor
       , "return_type"       .= cmdReturnType cmdDescriptor
       , "plugin_name"       .= pname
-      , "safety"            .= cmdSafety cmdDescriptor ]
+      , "save"              .= cmdSave cmdDescriptor ]
   jsRead v =
     ExtendedCommandDescriptor
     <$> (CommandDesc
@@ -176,7 +176,7 @@ instance ValidResponse ExtendedCommandDescriptor where
       <*> v .: "contexts"
       <*> v .: "additional_params"
       <*> v .: "return_type"
-      <*> v .: "safety")
+      <*> v .: "save")
     <*> v.: "plugin_name"
 
 type CommandName = T.Text
@@ -381,7 +381,7 @@ instance ValidResponse UntaggedCommandDescriptor where
       , "contexts" .= cmdContexts cmdDescriptor
       , "additional_params" .= cmdAdditionalParams cmdDescriptor
       , "return_type" .= cmdReturnType cmdDescriptor
-      , "safety" .= cmdSafety cmdDescriptor ]
+      , "save" .= cmdSave cmdDescriptor ]
   jsRead v =
     CommandDesc
       <$> v .: "name"
@@ -390,7 +390,7 @@ instance ValidResponse UntaggedCommandDescriptor where
       <*> v .: "contexts"
       <*> v .: "additional_params"
       <*> v .: "return_type"
-      <*> v .: "safety"
+      <*> v .: "save"
 
 instance ValidResponse IdePlugins where
   jsWrite (IdePlugins m) = H.fromList ["plugins" .= H.fromList
@@ -543,13 +543,11 @@ instance FromJSON UntaggedCommandDescriptor where
 
 -- -------------------------------------
 
-instance ToJSON Safety where
-  toJSON Safe          = "safe"
-  toJSON ChangeCurrent = "change_current"
-  toJSON ChangeAll     = "change_all"
+instance ToJSON Save where
+  toJSON SaveNone    = "save_none"
+  toJSON SaveAll = "save_all"
 
-instance FromJSON Safety where
-  parseJSON "safe" = return Safe
-  parseJSON "change_current" = return ChangeCurrent
-  parseJSON "change_all" = return ChangeAll
-  parseJSON x            = typeMismatch "Safety" x
+instance FromJSON Save where
+  parseJSON "save_none" = return SaveNone
+  parseJSON "save_all"  = return SaveAll
+  parseJSON x           = typeMismatch "Save" x

--- a/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
+++ b/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
@@ -25,10 +25,10 @@ exampleAsyncDescriptor = PluginDescriptor
   , pdUIOverview = "An example HIE plugin using multiple/async processes"
   , pdCommands =
          buildCommand (longRunningCmdSync Cmd1) (Proxy :: Proxy "cmd1")
-                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil Safe
+                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil SaveNone
       :& buildCommand (longRunningCmdSync Cmd2) (Proxy :: Proxy "cmd2")
-                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil Safe
-      :& buildCommand (streamingCmdAsync (CmdA 3 100)) (Proxy :: Proxy "cmdA3") "Long running async/streaming command" [] (SCtxNone :& RNil) RNil Safe
+                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil SaveNone
+      :& buildCommand (streamingCmdAsync (CmdA 3 100)) (Proxy :: Proxy "cmdA3") "Long running async/streaming command" [] (SCtxNone :& RNil) RNil SaveNone
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
+++ b/hie-eg-plugin-async/Haskell/Ide/ExamplePluginAsync.hs
@@ -25,10 +25,10 @@ exampleAsyncDescriptor = PluginDescriptor
   , pdUIOverview = "An example HIE plugin using multiple/async processes"
   , pdCommands =
          buildCommand (longRunningCmdSync Cmd1) (Proxy :: Proxy "cmd1")
-                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil
+                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil Safe
       :& buildCommand (longRunningCmdSync Cmd2) (Proxy :: Proxy "cmd2")
-                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil
-      :& buildCommand (streamingCmdAsync (CmdA 3 100)) (Proxy :: Proxy "cmdA3") "Long running async/streaming command" [] (SCtxNone :& RNil) RNil
+                      "Long running synchronous command" [] (SCtxNone :& RNil) RNil Safe
+      :& buildCommand (streamingCmdAsync (CmdA 3 100)) (Proxy :: Proxy "cmdA3") "Long running async/streaming command" [] (SCtxNone :& RNil) RNil Safe
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -20,13 +20,13 @@ example2Descriptor = PluginDescriptor
     pdUIShortName = "Hello World"
   , pdUIOverview = "An example of writing an HIE plugin"
   , pdCommands =
-         buildCommand sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] (SCtxNone :& RNil) RNil Safe
+         buildCommand sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] (SCtxNone :& RNil) RNil SaveNone
       :& buildCommand sayHelloToCmd (Proxy :: Proxy "sayHelloTo")
                           "say hello to the passed in param"
                           []
                           (SCtxNone :& RNil)
                           (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the name to greet") SPtText SRequired
-                          :& RNil) Safe
+                            :& RNil) SaveNone
 
       :& RNil
   , pdExposedServices = []

--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -20,13 +20,13 @@ example2Descriptor = PluginDescriptor
     pdUIShortName = "Hello World"
   , pdUIOverview = "An example of writing an HIE plugin"
   , pdCommands =
-         buildCommand sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] (SCtxNone :& RNil) RNil
+         buildCommand sayHelloCmd (Proxy :: Proxy "sayHello") "say hello" [] (SCtxNone :& RNil) RNil Safe
       :& buildCommand sayHelloToCmd (Proxy :: Proxy "sayHelloTo")
                           "say hello to the passed in param"
                           []
                           (SCtxNone :& RNil)
                           (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the name to greet") SPtText SRequired
-                          :& RNil)
+                          :& RNil) Safe
 
       :& RNil
   , pdExposedServices = []

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -31,10 +31,10 @@ ghcmodDescriptor = PluginDescriptor
 \from modern IDEs in any editor."
   , pdCommands =
          buildCommand checkCmd (Proxy :: Proxy "check") "check a file for GHC warnings and errors"
-                       [".hs",".lhs"] (SCtxFile :& RNil) RNil
+                       [".hs",".lhs"] (SCtxFile :& RNil) RNil ChangeCurrent
 
       :& buildCommand lintCmd (Proxy :: Proxy "lint")  "Check files using `hlint'"
-                     [".hs",".lhs"] (SCtxFile :& RNil) RNil
+                     [".hs",".lhs"] (SCtxFile :& RNil) RNil ChangeAll
 
       -- :& buildCommand findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
       --                [".hs",".lhs"] (SCtxProject :& RNil)
@@ -44,10 +44,10 @@ ghcmodDescriptor = PluginDescriptor
       :& buildCommand infoCmd (Proxy :: Proxy "info") "Look up an identifier in the context of FILE (like ghci's `:info')"
                      [".hs",".lhs"] (SCtxFile :& RNil)
                      (  SParamDesc (Proxy :: Proxy "expr") (Proxy :: Proxy "The EXPR to provide info on") SPtText SRequired
-                     :& RNil)
+                     :& RNil) Safe
 
       :& buildCommand typeCmd (Proxy :: Proxy "type") "Get the type of the expression under (LINE,COL)"
-                     [".hs",".lhs"] (SCtxPoint :& RNil) RNil
+                     [".hs",".lhs"] (SCtxPoint :& RNil) RNil ChangeCurrent
 
       :& RNil
   , pdExposedServices = []

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -31,10 +31,10 @@ ghcmodDescriptor = PluginDescriptor
 \from modern IDEs in any editor."
   , pdCommands =
          buildCommand checkCmd (Proxy :: Proxy "check") "check a file for GHC warnings and errors"
-                       [".hs",".lhs"] (SCtxFile :& RNil) RNil ChangeCurrent
+                       [".hs",".lhs"] (SCtxFile :& RNil) RNil SaveAll
 
       :& buildCommand lintCmd (Proxy :: Proxy "lint")  "Check files using `hlint'"
-                     [".hs",".lhs"] (SCtxFile :& RNil) RNil ChangeAll
+                     [".hs",".lhs"] (SCtxFile :& RNil) RNil SaveAll
 
       -- :& buildCommand findCmd (Proxy :: Proxy "find")  "List all modules that define SYMBOL"
       --                [".hs",".lhs"] (SCtxProject :& RNil)
@@ -44,10 +44,10 @@ ghcmodDescriptor = PluginDescriptor
       :& buildCommand infoCmd (Proxy :: Proxy "info") "Look up an identifier in the context of FILE (like ghci's `:info')"
                      [".hs",".lhs"] (SCtxFile :& RNil)
                      (  SParamDesc (Proxy :: Proxy "expr") (Proxy :: Proxy "The EXPR to provide info on") SPtText SRequired
-                     :& RNil) Safe
+                     :& RNil) SaveNone
 
       :& buildCommand typeCmd (Proxy :: Proxy "type") "Get the type of the expression under (LINE,COL)"
-                     [".hs",".lhs"] (SCtxPoint :& RNil) RNil ChangeCurrent
+                     [".hs",".lhs"] (SCtxPoint :& RNil) RNil SaveAll
 
       :& RNil
   , pdExposedServices = []

--- a/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
+++ b/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
@@ -24,7 +24,7 @@ ghcTreeDescriptor = PluginDescriptor
   , pdCommands =
 
         buildCommand trees (Proxy :: Proxy "trees") "Get ASTs for the given file"
-                   [".hs",".lhs"] (SCtxFile :& RNil) RNil
+                   [".hs",".lhs"] (SCtxFile :& RNil) RNil ChangeCurrent
 
       :& RNil
   , pdExposedServices = []

--- a/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
+++ b/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
@@ -24,7 +24,7 @@ ghcTreeDescriptor = PluginDescriptor
   , pdCommands =
 
         buildCommand trees (Proxy :: Proxy "trees") "Get ASTs for the given file"
-                   [".hs",".lhs"] (SCtxFile :& RNil) RNil ChangeCurrent
+                   [".hs",".lhs"] (SCtxFile :& RNil) RNil SaveAll
 
       :& RNil
   , pdExposedServices = []

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -37,26 +37,26 @@ hareDescriptor = PluginDescriptor
 \only swapping these with the originals when the change is accepted. "
     , pdCommands =
         buildCommand demoteCmd (Proxy :: Proxy "demote") "Move a definition one level down"
-                    [".hs"] (SCtxPoint :& RNil) RNil ChangeAll
+                    [".hs"] (SCtxPoint :& RNil) RNil SaveAll
 
       :& buildCommand dupdefCmd (Proxy :: Proxy "dupdef") "Duplicate a definition"
                      [".hs"] (SCtxPoint :& RNil)
                      (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText SRequired
-                     :& RNil) ChangeAll
+                     :& RNil) SaveAll
 
       :& buildCommand iftocaseCmd (Proxy :: Proxy "iftocase") "Converts an if statement to a case statement"
-                     [".hs"] (SCtxRegion :& RNil) RNil ChangeCurrent
+                     [".hs"] (SCtxRegion :& RNil) RNil SaveAll
 
       :& buildCommand liftonelevelCmd (Proxy :: Proxy "liftonelevel") "Move a definition one level up from where it is now"
-                     [".hs"] (SCtxPoint :& RNil) RNil ChangeAll
+                     [".hs"] (SCtxPoint :& RNil) RNil SaveAll
 
       :& buildCommand lifttotoplevelCmd (Proxy :: Proxy "lifttotoplevel") "Move a definition to the top level from where it is now"
-                     [".hs"] (SCtxPoint :& RNil) RNil ChangeAll
+                     [".hs"] (SCtxPoint :& RNil) RNil SaveAll
 
       :& buildCommand renameCmd (Proxy :: Proxy "rename") "rename a variable or type"
                      [".hs"] (SCtxPoint :& RNil)
                      (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText SRequired
-                     :& RNil) ChangeAll
+                     :& RNil) SaveAll
 
       :& RNil
   , pdExposedServices = []

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -37,26 +37,26 @@ hareDescriptor = PluginDescriptor
 \only swapping these with the originals when the change is accepted. "
     , pdCommands =
         buildCommand demoteCmd (Proxy :: Proxy "demote") "Move a definition one level down"
-                    [".hs"] (SCtxPoint :& RNil) RNil
+                    [".hs"] (SCtxPoint :& RNil) RNil ChangeCurrent
 
       :& buildCommand dupdefCmd (Proxy :: Proxy "dupdef") "Duplicate a definition"
                      [".hs"] (SCtxPoint :& RNil)
                      (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText SRequired
-                     :& RNil)
+                     :& RNil) ChangeCurrent
 
       :& buildCommand iftocaseCmd (Proxy :: Proxy "iftocase") "Converts an if statement to a case statement"
-                     [".hs"] (SCtxRegion :& RNil) RNil
+                     [".hs"] (SCtxRegion :& RNil) RNil ChangeCurrent
 
       :& buildCommand liftonelevelCmd (Proxy :: Proxy "liftonelevel") "Move a definition one level up from where it is now"
-                     [".hs"] (SCtxPoint :& RNil) RNil
+                     [".hs"] (SCtxPoint :& RNil) RNil ChangeCurrent
 
       :& buildCommand lifttotoplevelCmd (Proxy :: Proxy "lifttotoplevel") "Move a definition to the top level from where it is now"
-                     [".hs"] (SCtxPoint :& RNil) RNil
+                     [".hs"] (SCtxPoint :& RNil) RNil ChangeCurrent
 
       :& buildCommand renameCmd (Proxy :: Proxy "rename") "rename a variable or type"
                      [".hs"] (SCtxPoint :& RNil)
                      (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText SRequired
-                     :& RNil)
+                     :& RNil) ChangeAll
 
       :& RNil
   , pdExposedServices = []

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -37,21 +37,21 @@ hareDescriptor = PluginDescriptor
 \only swapping these with the originals when the change is accepted. "
     , pdCommands =
         buildCommand demoteCmd (Proxy :: Proxy "demote") "Move a definition one level down"
-                    [".hs"] (SCtxPoint :& RNil) RNil ChangeCurrent
+                    [".hs"] (SCtxPoint :& RNil) RNil ChangeAll
 
       :& buildCommand dupdefCmd (Proxy :: Proxy "dupdef") "Duplicate a definition"
                      [".hs"] (SCtxPoint :& RNil)
                      (  SParamDesc (Proxy :: Proxy "name") (Proxy :: Proxy "the new name") SPtText SRequired
-                     :& RNil) ChangeCurrent
+                     :& RNil) ChangeAll
 
       :& buildCommand iftocaseCmd (Proxy :: Proxy "iftocase") "Converts an if statement to a case statement"
                      [".hs"] (SCtxRegion :& RNil) RNil ChangeCurrent
 
       :& buildCommand liftonelevelCmd (Proxy :: Proxy "liftonelevel") "Move a definition one level up from where it is now"
-                     [".hs"] (SCtxPoint :& RNil) RNil ChangeCurrent
+                     [".hs"] (SCtxPoint :& RNil) RNil ChangeAll
 
       :& buildCommand lifttotoplevelCmd (Proxy :: Proxy "lifttotoplevel") "Move a definition to the top level from where it is now"
-                     [".hs"] (SCtxPoint :& RNil) RNil ChangeCurrent
+                     [".hs"] (SCtxPoint :& RNil) RNil ChangeAll
 
       :& buildCommand renameCmd (Proxy :: Proxy "rename") "rename a variable or type"
                      [".hs"] (SCtxPoint :& RNil)

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -157,9 +157,9 @@ buildCommand :: forall a s cxts tags. (ValidResponse a, KnownSymbol s)
   -> [T.Text]
   -> Rec SAcceptedContext cxts
   -> Rec SParamDescription tags
-  -> Safety
+  -> Save
   -> NamedCommand ( 'CommandType s cxts tags )
-buildCommand fun n d exts ctxs parm safety =
+buildCommand fun n d exts ctxs parm save =
   NamedCommand n $
   Command {cmdDesc =
             CommandDesc {cmdName = T.pack $ symbolVal n
@@ -169,7 +169,7 @@ buildCommand fun n d exts ctxs parm safety =
                         ,cmdAdditionalParams = parm
                         ,cmdReturnType =
                            T.pack $ show $ typeOf (undefined :: a)
-                        ,cmdSafety = safety}
+                        ,cmdSave = save}
           ,cmdFunc = fun}
 
 -- ---------------------------------------------------------------------

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -157,8 +157,9 @@ buildCommand :: forall a s cxts tags. (ValidResponse a, KnownSymbol s)
   -> [T.Text]
   -> Rec SAcceptedContext cxts
   -> Rec SParamDescription tags
+  -> Safety
   -> NamedCommand ( 'CommandType s cxts tags )
-buildCommand fun n d exts ctxs parm =
+buildCommand fun n d exts ctxs parm safety =
   NamedCommand n $
   Command {cmdDesc =
             CommandDesc {cmdName = T.pack $ symbolVal n
@@ -167,7 +168,8 @@ buildCommand fun n d exts ctxs parm =
                         ,cmdContexts = ctxs
                         ,cmdAdditionalParams = parm
                         ,cmdReturnType =
-                           T.pack $ show $ typeOf (undefined :: a)}
+                           T.pack $ show $ typeOf (undefined :: a)
+                        ,cmdSafety = safety}
           ,cmdFunc = fun}
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -32,18 +32,18 @@ baseDescriptor = PluginDescriptor
   , pdUIOverview = "Commands for HIE itself, "
   , pdCommands =
         buildCommand versionCmd (Proxy :: Proxy "version") "return HIE version"
-                        [] (SCtxNone :& RNil) RNil Safe
+                        [] (SCtxNone :& RNil) RNil SaveNone
       :& buildCommand pluginsCmd (Proxy :: Proxy "plugins") "list available plugins"
-                          [] (SCtxNone :& RNil) RNil Safe
+                          [] (SCtxNone :& RNil) RNil SaveNone
       :& buildCommand commandsCmd (Proxy :: Proxy "commands") "list available commands for a given plugin"
                          [] (SCtxNone :& RNil)
                             (  SParamDesc (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText SRequired
-                            :& RNil) Safe
+                            :& RNil) SaveNone
       :& buildCommand commandDetailCmd (Proxy :: Proxy "commandDetail") "list parameters required for a given command"
                          [] (SCtxNone :& RNil)
                          (  SParamDesc (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText SRequired
                          :& SParamDesc (Proxy :: Proxy "command") (Proxy :: Proxy "the command name") SPtText SRequired
-                         :& RNil) Safe
+                         :& RNil) SaveNone
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -32,18 +32,18 @@ baseDescriptor = PluginDescriptor
   , pdUIOverview = "Commands for HIE itself, "
   , pdCommands =
         buildCommand versionCmd (Proxy :: Proxy "version") "return HIE version"
-                        [] (SCtxNone :& RNil) RNil
+                        [] (SCtxNone :& RNil) RNil Safe
       :& buildCommand pluginsCmd (Proxy :: Proxy "plugins") "list available plugins"
-                          [] (SCtxNone :& RNil) RNil
+                          [] (SCtxNone :& RNil) RNil Safe
       :& buildCommand commandsCmd (Proxy :: Proxy "commands") "list available commands for a given plugin"
                          [] (SCtxNone :& RNil)
                             (  SParamDesc (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText SRequired
-                            :& RNil)
+                            :& RNil) Safe
       :& buildCommand commandDetailCmd (Proxy :: Proxy "commandDetail") "list parameters required for a given command"
                          [] (SCtxNone :& RNil)
                          (  SParamDesc (Proxy :: Proxy "plugin") (Proxy :: Proxy "the plugin name") SPtText SRequired
                          :& SParamDesc (Proxy :: Proxy "command") (Proxy :: Proxy "the command name") SPtText SRequired
-                         :& RNil)
+                         :& RNil) Safe
       :& RNil
   , pdExposedServices = []
   , pdUsedServices    = []

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -291,7 +291,7 @@ mkCmdWithContext n cts pds =
                         , cmdContexts = cts
                         , cmdAdditionalParams = pds
                         , cmdReturnType = "Text"
-                        , cmdSafety = Safe
+                        , cmdSave = SaveNone
                         }
           , cmdFunc = CmdSync $ \ctxs _ -> return (IdeResponseOk (T.pack $ "result:ctxs=" ++ show ctxs))
           }
@@ -305,7 +305,7 @@ mkAsyncCmdWithContext cf n cts pds =
                          , cmdContexts = cts
                          , cmdAdditionalParams = pds
                          , cmdReturnType = "Text"
-                         , cmdSafety = Safe
+                         , cmdSave = SaveNone
                          }
           ,cmdFunc = cf}
 

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -291,6 +291,7 @@ mkCmdWithContext n cts pds =
                         , cmdContexts = cts
                         , cmdAdditionalParams = pds
                         , cmdReturnType = "Text"
+                        , cmdSafety = Safe
                         }
           , cmdFunc = CmdSync $ \ctxs _ -> return (IdeResponseOk (T.pack $ "result:ctxs=" ++ show ctxs))
           }
@@ -298,12 +299,14 @@ mkCmdWithContext n cts pds =
 mkAsyncCmdWithContext :: (ValidResponse a) => CommandFunc a -> CommandName -> [AcceptedContext] -> [ParamDescription] -> UntaggedCommand
 mkAsyncCmdWithContext cf n cts pds =
   Command {cmdDesc =
-             CommandDesc {cmdName = n
-                         ,cmdUiDescription = "description"
-                         ,cmdFileExtensions = []
-                         ,cmdContexts = cts
-                         ,cmdAdditionalParams = pds
-                         ,cmdReturnType = "Text"}
+             CommandDesc { cmdName = n
+                         , cmdUiDescription = "description"
+                         , cmdFileExtensions = []
+                         , cmdContexts = cts
+                         , cmdAdditionalParams = pds
+                         , cmdReturnType = "Text"
+                         , cmdSafety = Safe
+                         }
           ,cmdFunc = cf}
 
 -- ---------------------------------------------------------------------

--- a/test/ExtensibleStateSpec.hs
+++ b/test/ExtensibleStateSpec.hs
@@ -93,7 +93,7 @@ mkCmdWithContext cmd n cts pds =
                         , cmdContexts = cts
                         , cmdAdditionalParams = pds
                         , cmdReturnType = "Text"
-                        , cmdSafety = Safe
+                        , cmdSave = SaveNone
                         }
           , cmdFunc = cmd
           }

--- a/test/ExtensibleStateSpec.hs
+++ b/test/ExtensibleStateSpec.hs
@@ -93,6 +93,7 @@ mkCmdWithContext cmd n cts pds =
                         , cmdContexts = cts
                         , cmdAdditionalParams = pds
                         , cmdReturnType = "Text"
+                        , cmdSafety = Safe
                         }
           , cmdFunc = cmd
           }

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -85,6 +85,7 @@ instance Arbitrary UntaggedCommandDescriptor where
     <*> smallList arbitraryBoundedEnum
     <*> smallList arbitrary
     <*> arbitrary
+    <*> arbitrary
 
 instance Arbitrary ExtendedCommandDescriptor where
   arbitrary = ExtendedCommandDescriptor
@@ -184,3 +185,6 @@ instance Arbitrary Col where
 
 instance Arbitrary (ParamVal 'PtPos) where
   arbitrary = ParamPos <$> arbitrary
+
+instance Arbitrary Safety where
+  arbitrary = oneof [return Safe, return ChangeCurrent, return ChangeAll]

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -186,5 +186,5 @@ instance Arbitrary Col where
 instance Arbitrary (ParamVal 'PtPos) where
   arbitrary = ParamPos <$> arbitrary
 
-instance Arbitrary Safety where
-  arbitrary = oneof [return Safe, return ChangeCurrent, return ChangeAll]
+instance Arbitrary Save where
+  arbitrary = oneof [return SaveNone, return SaveAll]

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -148,7 +148,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                                 , pRequired = Required
                                 }
                             ]
-                          , cmdSafety = Safe
+                          , cmdSave = SaveNone
                           }
             , cmdFunc = CmdSync $ \_ _ ->
                 return (IdeResponseOk ("" :: T.Text) :: IdeResponse T.Text)
@@ -175,7 +175,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                                 , pRequired = Optional
                                 }
                             ]
-                          , cmdSafety = Safe
+                          , cmdSave = SaveNone
                           }
             , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
             }
@@ -219,7 +219,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                               , pRequired = Required
                               }
                             ]
-                          , cmdSafety = Safe
+                          , cmdSave = SaveNone
                           }
             , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
             }
@@ -255,7 +255,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                                     , pRequired = Required
                                     }
                                 ]
-                              , cmdSafety = Safe
+                              , cmdSave = SaveNone
                               }
                 , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
                 }
@@ -275,7 +275,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                                     , pRequired = Required
                                     }
                                 ]
-                              , cmdSafety = Safe
+                              , cmdSave = SaveNone
                               }
                , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
                }
@@ -297,7 +297,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                               , cmdReturnType = ""
                               , cmdContexts = [CtxRegion, CtxPoint] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
                               , cmdAdditionalParams = []
-                              , cmdSafety = Safe
+                              , cmdSave = SaveNone
                               }
                 , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
                 }
@@ -338,7 +338,7 @@ pluginsWithoutCollisions = Map.fromList [("plugin1", PluginDescriptor
                                  , pRequired = Required
                                  }
                              ]
-                           , cmdSafety = Safe
+                           , cmdSave = SaveNone
                            } :: UntaggedCommandDescriptor
              , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
              }

--- a/test/UtilsSpec.hs
+++ b/test/UtilsSpec.hs
@@ -148,6 +148,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                                 , pRequired = Required
                                 }
                             ]
+                          , cmdSafety = Safe
                           }
             , cmdFunc = CmdSync $ \_ _ ->
                 return (IdeResponseOk ("" :: T.Text) :: IdeResponse T.Text)
@@ -174,6 +175,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                                 , pRequired = Optional
                                 }
                             ]
+                          , cmdSafety = Safe
                           }
             , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
             }
@@ -217,6 +219,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                               , pRequired = Required
                               }
                             ]
+                          , cmdSafety = Safe
                           }
             , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
             }
@@ -252,6 +255,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                                     , pRequired = Required
                                     }
                                 ]
+                              , cmdSafety = Safe
                               }
                 , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
                 }
@@ -271,6 +275,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                                     , pRequired = Required
                                     }
                                 ]
+                              , cmdSafety = Safe
                               }
                , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
                }
@@ -292,6 +297,7 @@ pluginsWithCollisions = Map.fromList [("plugin1", PluginDescriptor
                               , cmdReturnType = ""
                               , cmdContexts = [CtxRegion, CtxPoint] -- ["file", "start_pos", "file", "start_pos", "end_pos"]
                               , cmdAdditionalParams = []
+                              , cmdSafety = Safe
                               }
                 , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
                 }
@@ -332,6 +338,7 @@ pluginsWithoutCollisions = Map.fromList [("plugin1", PluginDescriptor
                                  , pRequired = Required
                                  }
                              ]
+                           , cmdSafety = Safe
                            } :: UntaggedCommandDescriptor
              , cmdFunc = CmdSync $ \_ _ -> return (IdeResponseOk ("" :: T.Text))
              }


### PR DESCRIPTION
This now looks at a safety attribute within the `CommandDescriptor` type. It specifies one of `Safe`, `ChangeCurrent` or `ChangeAll`.

* `Safe` means that the command will not read anything from disk
* `ChangeCurrent` may read the current file from disk
* `ChangeAll` may read multiple files from disk

Within Emacs, when calling `hie-run-command`, it will now save buffers based on the level of safety.

* `Safe` nothing happens
* `ChangeCurrent` will ask to save the current buffer
* `ChangeAll` will ask to save all buffers

Fixes #189 
