### PR TITLE
Add 'build-docs' action to Makefile that builds haddock docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,15 @@ build:
 		&& cp ~/.local/bin/hie-8.2.2 ~/.local/bin/hie-8.2
 .PHONY: build
 
+build-docs:
+	stack --stack-yaml=stack-8.0.2.yaml exec hoogle generate    \
+	&& stack --stack-yaml=stack-8.2.1.yaml exec hoogle generate \
+	&& stack --stack-yaml=stack.yaml exec hoogle generate
+.PHONY: build-docs
+
+build-all: | build build-docs
+.PHONY: build-all
+
 hie-8.2.2:
 	stack --stack-yaml=stack.yaml install                  \
 		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.2      \

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ $ cd haskell-ide-engine
 To install HIE, you need Stack version >= 1.6.1
 
 To install all supported GHC versions, and name them as expected
-by the vscode plugin, do
+by the vscode plugin, and also build a local hoogle database, do
 
 ```bash
-make
+make build-all
 ```
 
 Otherwise, do one of the following.


### PR DESCRIPTION
The atom integration throws warnings if you don't build the docs, so I've just added this step to the `Makefile`, instead of having to manually replace the `stack.yaml` file three times in:

```
stack --stack-yaml=<stack.yaml you used to build hie> exec hoogle generate
```