### PR TITLE
Fix builds on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,17 +61,6 @@ cd haskell-ide-engine
 stack install
 ```
 
-If you are on macOS, you might need to do the following to make sure `icu4c` is located properly
-
-```bash
-brew install icu4c
-cd haskell-ide-engine
-stack install text-icu \
- --extra-lib-dirs=/usr/local/opt/icu4c/lib \
- --extra-include-dirs=/usr/local/opt/icu4c/include
-stack install
-```
-
 ### Installation using Nix
 
 Alternatively, given that you have Nix installed:

--- a/stack.yaml
+++ b/stack.yaml
@@ -44,6 +44,7 @@ extra-deps:
 - monad-memo-0.4.1
 - hoogle-5.0.13
 - brittany-0.8.0.2
+- yi-rope-0.10
 flags:
   haskell-ide-engine:
     pedantic: true


### PR DESCRIPTION
Thanks to @ethercrow for removing `text-icu` as a dependency from `yi-rope`. This should now simply build with `stack install` on macOS.

I have never used nix and am not sure how it works, but I can only assume it's a simple as removing `icu` from this line https://github.com/haskell/haskell-ide-engine/blob/master/stack.yaml#L72. I'll leave that change for someone who can actually test it.

Perhaps someone could also test this on windows as I have no way of knowing if this `resolves` #300. 

Closes #303 