### PR TITLE
Grab bag

### DIFF
--- a/elisp/hie.el
+++ b/elisp/hie.el
@@ -127,7 +127,10 @@ If `haskell-process-load-or-reload-prompt' is nil, accept `default'."
   "Get the session cabal-dir."
   (or (hie-session-get s 'cabal-dir)
       (let* ((cabal-file (haskell-cabal-find-file))
-             (cabal-dir (when cabal-file (file-name-directory cabal-file))))
+             (cabal-dir (if cabal-file
+                            (file-name-directory cabal-file)
+                            "" ;; no cabal file, use directory only
+                          )))
         (progn (hie-session-set-cabal-dir s cabal-dir)
                cabal-dir))))
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -37,13 +37,13 @@ library
   build-depends:       Cabal >= 1.22
                      , aeson
                      , attoparsec
-                     , base >= 4.7 && < 5
+                     , base >= 4.9 && < 5
                      , bytestring
                      , containers
                      , directory
                      , either
                      , fast-logger
-                     , ghc >= 7.10.2 && < 8.2
+                     , ghc >= 8.0.1
                      , ghc-mod
                      , gitrev >= 1.1
                      , haskeline
@@ -74,7 +74,7 @@ library
                      , time
                      , transformers
                      , unordered-containers
-                     , vinyl >= 0.5 && < 0.6
+                     , vinyl >= 0.5
                      , wai
                      , warp
   ghc-options:         -Wall

--- a/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
+++ b/hie-apply-refact/Haskell/Ide/ApplyRefactPlugin.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -56,10 +55,6 @@ applyOneCmd = CmdSync $ \_ctxs req -> do
         Left err -> return $ IdeResponseFail (IdeError PluginError
                       (T.pack $ "applyOne: " ++ show err) Null)
         Right fs -> return (IdeResponseOk fs)
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "ApplyRefactPlugin.applyOneCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 
 -- ---------------------------------------------------------------------
@@ -75,10 +70,6 @@ applyAllCmd = CmdSync $ \_ctxs req -> do
         Left err -> return $ IdeResponseFail (IdeError PluginError
                       (T.pack $ "applyOne: " ++ show err) Null)
         Right fs -> return (IdeResponseOk fs)
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "ApplyRefactPlugin.applyOneCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 
 -- ---------------------------------------------------------------------

--- a/hie-apply-refact/hie-apply-refact.cabal
+++ b/hie-apply-refact/hie-apply-refact.cabal
@@ -17,7 +17,7 @@ flag pedantic
 
 library
   exposed-modules:     Haskell.Ide.ApplyRefactPlugin
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , aeson
                      , apply-refact
                      , containers
@@ -32,7 +32,7 @@ library
                      , refact
                      , text
                      , transformers
-                     , vinyl >= 0.5 && < 0.6
+                     , vinyl >= 0.5
   ghc-options:         -Wall
   if flag(pedantic)
      ghc-options:      -Werror

--- a/hie-base/hie-base.cabal
+++ b/hie-base/hie-base.cabal
@@ -20,13 +20,13 @@ library
                        Haskell.Ide.Engine.PluginTypes
                        Haskell.Ide.Engine.PluginTypes.Singletons
                        Haskell.Ide.Engine.SemanticTypes
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , aeson
                      , containers
                      , text
                      , unordered-containers
                      , singletons
-                     , swagger2 >= 2.0.2
+                     , swagger2 >= 2.1
                      , vinyl
   ghc-options:         -Wall
   if flag(pedantic)

--- a/hie-eg-plugin-async/hie-eg-plugin-async.cabal
+++ b/hie-eg-plugin-async/hie-eg-plugin-async.cabal
@@ -17,7 +17,7 @@ flag pedantic
 
 library
   exposed-modules:     Haskell.Ide.ExamplePluginAsync
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , hie-plugin-api
                      , aeson
                      , containers

