### PR TITLE
Add Makefile build that uses --copy-compiler-tool, along with a make icu-macos-fix for icu4c problems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,27 @@ build:
 .PHONY: build
 
 hie-8.2.2:
-	stack --stack-yaml=stack.yaml install                     \
-		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.2            \
+	stack --stack-yaml=stack.yaml install                  \
+		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.2      \
 		&& cp ~/.local/bin/hie-8.2.2 ~/.local/bin/hie-8.2
 .PHONY: hie-8.2.2
+
+build-copy-compiler-tool:
+	stack --stack-yaml=stack-8.0.2.yaml build --copy-compiler-tool    \
+	&& stack --stack-yaml=stack-8.2.1.yaml build --copy-compiler-tool \
+	&& stack --stack-yaml=stack.yaml build --copy-compiler-tool
+.PHONY: build-copy-compiler-tool
+
+icu-macos-fix:
+▶   brew install icu4c                                     \
+	&& stack --stack-yaml=stack-8.0.2.yaml build text-icu  \
+         --extra-lib-dirs=/usr/local/opt/icu4c/lib         \
+         --extra-include-dirs=/usr/local/opt/icu4c/include \
+	&& stack --stack-yaml=stack-8.2.1.yaml build text-icu  \
+         --extra-lib-dirs=/usr/local/opt/icu4c/lib         \
+         --extra-include-dirs=/usr/local/opt/icu4c/include \
+	&& stack --stack-yaml=stack.yaml build text-icu        \
+         --extra-lib-dirs=/usr/local/opt/icu4c/lib         \
+         --extra-include-dirs=/usr/local/opt/icu4c/include
+.PHONY: icu-macos-fix
+


### PR DESCRIPTION
#### Why
I didn't know about the `--copy-compiler-tool` flag in stack before reading [An Opinionated Guide to Haskell in 2018](https://lexi-lambda.github.io/blog/2018/02/10/an-opinionated-guide-to-haskell-in-2018/), but thought it would be an excellent way to setup hie.

Often I see people running into issues with the GHC hie was built with differing with the one they use in their project. I added a wrapper script to sorta alleviate this problem for myself (it's in the VSCode and Atom clients), but think it's a bit of a suboptimal solution.

#### What

So, this PR adds some preliminary support for building the different HIE versions tied specifically to the GHC compilers they were built on via `make build-copy-compiler-tool`. This way, a user that is using HIE on a mismatching GHC version will get an error if HIE has not been built for this, instead of it silently failing or only half working.

An example inside HIE,

```
$ stack --stack-yaml=stack-8.0.2.yaml exec -- which hie
/Users/tehnix/GitHub/Clones/haskell-ide-engine/.stack-work/install/x86_64-osx/lts-9.14/8.0.2/bin/hie
$ stack --stack-yaml=stack-8.2.1.yaml exec -- which hie
/Users/tehnix/GitHub/Clones/haskell-ide-engine/.stack-work/install/x86_64-osx/nightly-2017-11-24/8.2.1/bin/hie
```

and in an unrelated project,

```
$ stack exec -- which hie
/Users/tehnix/.stack/compiler-tools/x86_64-osx/ghc-8.0.2/bin/hie
```

Additionally I also added a `make icu-macos-fix`, because I kept running into the ICU issue on macOS, and it got tedious looking up the specific paths.

Some thoughts:

- We are only building for GHC 8.0.1, 8.2.1 and 8.2.2, so if a user is using something else, it doesn't support it. Optimally, this will be solved by having a stack file for all versions of GHC we want to support.