### PR TITLE
Don't force ghc-mod to use -Wall switch

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -118,7 +118,7 @@ run opts = do
 
   let vomitOptions = GM.defaultOptions { GM.optOutput = oo { GM.ooptLogLevel = GM.GmVomit}}
       oo = GM.optOutput GM.defaultOptions
-  let ghcModOptions = (if optGhcModVomit opts then vomitOptions else GM.defaultOptions) { GM.optGhcUserOptions = ["-Wall"]  }
+  let ghcModOptions = if optGhcModVomit opts then vomitOptions else GM.defaultOptions
 
   -- launch the dispatcher.
   let dispatcherProcP dispatcherEnv =


### PR DESCRIPTION
It will pick up the options from .cabal

Closes #918 - Extra warnings were displayed
for people who used -Wall and -Wno-xxx flags.
An extra -Wall added by HIE just cancelled
the effect of -Wno switches.

This change breaks the behaviour for people who
omitted -Wall in their .cabal files and relied
on HIE to add the switch. They should just
add -Wall to ghc-options in .cabal.