### PR TITLE
Add EKG support

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE TemplateHaskell     #-}
 module Main where
 
+
+
 import           Control.Concurrent.STM.TChan
 import           Control.Monad
 import           Control.Monad.STM
@@ -27,6 +29,7 @@ import           Options.Applicative.Simple
 import qualified Paths_haskell_ide_engine              as Meta
 import           System.Directory
 import qualified System.Log.Logger                     as L
+import qualified System.Remote.Monitoring              as EKG
 
 -- ---------------------------------------------------------------------
 -- plugins
@@ -101,6 +104,8 @@ run opts = do
                    else L.INFO
 
   Core.setupLogger mLogFileName ["hie"] logLevel
+
+  when (optEkg opts) $ EKG.forkServer "localhost" 8000 >> return ()
 
   origDir <- getCurrentDirectory
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -69,6 +69,7 @@ executable hie
                      , base
                      , containers
                      , directory
+                     , ekg
                      , ghc-mod-core
                      , gitrev >= 1.1
                      , haskell-ide-engine
@@ -91,6 +92,7 @@ executable hie
                      , unordered-containers
                      , vinyl
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wredundant-constraints
+                       -with-rtsopts=-T
   if flag(pedantic)
      ghc-options:      -Werror
   default-language:    Haskell2010

--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -17,6 +17,7 @@ data GlobalOpts = GlobalOpts
   , projectRoot    :: Maybe String
   , optDumpSwagger :: Bool
   , optGhcModVomit :: Bool
+  , optEkg         :: Bool
   } deriving (Show)
 
 globalOptsParser :: Parser GlobalOpts
@@ -64,3 +65,6 @@ globalOptsParser = GlobalOpts
   <*> flag False True
        ( long "vomit"
        <> help "enable vomit logging for ghc-mod")
+  <*> flag False True
+       ( long "ekg"
+       <> help "enable ekg collection and display on http://localhost:8000")


### PR DESCRIPTION
Launch with the `--ekg` option to `hie`, and point a browser at
http://localhost:8000