### PR TITLE
Make symbol requests check the module if no cache is available

### DIFF
--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -725,10 +725,10 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp = do
         liftIO $ U.logs $ "reactor:got Document symbol request:" ++ show req
         let uri = req ^. J.params . J.textDocument . J.uri
         callback <- hieResponseHelper (req ^. J.id) $ \docSymbols -> do
-            let rspMsg = Core.makeResponseMessage req $ J.List docSymbols
-            reactorSend rspMsg
-        let hreq = IReq (req ^. J.id) callback
-                 $ Hie.getSymbols uri
+          let rspMsg = Core.makeResponseMessage req $ J.List docSymbols
+          reactorSend rspMsg
+        let hreq = GReq (Just uri) Nothing (Just $ req ^. J.id) callback
+                   $ Hie.getSymbols uri
         makeRequest hreq
 
       -- -------------------------------


### PR DESCRIPTION
Currently if you make a document symbol request as soon as the server starts, you get an empty list as a response, usually since there is no cached module available.

This was causing problems with [noughtmare/haskell-lsp-client](https://github.com/noughtmare/haskell-lsp-client/tree/233eec4515844e3ec22ff2ec5cb28d565061dfc5), so this PR forces the module to be checked whenever there is no cache available to use during the request.