### PR TITLE
stack-8.0.2.yaml: remove unused submodules

### DIFF
--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -8,10 +8,6 @@ packages:
   extra-dep: true
 
 - location:
-    ./submodules/brittany
-  extra-dep: true
-
-- location:
     ./submodules/cabal-helper
   extra-dep: true
 

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -19,13 +19,6 @@ packages:
     - core
 
 - location:
-    ./submodules/haskell-lsp
-  extra-dep: true
-  subdirs:
-    - .
-    - haskell-lsp-types
-
-- location:
     ./submodules/yi-rope
   extra-dep: true
 


### PR DESCRIPTION
Seems like brittany is not in submodules anymore.