### PR TITLE
Add Makefile for building all GHC variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+BASEDIR=$(CURDIR)
+
+build:
+	stack --stack-yaml=stack-8.0.2.yaml install                  \
+		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.0.2            \
+		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.0              \
+	&& stack --stack-yaml=stack-8.2.1.yaml install               \
+		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.1            \
+		&& cp ~/.local/bin/hie-8.2.1 ~/.local/bin/hie-8.2        \
+	&& stack --stack-yaml=stack.yaml install                     \
+		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.2            \
+		&& cp ~/.local/bin/hie-8.2.2 ~/.local/bin/hie-8.2
+
+.PHONY: build


### PR DESCRIPTION
Following up on https://github.com/haskell/haskell-ide-engine/issues/439.

The Makefile makes it easy to build all the versions of HIE we have for different GHC versions. 

- It's intentionally sequenced with `&&`, so that `~/.local/bin/hie` doesn't get overwritten by another build (can one specify specific executable paths/names? with stack?)

- The reason for the redundant `~/.local/bin/hie-8.2` is merely that it is using the main `stack.yaml`, which I assume will be changed to a different GHC later on, and this will make sure we don't forget to add the `8.2` version of HIE.

- When we add new stack.yaml's or change GHC versions in the main config, we should update this accordingly.

This is meant to go with a wrapper script that automatically chooses the right version based on the GHC version of the project—PRs for those are under way to [VSCode](https://github.com/alanz/vscode-hie-server) and [Atom](https://github.com/Tehnix/ide-haskell-hie), and I'll update the README for the other editors after this.