### PR TITLE
Fix build error

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -169,7 +169,7 @@ setTypecheckedModule uri =
 -- ---------------------------------------------------------------------
 
 lintCmd :: CommandFunc Uri T.Text
-lintCmd = CmdSync $ \uri ->
+lintCmd = CmdSync $ \ uri ->
   lintCmd' uri
 
 lintCmd' :: Uri -> IdeGhcM (IdeResponse T.Text)


### PR DESCRIPTION
This failed to build (with GHC 8.2.2):
```
error: \u used with no following hex digits; treating as '\' followed by identifier [-Werror,-Wunicode]
```
Adding a space resolved it on my machine.