### PR TITLE
Add doc for gen. global hoogle db with stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ To generate a global hoogle database for your user from hackage, run
 $ hoogle generate
 ```
 
+To generate a global database for a stack installation, run
+
+```bash
+$ stack exec hoogle generate
+```
+
 To generate a project specific database for a stack project, run
 
 ```bash


### PR DESCRIPTION
This seemed to be just about the only thing that got the VS Code extension to stop complaining about a missing Hoogle database. Took me ages to figure it out, so hopefully this helps someone else!