### PR TITLE
Update for haskell-lsp 0.2.1.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "submodules/ghc-mod"]
 	path = submodules/ghc-mod
 	url = https://gitlab.com/alanz/ghc-mod.git
-[submodule "submodules/haskell-lsp"]
-	path = submodules/haskell-lsp
-	url = https://github.com/alanz/haskell-lsp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "submodules/ghc-mod"]
 	path = submodules/ghc-mod
 	url = https://gitlab.com/alanz/ghc-mod.git
+[submodule "submodules/haskell-lsp"]
+	path = submodules/haskell-lsp
+	url = https://github.com/alanz/haskell-lsp.git

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -57,7 +57,7 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp >= 0.2
+                     , haskell-lsp >= 0.2.1
                      , haskell-src-exts
                      , hie-plugin-api
                      , hlint >= 2.0.11

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginTypes.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginTypes.hs
@@ -32,19 +32,19 @@ import           Control.Applicative
 import           Data.Aeson
 import qualified Data.Text                             as T
 import           GHC.Generics
-import           Language.Haskell.LSP.TH.DataTypesJSON (Diagnostic (..),
-                                                        DiagnosticSeverity (..),
-                                                        List (..),
-                                                        Location (..),
-                                                        Position (..),
-                                                        PublishDiagnosticsParams (..),
-                                                        Range (..),
-                                                        TextDocumentIdentifier (..),
-                                                        TextDocumentPositionParams (..),
-                                                        Uri (..),
-                                                        WorkspaceEdit (..),
-                                                        filePathToUri,
-                                                        uriToFilePath)
+import           Language.Haskell.LSP.Types (Diagnostic (..),
+                                             DiagnosticSeverity (..),
+                                             List (..),
+                                             Location (..),
+                                             Position (..),
+                                             PublishDiagnosticsParams (..),
+                                             Range (..),
+                                             TextDocumentIdentifier (..),
+                                             TextDocumentPositionParams (..),
+                                             Uri (..),
+                                             WorkspaceEdit (..),
+                                             filePathToUri,
+                                             uriToFilePath)
 
 
 -- ---------------------------------------------------------------------

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -34,7 +34,7 @@ import qualified Data.Text                             as T
 import           FastString
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.ArtifactMap
-import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+import qualified Language.Haskell.LSP.Types            as J
 import           Prelude                               hiding (log)
 import           SrcLoc
 import           System.Directory

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -15,7 +15,7 @@ import qualified Data.Set                              as S
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Types
-import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+import qualified Language.Haskell.LSP.Types            as J
 
 data DispatcherEnv = DispatcherEnv
   { cancelReqsTVar     :: !(TVar (S.Set J.LspId))

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -119,6 +119,7 @@ parseErrorToDiagnostic (Hlint.ParseError l msg contents) =
       , _code     = Just "parser"
       , _source   = Just "hlint"
       , _message  = T.unlines [T.pack msg,T.pack contents]
+      , _relatedInformation = mempty
       }]
 
 {-
@@ -162,6 +163,7 @@ hintToDiagnostic idea
       , _code     = Just (T.pack $ ideaHint idea)
       , _source   = Just "hlint"
       , _message  = idea2Message idea
+      , _relatedInformation = mempty
       }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -90,7 +90,7 @@ opt = Option . Just
 showErr :: BrittanyError -> String
 showErr (ErrorInput s)          = s
 showErr (ErrorMacroConfig  err input)
-  = "Error: parse error in inline configuration:" ++ err ++ " in the string \"" ++ input ++ "\"."
+  = "Error: parse error in inline configuration: " ++ err ++ " in the string \"" ++ input ++ "\"."
 showErr (ErrorUnusedComment s)  = s
 showErr (LayoutWarning s)       = s
 showErr (ErrorUnknownNode s _)  = s

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -14,7 +14,7 @@ import qualified GhcMod.Utils                          as GM
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils
 import           Language.Haskell.Brittany