--- a/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
+++ b/hie-example-plugin2/Haskell/Ide/ExamplePlugin2.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -46,9 +45,6 @@ sayHelloToCmd = CmdSync $ \_ req ->
     Right (ParamText n :& RNil) -> do
       r <- liftIO $ sayHelloTo n
       return $ IdeResponseOk r
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> error "ghc's exhaustiveness checker is broken"
-#endif
 
 -- ---------------------------------------------------------------------
 {-

--- a/hie-example-plugin2/hie-example-plugin2.cabal
+++ b/hie-example-plugin2/hie-example-plugin2.cabal
@@ -17,7 +17,7 @@ flag pedantic
 
 library
   exposed-modules:     Haskell.Ide.ExamplePlugin2
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , hie-plugin-api
                      , aeson
                      , containers

--- a/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
+++ b/hie-ghc-mod/Haskell/Ide/GhcModPlugin.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE GADTs                 #-}
@@ -83,10 +82,6 @@ checkCmd = CmdSync $ \_ctxs req -> do
     Left err -> return err
     Right (ParamFile fileName :& RNil) -> do
       fmap T.pack <$> runGhcModCommand (GM.checkSyntax [(T.unpack fileName)])
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "GhcModPlugin.checkCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- ---------------------------------------------------------------------
 
@@ -113,10 +108,6 @@ lintCmd = CmdSync $ \_ctxs req -> do
     Left err -> return err
     Right (ParamFile fileName :& RNil) -> do
       fmap T.pack <$> runGhcModCommand (GM.lint GM.defaultLintOpts (T.unpack fileName))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "GhcModPlugin.lintCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- ---------------------------------------------------------------------
 
@@ -126,10 +117,6 @@ infoCmd = CmdSync $ \_ctxs req -> do
     Left err -> return err
     Right (ParamFile fileName :& ParamText expr :& RNil) -> do
       fmap T.pack <$> runGhcModCommand (GM.info (T.unpack fileName) (GM.Expression (T.unpack expr)))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "GhcModPlugin.infoCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- ---------------------------------------------------------------------
 
@@ -149,10 +136,6 @@ typeCmd = CmdSync $ \_ctxs req ->
 
       -}
       fmap (toTypeInfo . T.lines . T.pack) <$> runGhcModCommand (GM.types False (T.unpack fileName) l c)
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "GhcModPlugin.typesCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 
 

--- a/hie-ghc-mod/hie-ghc-mod.cabal
+++ b/hie-ghc-mod/hie-ghc-mod.cabal
@@ -17,7 +17,7 @@ flag pedantic
 
 library
   exposed-modules:     Haskell.Ide.GhcModPlugin
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , aeson
                      , containers
                      , directory

--- a/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
+++ b/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
@@ -11,11 +11,14 @@ module Haskell.Ide.GhcTreePlugin where
 
 import           Data.Aeson
 import qualified Data.Text as T
+-- import           Haskell.Ide.Engine.MonadFunctions (logm)
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.SemanticTypes
 import           Language.Haskell.GHC.DumpTree
 import           Language.Haskell.GhcMod.Monad
+
+-- ---------------------------------------------------------------------
 
 -- | Descriptor for the ghc-tree plugin
 ghcTreeDescriptor :: TaggedPluginDescriptor _
@@ -41,7 +44,7 @@ trees = CmdSync $ \_ctxs req -> do
   case getParams (IdFile "file" :& RNil) req of
     Left err -> return err
     Right (ParamFile fileName :& RNil) -> do
-      trs <- runGmlT' [Left $ T.unpack fileName] (return . treeDumpFlags)$ treesForSession
+      trs <- runGmlT' [Left $ T.unpack fileName] (return . treeDumpFlags) $ treesForTargets [T.unpack fileName]
       -- logm $ "getTrees:res=" ++ show trs
       case trs of
           [tree] -> return (IdeResponseOk $ treesToAST tree)

--- a/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
+++ b/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -50,10 +49,6 @@ trees = CmdSync $ \_ctxs req -> do
           [tree] -> return (IdeResponseOk $ treesToAST tree)
           _ -> return $ IdeResponseError (IdeError PluginError
                  "Expected one AST structure" (toJSON $ length trs))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "GhcTreePlugin.getTrees: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- | Convert from ghc-dump-tree type to our own type
 -- (avoids dependency on ghc-dump-tree from hie-base)

--- a/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
+++ b/hie-ghc-tree/Haskell/Ide/GhcTreePlugin.hs
@@ -10,7 +10,6 @@ module Haskell.Ide.GhcTreePlugin where
 
 import           Data.Aeson
 import qualified Data.Text as T
--- import           Haskell.Ide.Engine.MonadFunctions (logm)
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.SemanticTypes
@@ -44,7 +43,6 @@ trees = CmdSync $ \_ctxs req -> do
     Left err -> return err
     Right (ParamFile fileName :& RNil) -> do
       trs <- runGmlT' [Left $ T.unpack fileName] (return . treeDumpFlags) $ treesForTargets [T.unpack fileName]
-      -- logm $ "getTrees:res=" ++ show trs
       case trs of
           [tree] -> return (IdeResponseOk $ treesToAST tree)
           _ -> return $ IdeResponseError (IdeError PluginError

--- a/hie-ghc-tree/hie-ghc-tree.cabal
+++ b/hie-ghc-tree/hie-ghc-tree.cabal
@@ -17,7 +17,7 @@ flag pedantic
 
 library
   exposed-modules:     Haskell.Ide.GhcTreePlugin
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , aeson
                      , ghc-dump-tree
                      , ghc-mod

--- a/hie-hare/Haskell/Ide/HaRePlugin.hs
+++ b/hie-hare/Haskell/Ide/HaRePlugin.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -73,10 +72,6 @@ demoteCmd  = CmdSync $ \_ctxs req ->
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& RNil) ->
       runHareCommand "demote" (compDemote (T.unpack fileName) (unPos pos))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.demoteCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- compDemote :: FilePath -> SimpPos -> IO [FilePath]
 
