### PR TITLE
Do not return error message for hover and symbols req

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -115,7 +115,10 @@ run opts = do
   let ghcModOptions = if optGhcModVomit opts then vomitOptions else GM.defaultOptions
 
   -- launch the dispatcher.
-  let dispatcherProcP dispatcherEnv =
+  let
+    -- TODO: Why is this not together with dispatcherP?
+    dispatcherProcP :: DispatcherEnv -> IO ()
+    dispatcherProcP dispatcherEnv =
         void $ runIdeGhcM ghcModOptions
             (IdeState emptyModuleCache plugins Map.empty Nothing)
             (dispatcherP dispatcherEnv pin)

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -53,7 +53,7 @@ ideDispatcher env pin = forever $ do
     res <- action
     liftIO $ callback res
 
-ghcDispatcher :: foall void. DispatcherEnv -> TChan GhcRequest -> IdeGhcM void
+ghcDispatcher :: forall void. DispatcherEnv -> TChan GhcRequest -> IdeGhcM void
 ghcDispatcher env@DispatcherEnv{docVersionTVar} pin = forever $ do
   debugm "ghcDispatcher: top of loop"
   (GhcRequest context mver mid callback action) <- liftIO $ atomically $ readTChan pin

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -23,7 +23,7 @@ data DispatcherEnv = DispatcherEnv
   , docVersionTVar     :: !(TVar (Map.Map Uri Int))
   }
 
-dispatcherP :: DispatcherEnv -> TChan PluginRequest -> IdeGhcM ()
+dispatcherP :: forall void. DispatcherEnv -> TChan PluginRequest -> IdeGhcM void
 dispatcherP env inChan = do
   stateVar <- lift . lift $ ask
   gchan <- liftIO $ do
@@ -34,7 +34,7 @@ dispatcherP env inChan = do
     return ghcChan
   ghcDispatcher env gchan
 
-mainDispatcher :: TChan PluginRequest -> TChan GhcRequest -> TChan IdeRequest -> IO ()
+mainDispatcher :: forall void. TChan PluginRequest -> TChan GhcRequest -> TChan IdeRequest -> IO void
 mainDispatcher inChan ghcChan ideChan = forever $ do
   req <- atomically $ readTChan inChan
   case req of
@@ -43,7 +43,7 @@ mainDispatcher inChan ghcChan ideChan = forever $ do
     Left r ->
       atomically $ writeTChan ideChan r
 
-ideDispatcher :: DispatcherEnv -> TChan IdeRequest -> IdeM ()
+ideDispatcher :: forall void. DispatcherEnv -> TChan IdeRequest -> IdeM void
 ideDispatcher env pin = forever $ do
   debugm "ideDispatcher: top of loop"
   (IdeRequest lid callback action) <- liftIO $ atomically $ readTChan pin
@@ -53,7 +53,7 @@ ideDispatcher env pin = forever $ do
     res <- action
     liftIO $ callback res
 
-ghcDispatcher :: DispatcherEnv -> TChan GhcRequest -> IdeGhcM ()
+ghcDispatcher :: foall void. DispatcherEnv -> TChan GhcRequest -> IdeGhcM void
 ghcDispatcher env@DispatcherEnv{docVersionTVar} pin = forever $ do
   debugm "ghcDispatcher: top of loop"
   (GhcRequest context mver mid callback action) <- liftIO $ atomically $ readTChan pin

--- a/src/Haskell/Ide/Engine/Types.hs
+++ b/src/Haskell/Ide/Engine/Types.hs
@@ -14,7 +14,7 @@ pattern GReq :: Maybe Uri
                 -> Maybe J.LspId
                 -> (a1 -> IO ())
                 -> IdeGhcM a1
-                -> Either a GhcRequest
+                -> PluginRequest
 pattern GReq a b c d e = Right (GhcRequest   a b c d e)
 
 pattern IReq :: J.LspId -> (a -> IO ()) -> IdeM a -> Either IdeRequest b


### PR DESCRIPTION
IF the module is not currently loaded, simply return an empty result
for hover request and document symbols request.

Affects #416, #460, #462

I am not sure that it closes any of them though.