-import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+import qualified Language.Haskell.LSP.Types            as J
 import           System.FilePath (FilePath, takeDirectory)
 import           Data.Maybe (maybeToList)
 

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -88,9 +88,11 @@ opt :: a -> Option a
 opt = Option . Just
 
 showErr :: BrittanyError -> String
-showErr (ErrorInput s)         = s
-showErr (ErrorUnusedComment s) = s
-showErr (LayoutWarning s)      = s
-showErr (ErrorUnknownNode s _) = s
-showErr ErrorOutputCheck       = "Brittany error - invalid output"
+showErr (ErrorInput s)          = s
+showErr (ErrorMacroConfig  err input)
+  = "Error: parse error in inline configuration:" ++ err ++ " in the string \"" ++ input ++ "\"."
+showErr (ErrorUnusedComment s)  = s
+showErr (LayoutWarning s)       = s
+showErr (ErrorUnknownNode s _)  = s
+showErr ErrorOutputCheck        = "Brittany error - invalid output"
 

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -83,7 +83,7 @@ logDiag rfm eref dref df _reason sev spn style msg = do
     Right (Location uri range) -> do
       let update = Map.insertWith Set.union uri l
             where l = Set.singleton diag
-          diag = Diagnostic range (Just $ lspSev sev) Nothing (Just "ghcmod") msgTxt
+          diag = Diagnostic range (Just $ lspSev sev) Nothing (Just "ghcmod") msgTxt mempty
       modifyIORef' dref update
     Left _ -> do
       modifyIORef' eref (msgTxt:)
@@ -111,7 +111,7 @@ srcErrToDiag df rfm se = do
         eloc <- srcSpan2Loc rfm $ errMsgSpan err
         case eloc of
           Right (Location uri range) ->
-            return $ Right (uri, Diagnostic range sev Nothing (Just "ghcmod") msgTxt)
+            return $ Right (uri, Diagnostic range sev Nothing (Just "ghcmod") msgTxt mempty)
           Left _ -> return $ Left msgTxt
       processMsgs [] = return (Map.empty,[])
       processMsgs (x:xs) = do

--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -40,7 +40,7 @@ import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.Plugin.GhcMod            (setTypecheckedModule)
 import qualified Haskell.Ide.Engine.Plugin.Fuzzy              as Fuzzy
 import           HscTypes
-import qualified Language.Haskell.LSP.TH.DataTypesJSON        as J
+import qualified Language.Haskell.LSP.Types                   as J
 import           Language.Haskell.Refact.API                 (showGhc, showGhcQual, setGhcContext, hsNamessRdr)
 import           Language.Haskell.Refact.Utils.MonadFunctions
 import           Module                                       hiding (getModule)

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -28,7 +28,7 @@ import           Haskell.Ide.Engine.Dispatcher
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.Types
-import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+import qualified Language.Haskell.LSP.Types            as J
 import           System.Exit
 import           System.IO
 import qualified System.Log.Logger                     as L

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -60,7 +60,7 @@ import qualified Language.Haskell.LSP.Core             as Core
 import qualified Language.Haskell.LSP.VFS              as VFS
 import           Language.Haskell.LSP.Diagnostics
 import           Language.Haskell.LSP.Messages
-import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+import qualified Language.Haskell.LSP.Types            as J
 import qualified Language.Haskell.LSP.Utility          as U
 import           System.Exit
 import qualified System.Log.Logger as L
@@ -543,7 +543,7 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp = do
             (J.List diags) = params ^. J.context . J.diagnostics
 
         let
-          makeCommand (J.Diagnostic (J.Range start _) _s (Just code) (Just "hlint") m) = [J.Command title cmd cmdparams]
+          makeCommand (J.Diagnostic (J.Range start _) _s (Just code) (Just "hlint") m _) = [J.Command title cmd cmdparams]
             where
               title :: T.Text
               title = "Apply hint:" <> head (T.lines m)
@@ -552,7 +552,7 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp = do
               -- need 'file', 'start_pos' and hint title (to distinguish between alternative suggestions at the same location)
               args = J.Array $ V.singleton $ J.toJSON $ ApplyRefact.AOP doc start code
               cmdparams = Just args
