### PR TITLE
Add installation instructions for windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ stack --stack-yaml=stack-8.2.1.yaml install
 stack --stack-yaml=stack-8.0.2.yaml install
 ```
 
+#### Installation on Windows
+
+In order to avoid problems with long paths you can do the following:
+
+1. Edit the group policy: set "Enable Win32 long paths" to "Enabled". Works only only for Windows 10
+
+2. Clone the `haskell-ide-engine` to the root of your logical drive (e.g. to `E:\hie`)
+
+
 ### Installation with Nix
 
 Alternatively, given that you have Nix installed:


### PR DESCRIPTION
Add installation instructions for windows users who are facing the `path too long` issue on windows. Addresses #435 