### PR TITLE
Update resolver for ghc-8.2.2 to LTS

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,4 @@
-resolver: nightly-2018-02-26
-#resolver: nightly-2018-01-15
+resolver: lts-11.2
 packages:
 - .
 - hie-plugin-api


### PR DESCRIPTION
There is no longer need to use nightly builds of stack.