-          makeCommand (J.Diagnostic _r _s _c _source _m  ) = []
+          makeCommand (J.Diagnostic _r _s _c _source _m _) = []
           -- TODO: make context specific commands for all sorts of things, such as refactorings
         let body = J.List $ concatMap makeCommand diags
         let rspMsg = Core.makeResponseMessage req body
@@ -781,7 +781,7 @@ requestDiagnostics cin file ver = do
     sendOne pid (fileUri,ds) = do
       publishDiagnostics maxToSend fileUri Nothing (Map.fromList [(Just pid,SL.toSortedList ds)])
     hasSeverity :: J.DiagnosticSeverity -> J.Diagnostic -> Bool
-    hasSeverity sev (J.Diagnostic _ (Just s) _ _ _) = s == sev
+    hasSeverity sev (J.Diagnostic _ (Just s) _ _ _ _) = s == sev
     hasSeverity _ _ = False
     sendEmpty = publishDiagnostics maxToSend file Nothing (Map.fromList [(Just "ghcmod",SL.toSortedList [])])
     maxToSend = maybe 50 maxNumberOfProblems mc

--- a/src/Haskell/Ide/Engine/Types.hs
+++ b/src/Haskell/Ide/Engine/Types.hs
@@ -5,7 +5,7 @@
 module Haskell.Ide.Engine.Types where
 
 import           Haskell.Ide.Engine.MonadTypes
-import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+import qualified Language.Haskell.LSP.Types as J
 
 -- ---------------------------------------------------------------------
 

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -18,6 +18,13 @@ packages:
     ./submodules/cabal-helper
   extra-dep: true
 
+- location:
+    ./submodules/haskell-lsp
+  extra-dep: true
+  subdirs:
+    - .
+    - haskell-lsp-types
+
 extra-deps:
 - apply-refact-0.3.0.1
 - brittany-0.10.0.0
@@ -27,11 +34,11 @@ extra-deps:
 - czipwith-1.0.0.0
 - data-tree-print-0.1.0.0
 - deque-0.2
-- ghc-exactprint-0.5.6.0
-- haskell-lsp-0.2.0.1
+- ghc-exactprint-0.5.6.1
 - hlint-2.0.11
 - monad-memo-0.4.1
 - syz-0.2.0.0
+- sorted-list-0.2.1.0
 
 flags:
   haskell-ide-engine:

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -27,18 +27,17 @@ packages:
 
 extra-deps:
 - apply-refact-0.3.0.1
-- brittany-0.10.0.0
-- butcher-1.3.0.0
-# - cabal-helper-0.8.0.2
+- brittany-0.11.0.0
+- butcher-1.3.1.1
 - constrained-dynamic-0.1.0.0
-- czipwith-1.0.0.0
+- czipwith-1.0.1.0
 - data-tree-print-0.1.0.0
 - deque-0.2
 - ghc-exactprint-0.5.6.1
 - hlint-2.0.11
 - monad-memo-0.4.1
-- syz-0.2.0.0
 - sorted-list-0.2.1.0
+- syz-0.2.0.0
 
 flags:
   haskell-ide-engine:

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -18,22 +18,17 @@ packages:
     ./submodules/cabal-helper
   extra-dep: true
 
-- location:
-    ./submodules/haskell-lsp
-  extra-dep: true
-  subdirs:
-    - .
-    - haskell-lsp-types
-
 extra-deps:
 - apply-refact-0.3.0.1
 - brittany-0.11.0.0
 - butcher-1.3.1.1
 - constrained-dynamic-0.1.0.0
 - czipwith-1.0.1.0
-- data-tree-print-0.1.0.0
+- data-tree-print-0.1.0.1
 - deque-0.2
 - ghc-exactprint-0.5.6.1
