### PR TITLE
Dignostic relatedInformation is optional in LSP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 	path = submodules/yi-rope
         url = https://github.com/yi-editor/yi-rope.git
 
+[submodule "submodules/haskell-lsp"]
+	path = submodules/haskell-lsp
+	url = https://github.com/alanz/haskell-lsp.git

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -58,7 +58,7 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp >= 0.2.1
+                     , haskell-lsp >= 0.2.2
                      , haskell-src-exts
                      , hie-plugin-api
                      , hlint >= 2.0.11

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -119,7 +119,7 @@ parseErrorToDiagnostic (Hlint.ParseError l msg contents) =
       , _code     = Just "parser"
       , _source   = Just "hlint"
       , _message  = T.unlines [T.pack msg,T.pack contents]
-      , _relatedInformation = List []
+      , _relatedInformation = Nothing
       }]
 
 {-
@@ -163,7 +163,7 @@ hintToDiagnostic idea
       , _code     = Just (T.pack $ ideaHint idea)
       , _source   = Just "hlint"
       , _message  = idea2Message idea
-      , _relatedInformation = List []
+      , _relatedInformation = Nothing
       }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -85,7 +85,7 @@ logDiag rfm eref dref df _reason sev spn style msg = do
     Right (Location uri range) -> do
       let update = Map.insertWith Set.union uri l
             where l = Set.singleton diag
-          diag = Diagnostic range (Just $ lspSev sev) Nothing (Just "ghcmod") msgTxt (List [])
+          diag = Diagnostic range (Just $ lspSev sev) Nothing (Just "ghcmod") msgTxt Nothing
       modifyIORef' dref update
     Left _ -> do
       modifyIORef' eref (msgTxt:)
@@ -113,7 +113,7 @@ srcErrToDiag df rfm se = do
         eloc <- srcSpan2Loc rfm $ errMsgSpan err
         case eloc of
           Right (Location uri range) ->
-            return $ Right (uri, Diagnostic range sev Nothing (Just "ghcmod") msgTxt (List []))
+            return $ Right (uri, Diagnostic range sev Nothing (Just "ghcmod") msgTxt Nothing)
           Left _ -> return $ Left msgTxt
       processMsgs [] = return (Map.empty,[])
       processMsgs (x:xs) = do

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -42,8 +42,8 @@ extra-deps:
 - data-tree-print-0.1.0.1
 - deque-0.2.1
 - ghc-exactprint-0.5.6.1
-- haskell-lsp-0.2.1.0
-- haskell-lsp-types-0.2.1.0
+- haskell-lsp-0.2.2.0
+- haskell-lsp-types-0.2.2.0
 - hlint-2.0.11
 - monad-memo-0.4.1
 - sorted-list-0.2.1.0

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -31,8 +31,8 @@ extra-deps:
 - ghc-exactprint-0.5.6.1
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.2.1.0
-- haskell-lsp-types-0.2.1.0
+- haskell-lsp-0.2.2.0
+- haskell-lsp-types-0.2.2.0
 - hlint-2.0.11
 - sorted-list-0.2.1.0
 - syz-0.2.0.0

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -29,8 +29,8 @@ extra-deps:
 - czipwith-1.0.1.0
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.2.1.0
-- haskell-lsp-types-0.2.1.0
+- haskell-lsp-0.2.2.0
+- haskell-lsp-types-0.2.2.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,6 @@ packages:
     ./submodules/yi-rope
   extra-dep: true
 
-
 extra-deps:
 - apply-refact-0.5.0.0
 - brittany-0.11.0.0
@@ -31,8 +30,8 @@ extra-deps:
 - czipwith-1.0.1.0
 - data-tree-print-0.1.0.1
 - haddock-api-2.19.0.1
-- haskell-lsp-0.2.1.0
-- haskell-lsp-types-0.2.1.0
+- haskell-lsp-0.2.2.0
+- haskell-lsp-types-0.2.2.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 

--- a/test/ApplyRefactPluginSpec.hs
+++ b/test/ApplyRefactPluginSpec.hs
@@ -81,13 +81,13 @@ applyRefactSpec = do
                             (Just "Redundant bracket")
                             (Just "hlint")
                             "Redundant bracket\nFound:\n  (putStrLn \"hello\")\nWhy not:\n  putStrLn \"hello\"\n"
-                            (List [])
+                            Nothing
                , Diagnostic (Range (Position 3 8) (Position 3 15))
                             (Just DsHint)
                             (Just "Redundant bracket")
                             (Just "hlint")
                             "Redundant bracket\nFound:\n  (x + 1)\nWhy not:\n  x + 1\n"
-                            (List [])
+                            Nothing
                ]}
       testCommand testPlugins act "applyrefact" "lint" arg res
 
@@ -108,7 +108,7 @@ applyRefactSpec = do
                            , _code = Just "parser"
                            , _source = Just "hlint"
                            , _message = "Parse error: :~:\n  import           Data.Type.Equality            ((:~:) (..), (:~~:) (..))\n  \n> data instance Sing (z :: (a :~: b)) where\n      SRefl :: Sing Refl\n\n"
-                           , _relatedInformation = List [] }]}
+                           , _relatedInformation = Nothing }]}
       testCommand testPlugins act "applyrefact" "lint" arg res
 
     -- ---------------------------------
@@ -128,7 +128,7 @@ applyRefactSpec = do
                            (Just "Redundant bracket")
                            (Just "hlint")
                            "Redundant bracket\nFound:\n  (\"hello\")\nWhy not:\n  \"hello\"\n"
-                           (List [])
+                           Nothing
               ]
             }
            ))

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -127,7 +127,7 @@ functionalSpec = do
                                              (Just "Redundant do")
                                              (Just "hlint")
                                              "Redundant do\nFound:\n  do putStrLn \"hello\"\nWhy not:\n  putStrLn \"hello\"\n"
-                                             (List [])
+                                             Nothing
                                 ]
                               })
 

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -50,7 +50,7 @@ ghcmodSpec = do
                             Nothing
                             (Just "ghcmod")
                             "Variable not in scope: x"
-                            (List [])
+                            Nothing
 
       testCommand testPlugins act "ghcmod" "check" arg res
 


### PR DESCRIPTION
Match changes in `haskell-lsp-types`

vscode was unhappy with non-optional relatedInformation field in a Diagnostic.

cc @Bubba 