### PR TITLE
Use current directory as default when project root is not specified

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -97,12 +97,7 @@ run opts = do
 
   origDir <- getCurrentDirectory
 
-  case projectRoot opts of
-    Nothing -> do
-      h <- getHomeDirectory
-      setCurrentDirectory h
-      logm $ "Setting home directory:" ++ h
-    Just root -> setCurrentDirectory root
+  maybe (pure ()) setCurrentDirectory $ projectRoot opts
 
   logm $  "run entered for HIE " ++ version
   d <- getCurrentDirectory


### PR DESCRIPTION
Is using `$HOME` as default root dir the desired behavior? It doesn't seem to me like a sensible default to use. Even the CLI docs say the default is current directory

```
  -r,--project-root PROJECTROOT
                           Root directory of project, defaults to cwd
```