### PR TITLE
Do not send hlint diagnostics when there is a ghc error reported

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -109,7 +109,7 @@ parseErrorToDiagnostic :: Hlint.ParseError -> [Diagnostic]
 parseErrorToDiagnostic (Hlint.ParseError l msg contents) =
   [Diagnostic
       { _range    = srcLoc2Range l
-      , _severity = Just DsError
+      , _severity = Just DsInfo -- Not displayed
       , _code     = Just "parser"
       , _source   = Just "hlint"
       , _message  = T.unlines [T.pack msg,T.pack contents]

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -762,10 +762,21 @@ requestDiagnostics :: TChan PluginRequest -> J.Uri -> Int -> R ()
 requestDiagnostics cin file ver = do
   lf <- ask
   mc <- liftIO $ Core.config lf
-  let sendOne pid (uri',ds) =
-        publishDiagnostics maxToSend uri' Nothing (Map.fromList [(Just pid,SL.toSortedList ds)])
-      sendEmpty = publishDiagnostics maxToSend file Nothing (Map.fromList [(Just "ghcmod",SL.toSortedList [])])
-      maxToSend = maybe 50 maxNumberOfProblems mc
+  let
+    -- | If there is a GHC error, flush the hlint diagnostics
+    sendOneGhc :: J.DiagnosticSource -> (Uri, [Diagnostic]) -> R ()
+    sendOneGhc pid (fileUri,ds) = do
+      if (any (hasSeverity J.DsError) ds)
+        then publishDiagnostics maxToSend fileUri Nothing
+               (Map.fromList [(Just "hlint",SL.toSortedList []),(Just pid,SL.toSortedList ds)])
+        else sendOne pid (fileUri,ds)
+    sendOne pid (fileUri,ds) = do
+      publishDiagnostics maxToSend fileUri Nothing (Map.fromList [(Just pid,SL.toSortedList ds)])
+    hasSeverity :: J.DiagnosticSeverity -> J.Diagnostic -> Bool
+    hasSeverity sev (J.Diagnostic _ (Just s) _ _ _) = s == sev
+    hasSeverity _ _ = False
+    sendEmpty = publishDiagnostics maxToSend file Nothing (Map.fromList [(Just "ghcmod",SL.toSortedList [])])
+    maxToSend = maybe 50 maxNumberOfProblems mc
 
   -- mc <- asks Core.config
   let sendHlint = maybe True hlintOn mc
@@ -794,7 +805,7 @@ requestDiagnostics cin file ver = do
         let ds = Map.toList $ S.toList <$> pd
         case ds of
           [] -> sendEmpty
-          _ -> mapM_ (sendOne "ghcmod") ds
+          _ -> mapM_ (sendOneGhc "ghcmod") ds
       callbackg _ = error "impossible"
 
   liftIO $ atomically $ writeTChan cin reqg

--- a/test/ApplyRefactPluginSpec.hs
+++ b/test/ApplyRefactPluginSpec.hs
@@ -90,6 +90,24 @@ applyRefactSpec = do
 
     -- ---------------------------------
 
+    it "returns hlint parse error as DsInfo ignored diagnostic" $ do
+
+      let act = lintCmd' arg
+          arg = filePathToUri "./test/testdata/HlintParseFail.hs"
+          res = IdeResponseOk
+            PublishDiagnosticsParams
+             { _uri = Uri {getUri = "file://./test/testdata/HlintParseFail.hs"}
+             , _diagnostics = List $
+               [Diagnostic {_range = Range { _start = Position {_line = 11, _character = 28}
+                                           , _end = Position {_line = 11, _character = 100000}}
+                           , _severity = Just DsInfo
+                           , _code = Just "parser"
+                           , _source = Just "hlint"
+                           , _message = "Parse error: :~:\n  import           Data.Type.Equality            ((:~:) (..), (:~~:) (..))\n  \n> data instance Sing (z :: (a :~: b)) where\n      SRefl :: Sing Refl\n\n"}]}
+      testCommand testPlugins act "applyrefact" "lint" arg res
+
+    -- ---------------------------------
+
     it "respects hlint pragmas in the source file" $ do
 
       let req = lintCmd' (filePathToUri "./test/testdata/HlintPragma.hs")

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -129,6 +129,7 @@ functionalSpec = do
                                              "Redundant do\nFound:\n  do putStrLn \"hello\"\nWhy not:\n  putStrLn \"hello\"\n"
                                 ]
                               })
+
       let req3 = HP (filePathToUri "./FuncTest.hs") (toPos (8,1))
       r3 <- dispatchRequest cin "hare" "demote" req3
       fmap fromDynJSON r3 `shouldBe`

--- a/test/testdata/FuncTestError.hs
+++ b/test/testdata/FuncTestError.hs
@@ -1,0 +1,15 @@
+module Main where
+
+main = putStrLn "hello"
+
+foo :: Int
+foo = bb
+
+bb = 5
+
+bug -- no hlint returned because of this, despite redundant do below
+
+baz = do
+  putStrLn "hello"
+
+f x = x+1

--- a/test/testdata/HlintParseFail.hs
+++ b/test/testdata/HlintParseFail.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeInType #-}
+module Test where
+
+import           Data.Singletons.Prelude
+import           Data.Singletons.TypeLits
+import           Data.Type.Equality            ((:~:) (..), (:~~:) (..))
+
+data instance Sing (z :: (a :~: b)) where
+    SRefl :: Sing Refl


### PR DESCRIPTION
And if hlint reports a parse error, do not report that either, by
setting the severity to DsInfo, which is not displayed.

Addresses #490