+- haskell-lsp-0.2.1.0
+- haskell-lsp-types-0.2.1.0
 - hlint-2.0.11
 - monad-memo-0.4.1
 - sorted-list-0.2.1.0

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -18,21 +18,17 @@ packages:
     ./submodules/cabal-helper
   extra-dep: true
 
-- location:
-    ./submodules/haskell-lsp
-  extra-dep: true
-  subdirs:
-    - .
-    - haskell-lsp-types
-
 extra-deps:
 - brittany-0.11.0.0
 - butcher-1.3.1.1
 - constrained-dynamic-0.1.0.0
 - czipwith-1.0.1.0
+- data-tree-print-0.1.0.1
 - ghc-exactprint-0.5.6.1
 - haddock-api-2.18.1
 - haddock-library-1.4.4
+- haskell-lsp-0.2.1.0
+- haskell-lsp-types-0.2.1.0
 - hlint-2.0.11
 - sorted-list-0.2.1.0
 - syz-0.2.0.0

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -18,17 +18,24 @@ packages:
     ./submodules/cabal-helper
   extra-dep: true
 
+- location:
+    ./submodules/haskell-lsp
+  extra-dep: true
+  subdirs:
+    - .
+    - haskell-lsp-types
+
 extra-deps:
 - brittany-0.10.0.0
 - butcher-1.3.0.0
 # - cabal-helper-0.8.0.2
 - constrained-dynamic-0.1.0.0
-- ghc-exactprint-0.5.6.0
+- ghc-exactprint-0.5.6.1
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.2.0.1
 - hlint-2.0.11
 - syz-0.2.0.0
+- sorted-list-0.2.1.0
 
 flags:
   haskell-ide-engine:

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -26,16 +26,16 @@ packages:
     - haskell-lsp-types
 
 extra-deps:
-- brittany-0.10.0.0
-- butcher-1.3.0.0
-# - cabal-helper-0.8.0.2
+- brittany-0.11.0.0
+- butcher-1.3.1.1
 - constrained-dynamic-0.1.0.0
+- czipwith-1.0.1.0
 - ghc-exactprint-0.5.6.1
 - haddock-api-2.18.1
 - haddock-library-1.4.4
 - hlint-2.0.11
-- syz-0.2.0.0
 - sorted-list-0.2.1.0
+- syz-0.2.0.0
 
 flags:
   haskell-ide-engine:

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,20 +18,17 @@ packages:
     ./submodules/cabal-helper
   extra-dep: true
 
-- location:
-    ./submodules/haskell-lsp
-  extra-dep: true
-  subdirs:
-    - .
-    - haskell-lsp-types
 
 extra-deps:
 - brittany-0.11.0.0
 - butcher-1.3.1.1
 - constrained-dynamic-0.1.0.0
 - czipwith-1.0.1.0
+- data-tree-print-0.1.0.1
 - haddock-api-2.18.1
 - haddock-library-1.4.4
+- haskell-lsp-0.2.1.0
+- haskell-lsp-types-0.2.1.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,13 +26,14 @@ packages:
     - haskell-lsp-types
 
 extra-deps:
-- brittany-0.10.0.0
-# - cabal-helper-0.8.0.2
+- brittany-0.11.0.0
+- butcher-1.3.1.1
 - constrained-dynamic-0.1.0.0
+- czipwith-1.0.1.0
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- syz-0.2.0.0
 - sorted-list-0.2.1.0
+- syz-0.2.0.0
 
 flags:
   haskell-ide-engine:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.6
+resolver: lts-11.7
 packages:
 - .
 - hie-plugin-api
@@ -18,6 +18,13 @@ packages:
     ./submodules/cabal-helper
   extra-dep: true
 
+- location:
+    ./submodules/haskell-lsp
+  extra-dep: true
+  subdirs:
+    - .
+    - haskell-lsp-types
+
 extra-deps:
 - brittany-0.10.0.0
 # - cabal-helper-0.8.0.2
@@ -25,6 +32,7 @@ extra-deps:
 - haddock-api-2.18.1
 - haddock-library-1.4.4
 - syz-0.2.0.0
