### PR TITLE
Logging

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -135,6 +135,8 @@ run opts = do
       then setLogLevel LevelDebug
       else setLogLevel LevelError
 
+    origDir <- getCurrentDirectory
+
     case projectRoot opts of
       Nothing -> do
         h <- getHomeDirectory
@@ -179,7 +181,7 @@ run opts = do
     if (optConsole opts)
        then consoleListener plugins cin
        else if optLsp opts
-               then lspStdioTransport dispatcherProc cin
+               then lspStdioTransport dispatcherProc cin origDir
                else jsonStdioTransport (optOneShot opts) cin
 
     -- At least one needs to be launched, othewise a threadDelay with a large

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -52,17 +52,17 @@ import           Text.Parsec
 
 -- ---------------------------------------------------------------------
 
-lspStdioTransport :: IO () -> TChan ChannelRequest -> IO ()
-lspStdioTransport hieDispatcherProc cin = do
-  run hieDispatcherProc cin >>= \case
+lspStdioTransport :: IO () -> TChan ChannelRequest -> FilePath -> IO ()
+lspStdioTransport hieDispatcherProc cin origDir = do
+  run hieDispatcherProc cin origDir >>= \case
     0 -> exitSuccess
     c -> exitWith . ExitFailure $ c
 
 
 -- ---------------------------------------------------------------------
 
-run :: IO () -> TChan ChannelRequest -> IO Int
-run dispatcherProc cin = flip E.catches handlers $ do
+run :: IO () -> TChan ChannelRequest -> FilePath -> IO Int
+run dispatcherProc cin origDir = flip E.catches handlers $ do
 
   cout <- atomically newTChan :: IO (TChan ChannelResponse)
   rin  <- atomically newTChan :: IO (TChan ReactorInput)
@@ -79,8 +79,10 @@ run dispatcherProc cin = flip E.catches handlers $ do
     tmpDir <- getTemporaryDirectory
     let logDir = tmpDir </> "hie-logs"
     createDirectoryIfMissing True logDir
-    (logFileName,handle) <- openTempFile logDir "hie-lsp.log"
-    hClose handle -- Logger will open the file again
+    let dirStr = map (\c -> if c == pathSeparator then '-' else c) origDir
+    -- (logFileName,handle) <- openTempFile logDir "hie-lsp.log"
+    -- hClose handle -- Logger will open the file again
+    let logFileName = logDir </> (dirStr ++ "-hie.log")
     Core.setupLogger logFileName L.DEBUG
     CTRL.run dp (hieHandlers rin) hieOptions
 

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -42,7 +42,6 @@ import           System.Directory
 import           System.Exit
 import           System.FilePath
 import qualified System.Log.Logger as L
-import           System.IO
 import           Text.Parsec
 -- import qualified Yi.Rope as Yi
 


### PR DESCRIPTION
Create a different log file for each directory hie is started in.

This helps for when more than one project is running at the same time, as the current logging framework silently discards log entries for a second instance that cannot open the log file.

And it makes the file predictable, for tailing it and restarting the process.