### PR TITLE
Speed up dev cycle by using cabal new-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ haskell-lsp/
 /.cabal-sandbox/
 /.idea/
 /.stack-work
+/.cabal-project-deps
 /_release/
 /docs/hcar/auto/2015.el
 /docs/hcar/prv_2015.fmt

--- a/Makefile
+++ b/Makefile
@@ -43,3 +43,12 @@ icu-macos-fix:
          --extra-include-dirs=/usr/local/opt/icu4c/include
 .PHONY: icu-macos-fix
 
+.PHONY: cabal-project-deps
+cabal-project-deps:
+	mkdir -p ./.cabal-project-deps
+	- (cd ./.cabal-project-deps && git clone https://gitlab.com/alanz/HaRe.git)
+	(cd ./.cabal-project-deps/HaRe && git fetch)
+	(cd ./.cabal-project-deps/HaRe && git checkout e325975450ce89d790ed3f92de3ef675967d9538)
+	- (cd ./.cabal-project-deps && git clone https://github.com/alanz/ghc-mod.git)
+	(cd ./.cabal-project-deps/ghc-mod && git fetch)
+	(cd ./.cabal-project-deps/ghc-mod && git checkout 47e200a728a575f407ee6f9893d9a1e77b1b5325)

--- a/cabal.project
+++ b/cabal.project
@@ -1,16 +1,8 @@
 packages:
          ./
-         hie-apply-refact/
-         hie-base/
-         hie-brittany/
-         hie-docs-generator/
-         hie-eg-plugin-async/
-         hie-example-plugin2/
-         hie-ghc-mod/
-         hie-ghc-tree/
-         hie-hare/
-         hie-hoogle/
-         hie-plugin-api/
-         ../haskell-lsp/
-         ../../lspitzner/brittany
-         -- ../ghc-mod/
+         ./hie-plugin-api/
+         ./.cabal-project-deps/HaRe
+         ./.cabal-project-deps/ghc-mod/
+         ./.cabal-project-deps/ghc-mod//core/
+
+

--- a/docs/Hacking.md
+++ b/docs/Hacking.md
@@ -23,6 +23,35 @@ hie --version
 Version 0.1.0.0, Git revision 54338553f9c07b7d3427a769f7f4c2c366cefc7f (dirty) (1218 commits) x86_64 ghc-8.2.2
 ```
 
+### Building with cabal new-build
+
+At the moment, `stack build` takes a *ver* long time, because it
+always rebuilds the `haddock-api` and `haddock-library` dependencies.
+
+It is quicker to develop using `cabal new-build`, and a
+`cabal.project` file has been set up for it.
+
+First clone the git repos required, mirroring what is in `stack.yaml`.
+
+```bash
+make cabal-project-deps
+```
+
+Then
+
+```bash
+cabal new-configure --enable-tests
+cabal new-build
+```
+
+Run the tests (after building if necessary) with
+
+```bash
+cabal new-test
+```
+
+This is much quicker, as it does not gratuitously rebuild anything.
+
 
 ### Plugins (Old architecture)
 


### PR DESCRIPTION
This does not gratuitously rebuild haddock-api and haddock-library for
every change made.