+- sorted-list-0.2.1.0
 
 flags:
   haskell-ide-engine:

--- a/test/DispatcherSpec.hs
+++ b/test/DispatcherSpec.hs
@@ -13,7 +13,7 @@ import           Haskell.Ide.Engine.Monad
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.Types
-import qualified Language.Haskell.LSP.TH.DataTypesJSON as J
+import qualified Language.Haskell.LSP.Types            as J
 import           TestUtils
 
 import           Test.Hspec

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -35,7 +35,7 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.Types
-import           Language.Haskell.LSP.TH.DataTypesJSON hiding (error, name)
+import           Language.Haskell.LSP.Types hiding (error, name)
 import           System.Directory
 import           System.FilePath
 import           TestUtils
@@ -116,22 +116,23 @@ functionalSpec = do
 
       -- -------------------------------
 
-      let req1 = filePathToUri "./FuncTest.hs"
+      let req1 = filePathToUri $ cwd </> "FuncTest.hs"
       r1 <- dispatchRequest cin "applyrefact" "lint" req1
       fmap fromDynJSON r1 `shouldBe` IdeResponseOk
                            ( Just
                            $ PublishDiagnosticsParams
-                              { _uri = filePathToUri "./FuncTest.hs"
+                              { _uri = filePathToUri $ cwd </> "FuncTest.hs"
                               , _diagnostics = List
                                 [ Diagnostic (Range (Position 9 6) (Position 10 18))
                                              (Just DsInfo)
                                              (Just "Redundant do")
                                              (Just "hlint")
                                              "Redundant do\nFound:\n  do putStrLn \"hello\"\nWhy not:\n  putStrLn \"hello\"\n"
+                                             mempty
                                 ]
                               })
 
-      let req3 = HP (filePathToUri "./FuncTest.hs") (toPos (8,1))
+      let req3 = HP (filePathToUri $ cwd </> "FuncTest.hs") (toPos (8,1))
       r3 <- dispatchRequest cin "hare" "demote" req3
       fmap fromDynJSON r3 `shouldBe`
         (IdeResponseOk

--- a/test/HaRePluginSpec.hs
+++ b/test/HaRePluginSpec.hs
@@ -10,7 +10,7 @@ import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.Plugin.GhcMod
 import           Haskell.Ide.Engine.Plugin.HaRe
 import           Haskell.Ide.Engine.Plugin.HieExtras
-import           Language.Haskell.LSP.TH.DataTypesJSON (Location(..), TextEdit(..))
+import           Language.Haskell.LSP.Types (Location(..), TextEdit(..))
 import           System.Directory
 import           System.FilePath
 import           TestUtils
@@ -49,7 +49,7 @@ hareSpec = do
 
     it "renames" $ cdAndDo "test/testdata" $ do
 
-      let uri = filePathToUri "./HaReRename.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/HaReRename.hs"
           act = renameCmd' uri (toPos (5,1)) "foolong"
           arg = HPT uri (toPos (5,1)) "foolong"
           res = IdeResponseOk $ WorkspaceEdit
@@ -62,7 +62,7 @@ hareSpec = do
     -- ---------------------------------
 
     it "returns an error for invalid rename" $ cdAndDo "test/testdata" $ do
-      let uri = filePathToUri "./HaReRename.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/HaReRename.hs"
           act = renameCmd' uri (toPos (15,1)) "foolong"
           arg = HPT uri (toPos (15,1)) "foolong"
           res = IdeResponseFail
@@ -73,7 +73,7 @@ hareSpec = do
     -- ---------------------------------
 
     it "demotes" $ cdAndDo "test/testdata" $ do
-      let uri = filePathToUri "./HaReDemote.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/HaReDemote.hs"
           act = demoteCmd' uri (toPos (6,1))
           arg = HP uri (toPos (6,1))
           res = IdeResponseOk $ WorkspaceEdit
@@ -86,7 +86,7 @@ hareSpec = do
     -- ---------------------------------
 
     it "duplicates a definition" $ cdAndDo "test/testdata" $ do
-      let uri = filePathToUri "./HaReRename.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/HaReRename.hs"
           act = dupdefCmd' uri (toPos (5,1)) "foonew"
           arg = HPT uri (toPos (5,1)) "foonew"
           res = IdeResponseOk $ WorkspaceEdit
@@ -100,7 +100,7 @@ hareSpec = do
 
     it "converts if to case" $ cdAndDo "test/testdata" $ do
 
-      let uri = filePathToUri "./HaReCase.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/HaReCase.hs"
           act = iftocaseCmd' uri (Range (toPos (5,9))
                                         (toPos (9,12)))
           arg = HR uri (toPos (5,9)) (toPos (9,12))
@@ -116,7 +116,7 @@ hareSpec = do
 
     it "lifts one level" $ cdAndDo "test/testdata" $ do
 
-      let uri = filePathToUri "./HaReMoveDef.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/HaReMoveDef.hs"
           act = liftonelevelCmd' uri (toPos (6,5))
           arg = HP uri (toPos (6,5))
           res = IdeResponseOk $ WorkspaceEdit
@@ -132,7 +132,7 @@ hareSpec = do
 
     it "lifts to top level" $ cdAndDo "test/testdata" $ do
 
-      let uri = filePathToUri "./HaReMoveDef.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/HaReMoveDef.hs"
           act = lifttotoplevelCmd' uri (toPos (12,9))
           arg = HP uri (toPos (12,9))
           res = IdeResponseOk $ WorkspaceEdit
@@ -148,7 +148,7 @@ hareSpec = do
     -- ---------------------------------
 
     it "deletes a definition" $ cdAndDo "test/testdata" $ do
-      let uri = filePathToUri "./FuncTest.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/FuncTest.hs"
           act = deleteDefCmd' uri (toPos (6,1))
           arg = HP uri (toPos (6,1))
           res = IdeResponseOk $ WorkspaceEdit
@@ -160,7 +160,7 @@ hareSpec = do
     -- ---------------------------------
 
     it "generalises an applicative" $ cdAndDo "test/testdata" $ do
-      let uri = filePathToUri "./HaReGA1.hs"
+      let uri = filePathToUri $ cwd </> "test/testdata/HaReGA1.hs"
           act = genApplicativeCommand' uri (toPos (4,1))
           arg = HP uri (toPos (4,1))
           res = IdeResponseOk $ WorkspaceEdit
@@ -176,7 +176,7 @@ hareSpec = do
     cwd <- runIO getCurrentDirectory
 
     it "finds definition across components" $ do
-      let u = filePathToUri "./app/Main.hs"
+      let u = filePathToUri $ cwd </> "test/testdata/gototest/app/Main.hs"
           lreq = setTypecheckedModule u
           req = findDef u (toPos (7,8))
       r <- dispatchRequestPGoto $ lreq >> req
@@ -187,14 +187,14 @@ hareSpec = do
       r2 `shouldBe` IdeResponseOk [Location (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib2.hs")
                                             (Range (toPos (5,1)) (toPos (5,2)))]
     it "finds definition in the same component" $ do
-      let u = filePathToUri "./src/Lib2.hs"
+      let u = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib2.hs"
           lreq = setTypecheckedModule u
           req = findDef u (toPos (6,5))
       r <- dispatchRequestPGoto $ lreq >> req
       r `shouldBe` IdeResponseOk [Location (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs")
                                            (Range (toPos (6,1)) (toPos (6,9)))]
     it "finds local definitions" $ do
-      let u = filePathToUri "./src/Lib2.hs"
+      let u = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib2.hs"
           lreq = setTypecheckedModule u
           req = findDef u (toPos (7,11))
       r <- dispatchRequestPGoto $ lreq >> req


### PR DESCRIPTION
This is to match the upcoming change in the https://github.com/alanz/haskell-ide-engine/tree/ghc-8.4 branch, and will then create a hie-0.1.0.0 branch, which will be the last to support GHC 8.0.2.