### PR TITLE
Update to latest cabal-helper/ghc-mod, add ghc version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,10 @@ build:
 	&& stack --stack-yaml=stack.yaml install                     \
 		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.2            \
 		&& cp ~/.local/bin/hie-8.2.2 ~/.local/bin/hie-8.2
-
 .PHONY: build
+
+hie-8.2.2:
+	stack --stack-yaml=stack.yaml install                     \
+		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.2            \
+		&& cp ~/.local/bin/hie-8.2.2 ~/.local/bin/hie-8.2
+.PHONY: hie-8.2.2

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -2,17 +2,12 @@
 {-# LANGUAGE TemplateHaskell     #-}
 module Main where
 
-
-
 import           Control.Concurrent.STM.TChan
 import           Control.Monad
 import           Control.Monad.STM
 import           Data.Semigroup
 import qualified Data.Map as Map
 import           Data.Version                          (showVersion)
-import           Development.GitRev                    (gitCommitCount)
-import           Distribution.System                   (buildArch)
-import           Distribution.Text                     (display)
 import qualified GhcMod.Types                          as GM
 import           Haskell.Ide.Engine.Dispatcher
 import           Haskell.Ide.Engine.Monad
@@ -59,16 +54,7 @@ plugins = pluginDescToIdePlugins
 
 main :: IO ()
 main = do
-    -- Version code from stack. Maybe move this stuff into optparse-simple ?
-    let commitCount = $gitCommitCount
-        versionString' = concat $ concat
-            [ [$(simpleVersion Meta.version)]
-              -- Leave out number of commits for --depth=1 clone
-              -- See https://github.com/commercialhaskell/stack/issues/792
-            , [" (" ++ commitCount ++ " commits)" | commitCount /= ("1"::String) &&
-                                                    commitCount /= ("UNKNOWN" :: String)]
-            , [" ", display buildArch]
-            ]
+    let
         numericVersion :: Parser (a -> a)
         numericVersion =
             infoOption
@@ -78,7 +64,7 @@ main = do
     -- Parse the options and run
     (global, ()) <-
         simpleOptions
-            versionString'
+            version
             "haskell-ide-engine - Provide a common engine to power any Haskell IDE"
             ""
             (numericVersion <*> globalOptsParser)

--- a/src/Haskell/Ide/Engine/BasePlugin.hs
+++ b/src/Haskell/Ide/Engine/BasePlugin.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DataKinds             #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE OverloadedStrings     #-}
@@ -20,6 +21,7 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Options.Applicative.Simple      (simpleVersion)
 import qualified Paths_haskell_ide_engine        as Meta
 import           Prelude                         hiding (log)
+import           System.Info
 
 -- ---------------------------------------------------------------------
 
@@ -84,6 +86,6 @@ version =
       -- See https://github.com/commercialhaskell/stack/issues/792
     , [" (" ++ commitCount ++ " commits)" | commitCount /= ("1"::String) &&
                                             commitCount /= ("UNKNOWN" :: String)]
-    , [" ", display buildArch] ]
-
--- ---------------------------------------------------------------------
+    , [" ", display buildArch]
+    , [" ", compilerName, "-", VERSION_ghc]
+    ]

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -18,17 +18,16 @@ packages:
   extra-dep: true
 
 - location:
-    git: https://github.com/wz1000/ghc-mod.git
-    commit: a2beda19b6d1975be7bed1081069ed0e42fa39e9
-    # ../ghc-mod
+    git: https://github.com/alanz/ghc-mod.git
+    commit: 47e200a728a575f407ee6f9893d9a1e77b1b5325
   extra-dep: true
   subdirs:
     - .
     - core
 
 - location:
-    git: https://gitlab.com/dxld/cabal-helper.git
-    commit: 4bfc6b916fcc696a5d82e7cd35713d6eabcb0533
+    git: https://gitlab.com/alanz/cabal-helper.git
+    commit: f53a39b7fac201d9ac2baae709b977546e448baf
   extra-dep: true
 
 extra-deps:

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -18,17 +18,16 @@ packages:
   extra-dep: true
 
 - location:
-    git: https://github.com/wz1000/ghc-mod.git
-    commit: a2beda19b6d1975be7bed1081069ed0e42fa39e9
-    # ../ghc-mod
+    git: https://github.com/alanz/ghc-mod.git
+    commit: 47e200a728a575f407ee6f9893d9a1e77b1b5325
   extra-dep: true
   subdirs:
     - .
     - core
 
 - location:
-    git: https://gitlab.com/dxld/cabal-helper.git
-    commit: 4bfc6b916fcc696a5d82e7cd35713d6eabcb0533
+    git: https://gitlab.com/alanz/cabal-helper.git
+    commit: f53a39b7fac201d9ac2baae709b977546e448baf
   extra-dep: true
 
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,17 +19,16 @@ packages:
   extra-dep: true
 
 - location:
-    # ../ghc-mod
-    git: https://github.com/wz1000/ghc-mod.git
-    commit: a2beda19b6d1975be7bed1081069ed0e42fa39e9
+    git: https://github.com/alanz/ghc-mod.git
+    commit: 47e200a728a575f407ee6f9893d9a1e77b1b5325
   extra-dep: true
   subdirs:
     - .
     - core
 
 - location:
-    git: https://gitlab.com/dxld/cabal-helper.git
-    commit: 4bfc6b916fcc696a5d82e7cd35713d6eabcb0533
+    git: https://gitlab.com/alanz/cabal-helper.git
+    commit: f53a39b7fac201d9ac2baae709b977546e448baf
   extra-dep: true
 
 extra-deps:
@@ -37,7 +36,6 @@ extra-deps:
 - haddock-api-2.18.1
 - haddock-library-1.4.4
 - syz-0.2.0.0
-- unix-compat-0.4.3.1
 
 flags:
   haskell-ide-engine:


### PR DESCRIPTION
to the startup version message, and version command.

So we now get

    hie --version
    Version 0.1.0.0, Git revision 9ad6d0c29ae1559202edba824453031fbc76ef8a (dirty) (1170 commits) x86_64 ghc-8.2.2