### PR TITLE
Limit number of diagnostics provided per file.

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -49,6 +49,7 @@ library
                      , lens >= 4.15.2
                      , mtl
                      , optparse-simple >= 0.0.3
+                     , sorted-list == 0.2.0.*
                      , stm
                      , text
                      , unordered-containers

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -36,6 +36,7 @@ import           Data.List
 import qualified Data.HashMap.Strict as H
 import qualified Data.Map as Map
 import qualified Data.Set as S
+import qualified Data.SortedList as SL
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified GhcModCore               as GM
@@ -242,10 +243,10 @@ updatePositionMap uri changes = do
 -- ---------------------------------------------------------------------
 
 publishDiagnostics :: (MonadIO m, MonadReader Core.LspFuncs m)
-  => J.Uri -> Maybe J.TextDocumentVersion -> DiagnosticsBySource -> m ()
-publishDiagnostics uri' mv diags = do
+  => Int -> J.Uri -> Maybe J.TextDocumentVersion -> DiagnosticsBySource -> m ()
+publishDiagnostics maxToSend uri' mv diags = do
   lf <- ask
-  liftIO $ (Core.publishDiagnosticsFunc lf) uri' mv diags
+  liftIO $ (Core.publishDiagnosticsFunc lf) maxToSend uri' mv diags
 
 -- ---------------------------------------------------------------------
 
@@ -661,8 +662,9 @@ requestDiagnostics :: TChan PluginRequest -> J.Uri -> Int -> R ()
 requestDiagnostics cin file ver = do
   lf <- ask
   let sendOne pid (uri',ds) =
-        publishDiagnostics uri' Nothing (Map.fromList [(Just pid,ds)])
-      sendEmpty = publishDiagnostics file Nothing (Map.fromList [(Just "ghcmod",[])])
+        publishDiagnostics maxToSend uri' Nothing (Map.fromList [(Just pid,SL.toSortedList ds)])
+      sendEmpty = publishDiagnostics maxToSend file Nothing (Map.fromList [(Just "ghcmod",SL.toSortedList [])])
+      maxToSend = 50
   -- get hlint diagnostics
   let reql = PReq (Just file) (Just (file,ver)) Nothing (flip runReaderT lf . callbackl)
                $ ApplyRefact.lintCmd' file

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,11 +12,13 @@ packages:
 - hie-hoogle
 - hie-plugin-api
 - hie-brittany
-# - ./haskell-lsp
+
+# - ../haskell-lsp
 - location:
     git: https://github.com/alanz/haskell-lsp.git
-    commit: a98b2c452248b0dfe461b339d275734977151e37
+    commit: bdbab47f070c5b3b45d31bcb4b22ebcd9a34ff15
   extra-dep: true
+
 - location:
     git: https://github.com/alanz/ghc-dump-tree.git
     commit: 9dbca928ad5507b144f46bb95123a08d24f24808
@@ -37,6 +39,7 @@ packages:
 - location:
     git: https://github.com/alanz/ghc-mod.git
     commit: 1008d147a9e7eaa4e3f1c3ee6f454550e00f1899
+    # commit: 39db9b2d64e2405bce34fbc96d4bc97ab6fcc8b3
   extra-dep: true
   subdirs:
     - .


### PR DESCRIPTION
If a file is badly broken it can end up with a large number of diagnostics,
which can slow things down.

Limit the number sent to the client. This is currently hard coded to 50, but
should probably be settable via a command line option.

There is also a custom message from vscode to set this to a configuration value,
per project. It could perhaps honour that too.