### PR TITLE
Add an architecture decision record directory

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/adr

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2018-03-12
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at https://github.com/npryce/adr-tools.


### PR DESCRIPTION
See https://adr.github.io/

Add lightweight documents defining architectural decisions taken at a
point in time, so that the discussion around the decision-making
process is not lost.

To me this would include changes like deciding to do away with most of
the sub-projects, the decision to bring in IdeM and IdeGhcM, and so
on.

We do not have to retroactively document these, but it gives us a
place to capture decisions at least.