### PR TITLE
Apply any hlint

### DIFF
--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -543,14 +543,14 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp = do
             (J.List diags) = params ^. J.context . J.diagnostics
 
         let
-          makeCommand (J.Diagnostic (J.Range start _) _s _c (Just "hlint") m  ) = [J.Command title cmd cmdparams]
+          makeCommand (J.Diagnostic (J.Range start _) _s (Just code) (Just "hlint") m) = [J.Command title cmd cmdparams]
             where
               title :: T.Text
               title = "Apply hint:" <> head (T.lines m)
               -- NOTE: the cmd needs to be registered via the InitializeResponse message. See hieOptions above
               cmd = "applyrefact:applyOne"
-              -- need 'file' and 'start_pos'
-              args = J.Array $ V.singleton $ J.toJSON $ ApplyRefact.AOP doc start
+              -- need 'file', 'start_pos' and hint title (to distinguish between alternative suggestions at the same location)
+              args = J.Array $ V.singleton $ J.toJSON $ ApplyRefact.AOP doc start code
               cmdparams = Just args
           makeCommand (J.Diagnostic _r _s _c _source _m  ) = []
           -- TODO: make context specific commands for all sorts of things, such as refactorings

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.2
+resolver: lts-11.6
 packages:
 - .
 - hie-plugin-api

--- a/test/ApplyRefactPluginSpec.hs
+++ b/test/ApplyRefactPluginSpec.hs
@@ -13,6 +13,8 @@ import           TestUtils
 
 import           Test.Hspec
 
+{-# ANN module ("HLint: ignore Redundant do"       :: String) #-}
+
 -- ---------------------------------------------------------------------
 
 main :: IO ()
@@ -39,9 +41,8 @@ applyRefactSpec = do
     it "applies one hint only" $ do
 
       let furi = filePathToUri "./test/testdata/ApplyRefact.hs"
-          act = applyOneCmd' furi
-                             (toPos (2,8))
-          arg = AOP furi (toPos (2,8))
+          act = applyOneCmd' furi (OneHint (toPos (2,8)) "Redundant bracket")
+          arg = AOP furi (toPos (2,8)) "Redundant bracket"
           res = IdeResponseOk $ WorkspaceEdit
             (Just $ H.singleton applyRefactPath
                                 $ List [TextEdit (Range (Position 1 0) (Position 1 25))
@@ -77,12 +78,12 @@ applyRefactSpec = do
              , _diagnostics = List $
                [ Diagnostic (Range (Position 1 7) (Position 1 25))
                             (Just DsHint)
-                            Nothing
+                            (Just "Redundant bracket")
                             (Just "hlint")
                             "Redundant bracket\nFound:\n  (putStrLn \"hello\")\nWhy not:\n  putStrLn \"hello\"\n"
                , Diagnostic (Range (Position 3 8) (Position 3 15))
                             (Just DsHint)
-                            Nothing
+                            (Just "Redundant bracket")
                             (Just "hlint")
                             "Redundant bracket\nFound:\n  (x + 1)\nWhy not:\n  x + 1\n"
                ]}
@@ -119,7 +120,7 @@ applyRefactSpec = do
             , _diagnostics = List
               [ Diagnostic (Range (Position 3 11) (Position 3 20))
                            (Just DsInfo)
-                           Nothing
+                           (Just "Redundant bracket")
                            (Just "hlint")
                            "Redundant bracket\nFound:\n  (\"hello\")\nWhy not:\n  \"hello\"\n"
               ]

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -51,6 +51,7 @@ import           Haskell.Ide.Engine.Plugin.Example2
 import           Haskell.Ide.Engine.Plugin.GhcMod
 import           Haskell.Ide.Engine.Plugin.HaRe
 
+{-# ANN module ("HLint: ignore Redundant do"       :: String) #-}
 -- ---------------------------------------------------------------------
 
 plugins :: IdePlugins
@@ -124,7 +125,7 @@ functionalSpec = do
                               , _diagnostics = List
                                 [ Diagnostic (Range (Position 9 6) (Position 10 18))
                                              (Just DsInfo)
-                                             Nothing
+                                             (Just "Redundant do")
                                              (Just "hlint")
                                              "Redundant do\nFound:\n  do putStrLn \"hello\"\nWhy not:\n  putStrLn \"hello\"\n"
                                 ]

--- a/test/JsonSpec.hs
+++ b/test/JsonSpec.hs
@@ -20,6 +20,8 @@ import           Test.QuickCheck.Instances     ()
 -- import Debug.Trace
 -- ---------------------------------------------------------------------
 
+{-# ANN module ("HLint: ignore Redundant do"       :: String) #-}
+
 main :: IO ()
 main = hspec spec
 
@@ -48,16 +50,14 @@ propertyJsonRoundtrip a = Success a == fromJSON (toJSON a)
 
 -- enough for our needs
 instance Arbitrary Value where
-  arbitrary = do
-    s <- arbitrary
-    return $ String s
+  arbitrary = String <$> arbitrary
 
 -- | make lists of maximum length 3 for test performance
 smallList :: Gen a -> Gen [a]
 smallList = resize 3 . listOf
 
 instance Arbitrary ApplyOneParams where
-  arbitrary = AOP <$> arbitrary <*> arbitrary
+  arbitrary = AOP <$> arbitrary <*> arbitrary <*>  arbitrary
 
 instance Arbitrary InfoParams where
   arbitrary = IP <$> arbitrary <*> arbitrary


### PR DESCRIPTION
## Improve `hlint` experience
This closes https://github.com/alanz/vscode-hie-server/issues/20 and https://github.com/haskell/haskell-ide-engine/issues/533

Previously `hlint`-related functionality did not work reliably because:
- It was not possible to distinguish between alternative suggestion at the same position
- Some suggestions were ignored by `apply-refact.applyRefactorings` because of a possible misuse of a hint position

I have also found that a temporary file has been used unnecessarily during `hlint`ing and removed it appropriately.