### PR TITLE
Fix warning: '\u used with no following hex digits' in GhcMod.hs

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -63,7 +63,7 @@ type Diagnostics = Map.Map Uri (Set.Set Diagnostic)
 type AdditionalErrs = [T.Text]
 
 checkCmd :: CommandFunc Uri (Diagnostics, AdditionalErrs)
-checkCmd = CmdSync $ \uri ->
+checkCmd = CmdSync $ \ uri ->
   setTypecheckedModule uri
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
Current nightly stack.yaml on macOS - `stack build` produces an error:
```
    /Users/pavlo/Projects/haskell-ide-engine/src/Haskell/Ide/Engine/Plugin/GhcMod.hs:66:22: error:
         error: \u used with no following hex digits; treating as '\' followed by identifier [-Werror,-Wunicode]
       |
    66 | checkCmd = CmdSync $ \uri ->
       |                      ^
    checkCmd = CmdSync $ \uri ->
                         ^
```

The patch fixes it and lets `hie` to be built and installed.