### PR TITLE
Don't provide code actions for diagnostics that hlint doesn't have refactorings for

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -272,3 +272,25 @@ makeDiffResult orig new fileMap = do
   let fp' = fileMap orig
   fp <- GM.makeAbsolute' fp'
   return $ diffText (filePathToUri fp,origText) new
+
+-- | Removes diagnostics that can't be refactored automatically by HLint
+filterUnrefactorableDiagnostics :: Uri -> [Diagnostic] -> IdeGhcM (IdeResponse [Diagnostic])
+filterUnrefactorableDiagnostics uri diags = do
+    maybeIdeas <- pluginGetFile "filterUnrefactorableDiagnostics: " uri $ \fp -> do
+      res <- GM.withMappedFile fp $ \file' -> liftIO $ runExceptT $ getIdeas file' Nothing :: IdeGhcM (Either String [Idea])
+      case res of
+        Left err -> return $ IdeResponseFail (IdeError PluginError
+          (T.pack $ "filterUnrefactorableDiagnostics: " ++ show err) Null)
+        Right ideas -> return $ IdeResponseOk ideas
+
+    case maybeIdeas of
+      Left err -> return $ Left err
+      Right ideas ->
+        let hasRefactoring :: Diagnostic -> Bool
+            hasRefactoring diag = let matches = filter ((== diag) . hintToDiagnostic) ideas
+                in if null matches
+                  -- by default we don't want to throw away refactorings just because we can't find a match
+                  then True
+                  -- otherwise make sure the matched idea has a possible refactoring
+                  else (not . null . ideaRefactoring) $ head matches
+            in return $ IdeResponseOk $ filter hasRefactoring diags

--- a/test/ApplyRefactPluginSpec.hs
+++ b/test/ApplyRefactPluginSpec.hs
@@ -148,3 +148,24 @@ applyRefactSpec = do
             , _diagnostics = List []
             }
            ))
+
+    -- ---------------------------------
+    
+    it "filters code actions for hlint ideas with no refactorings" $ do
+      filePath <- filePathToUri <$> makeAbsolute "./test/testdata/HlintNoRefactorings.hs"
+
+      let diagsReq = lintCmd' filePath
+      (IdeResponseOk (PublishDiagnosticsParams _ (List diags))) <- runIGM testPlugins diagsReq
+
+      let req = filterUnrefactorableDiagnostics filePath diags
+      res <- runIGM testPlugins req
+      res `shouldBe`
+        (IdeResponseOk
+          [ Diagnostic (Range (Position 3 8) (Position 3 13))
+                      (Just DsInfo)
+                      (Just "Evaluate")
+                      (Just "hlint")
+                      "Evaluate\nFound:\n  id 42\nWhy not:\n  42\n"
+                      Nothing
+          ]
+        )

--- a/test/testdata/HlintNoRefactorings.hs
+++ b/test/testdata/HlintNoRefactorings.hs
@@ -1,0 +1,4 @@
+main = putStrLn "hello"
+
+foo x = putStrLn x
+bar y = id 42


### PR DESCRIPTION
This changes the code action request reactor to send a request to hlint.
It can use this information to determine if any of the diagnostics coming from the LSP client are actionable, and filter out the ones that aren't.

Fixes alanz/vscode-hie-server#61