@@ -88,10 +83,6 @@ dupdefCmd = CmdSync $ \_ctxs req ->
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& ParamText name :& RNil) ->
       runHareCommand "dupdef" (compDuplicateDef (T.unpack fileName) (T.unpack name) (unPos pos))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.dupdefCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- compDuplicateDef :: FilePath -> String -> SimpPos -> IO [FilePath]
 
@@ -103,10 +94,6 @@ iftocaseCmd = CmdSync $ \_ctxs req ->
     Left err -> return err
     Right (ParamFile fileName :& ParamPos startPos :& ParamPos endPos :& RNil) ->
       runHareCommand "iftocase" (compIfToCase (T.unpack fileName) (unPos startPos) (unPos endPos))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.ifToCaseCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- compIfToCase :: FilePath -> SimpPos -> SimpPos -> IO [FilePath]
 
@@ -118,10 +105,6 @@ liftonelevelCmd = CmdSync $ \_ctxs req ->
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& RNil) ->
       runHareCommand "liftonelevel" (compLiftOneLevel (T.unpack fileName) (unPos pos))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.liftOneLevel: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- compLiftOneLevel :: FilePath -> SimpPos -> IO [FilePath]
 
@@ -133,10 +116,6 @@ lifttotoplevelCmd = CmdSync $ \_ctxs req ->
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& RNil) ->
       runHareCommand "lifttotoplevel" (compLiftToTopLevel (T.unpack fileName) (unPos pos))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.liftToTopLevel: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- compLiftToTopLevel :: FilePath -> SimpPos -> IO [FilePath]
 
@@ -148,10 +127,6 @@ renameCmd = CmdSync $ \_ctxs req ->
     Left err -> return err
     Right (ParamFile fileName :& ParamPos pos :& ParamText name :& RNil) ->
       runHareCommand "rename" (compRename (T.unpack fileName) (T.unpack name) (unPos pos))
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError (IdeError InternalError
-      "HaRePlugin.renameCmd: ghc’s exhaustiveness checker is broken" Null)
-#endif
 
 -- compRename :: FilePath -> String -> SimpPos -> IO [FilePath]
 

--- a/hie-hare/hie-hare.cabal
+++ b/hie-hare/hie-hare.cabal
@@ -17,7 +17,7 @@ flag pedantic
 
 library
   exposed-modules:     Haskell.Ide.HaRePlugin
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , HaRe
                      , aeson
                      , containers
@@ -27,11 +27,11 @@ library
                      , ghc-mod
                      , hie-base
                      , hie-plugin-api
-                     , monad-control >= 1.0 && < 1.1
-                     , mtl >= 2.2 && < 2.3
+                     , monad-control
+                     , mtl
                      , text
                      , transformers
-                     , vinyl >= 0.5 && < 0.6
+                     , vinyl >= 0.5
   ghc-options:         -Wall
   if flag(pedantic)
      ghc-options:      -Werror

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -22,7 +22,7 @@ library
                        Haskell.Ide.Engine.MonadFunctions
                        Haskell.Ide.Engine.PluginDescriptor
                        Haskell.Ide.Engine.PluginUtils
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.9 && < 5
                      , Diff
                      , aeson
                      , containers
@@ -30,8 +30,7 @@ library
                      , fast-logger
                      , filepath
                      , ghc
--- ghc-mod > 5.4.0.0 -- TODO before release
-                     , ghc-mod >= 5.4.0.0
+                     , ghc-mod >= 5.6.0.0
                      , hie-base
                      , lifted-base
                      , monad-control
@@ -43,7 +42,7 @@ library
                      , time
                      , transformers
                      , unordered-containers
-                     , vinyl >= 0.5 && < 0.6
+                     , vinyl >= 0.5
   ghc-options:         -Wall
   if flag(pedantic)
      ghc-options:      -Werror

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -1,6 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
-{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -94,13 +93,6 @@ commandDetailCmd = CmdSync $ \_ req -> do
             , ideInfo = toJSON command
             }
           Just detail -> return $ IdeResponseOk (ExtendedCommandDescriptor (cmdDesc detail) p)
-#if __GLASGOW_HASKELL__ <= 710
-    Right _ -> return $ IdeResponseError $ IdeError
-      { ideCode = InternalError
-      , ideMessage = "commandDetailCmd: ghc’s exhaustiveness checker is broken"
-      , ideInfo = Null
-      }
-#endif
 
 -- ---------------------------------------------------------------------
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,10 @@ packages:
 - hie-ghc-tree
 - hie-hare
 - hie-docs-generator
+- location:
+    git: https://github.com/alanz/HaRe.git
+    commit:  07e88c52c2a36e4a7d422113389171221b140cb6
+  extra-dep: true
 extra-deps:
   - ghc-dump-tree-0.2.0.1
   # - ghc-7.10.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2016-08-28
+resolver: nightly-2016-09-04
 packages:
 - .
 - hie-apply-refact


### PR DESCRIPTION
- Target GHC 8.0.x only, getting rid of broken exhaustiveness checker tweaks
- deal with "projects" not having a cabal file, in the elisp
- ghc-tree returns the tree(s) for the requested file only