### PR TITLE
[WIP] Add a queue for module caches

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -118,7 +118,7 @@ run opts = do
     dispatcherProcP :: DispatcherEnv -> IO ()
     dispatcherProcP dispatcherEnv =
         void $ runIdeGhcM ghcModOptions
-            (IdeState emptyModuleCache plugins Map.empty Nothing)
+            (IdeState emptyModuleCache Map.empty plugins Map.empty Nothing)
             (dispatcherP dispatcherEnv pin)
 
   if optLsp opts then

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -33,7 +33,12 @@ data CachedModule = CachedModule
   , oldPosToNew :: Position -> Maybe Position
   }
 
-getCachedModule :: Uri -> IdeM (Maybe CachedModule)
+data CachedModuleResult = ModuleLoading
+                        | ModuleFailed String
+                        | ModuleCached CachedModule
+                        | ModuleStale CachedModule
+
+getCachedModule :: Uri -> IdeM CachedModuleResult
 ```
 
 On every file open or edit, HIE tries to load a `TypecheckedModule`(as defined in the ghc api)

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -35,8 +35,8 @@ data CachedModule = CachedModule
 
 data CachedModuleResult = ModuleLoading
                         | ModuleFailed String
-                        | ModuleCached CachedModule
-                        | ModuleStale CachedModule
+                        | ModuleCached CachedModule IsStale
+type IsStale = Bool
 
 getCachedModule :: Uri -> IdeM CachedModuleResult
 ```

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -116,6 +116,7 @@ test-suite haskell-ide-test
                        GhcModPluginSpec
                        HaRePluginSpec
                        HooglePluginSpec
+                       IdeResponseSpec
                        JsonSpec
                        Spec
                        TestUtils
@@ -151,6 +152,7 @@ test-suite haskell-ide-dispatcher-test
                        GhcModPluginSpec
                        HaRePluginSpec
                        HooglePluginSpec
+                       IdeResponseSpec
                        JsonSpec
                        Spec
                        TestUtils

--- a/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
@@ -15,12 +15,12 @@ import           GHC                               (TypecheckedModule)
 import Haskell.Ide.Engine.ArtifactMap
 import Haskell.Ide.Engine.PluginTypes
 
-
 type UriCaches = Map.Map FilePath UriCache
 
 data UriCache = UriCache
   { cachedModule :: !CachedModule
   , cachedData   :: !(Map.Map TypeRep Dynamic)
+  , isStale    :: Bool
   } deriving Show
 
 data CachedModule = CachedModule

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -159,19 +159,19 @@ withCachedModuleAndData uri noCache callback = do
 
 -- | Saves a module to the cache and executes any queued actions for it
 cacheModule :: FilePath -> CachedModule -> IdeGhcM ()
-cacheModule uri cm = do
-  uri'    <- liftIO $ canonicalizePath uri
+cacheModule fp cm = do
+  fp'    <- liftIO $ canonicalizePath fp
 
   -- execute any queued actions for the module
-  actions <- fmap (fromMaybe [] . Map.lookup uri') (actionQueue <$> readMTS)
+  actions <- fmap (fromMaybe [] . Map.lookup fp') (actionQueue <$> readMTS)
   liftToGhc $ forM_ actions (\a -> a cm)
 
   -- remove queued actions
-  modifyMTS $ \s -> s { actionQueue = Map.delete uri' (actionQueue s) }
+  modifyMTS $ \s -> s { actionQueue = Map.delete fp' (actionQueue s) }
 
   modifyCache
     (\gmc -> gmc
-      { uriCaches = Map.insert uri'
+      { uriCaches = Map.insert fp'
                                (UriCache cm Map.empty False)
                                (uriCaches gmc)
       }

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -81,7 +81,7 @@ getCradle fp = do
           -- | The possible states the cache can be in
             -- along with the cache or error if present
 data CachedModuleResult = ModuleLoading
-                        | ModuleFailed String
+                        | ModuleFailed IdeError
                         | ModuleCached CachedModule IsStale
 type IsStale = Bool
   

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -102,6 +102,7 @@ getCachedModule :: (GM.MonadIO m, HasGhcModuleCache m, MonadMTState IdeState m)
 getCachedModule uri = do
   uri' <- liftIO $ canonicalizePath uri
   maybeUriCache <- fmap (Map.lookup uri' . uriCaches) getModuleCache
+  -- TODO: Figure out how to tell if a module failed to load
   return $ case maybeUriCache of
     Nothing -> ModuleLoading
     Just uriCache ->

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginTypes.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginTypes.hs
@@ -4,16 +4,8 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Haskell.Ide.Engine.PluginTypes
   (
-  -- * Interface types
-    IdeFailure(..)
-  , IdeResponse
-  , pattern IdeResponseOk
-  , pattern IdeResponseError
-  , pattern IdeResponseFail
-  , IdeError(..)
-  , IdeErrorCode(..)
   -- * LSP types
-  , Uri(..)
+    Uri(..)
   , uriToFilePath
   , filePathToUri
   , Position(..)
@@ -27,11 +19,7 @@ module Haskell.Ide.Engine.PluginTypes
   , PublishDiagnosticsParams(..)
   , List(..)
   ) where
-
-import           Control.Applicative
-import           Data.Aeson
-import qualified Data.Text                             as T
-import           GHC.Generics
+    
 import           Language.Haskell.LSP.Types (Diagnostic (..),
                                              DiagnosticSeverity (..),
                                              List (..),
@@ -45,58 +33,3 @@ import           Language.Haskell.LSP.Types (Diagnostic (..),
                                              WorkspaceEdit (..),
                                              filePathToUri,
                                              uriToFilePath)
-
-
--- ---------------------------------------------------------------------
-
-data IdeFailure = IdeRFail IdeError
-                | IdeRErr  IdeError
-                deriving(Show, Eq, Generic)
-
-instance ToJSON IdeFailure where
- toJSON (IdeRFail v) = object [ "fail" .= v ]
- toJSON (IdeRErr v)  = object [ "error" .= v ]
-
-instance FromJSON IdeFailure where
-  parseJSON = withObject "IdeFailure" $ \v -> do
-   mf <- fmap IdeRFail <$> v .:? "fail"
-   me <- fmap IdeRErr <$> v .:? "error"
-   case mf <|> me of
-     Just r  -> return r
-     Nothing -> empty
-
--- | The IDE response, with the type of response it contains
-type IdeResponse a = Either IdeFailure a
-pattern IdeResponseOk :: a -> IdeResponse a
-pattern IdeResponseOk a = Right a
-pattern IdeResponseFail :: IdeError -> IdeResponse a
-pattern IdeResponseFail a = Left (IdeRFail a)
-pattern IdeResponseError :: IdeError -> IdeResponse a
-pattern IdeResponseError a = Left (IdeRErr a)
-
--- | Error codes. Add as required
-data IdeErrorCode
- = ParameterError          -- ^ Wrong parameter type
- | PluginError             -- ^ An error returned by a plugin
- | InternalError           -- ^ Code error (case not handled or deemed
-                           --   impossible)
- | UnknownPlugin           -- ^ Plugin is not registered
- | UnknownCommand          -- ^ Command is not registered
- | InvalidContext          -- ^ Context invalid for command
- | OtherError              -- ^ An error for which there's no better code
- | ParseError              -- ^ Input could not be parsed
- deriving (Show,Read,Eq,Ord,Bounded,Enum,Generic)
-
-instance ToJSON IdeErrorCode
-instance FromJSON IdeErrorCode
-
--- | A more structured error than just a string
-data IdeError = IdeError
- { ideCode    :: IdeErrorCode -- ^ The error code
- , ideMessage :: T.Text       -- ^ A human readable message
- , ideInfo    :: Value        -- ^ Additional information
- }
- deriving (Show,Read,Eq,Generic)
-
-instance ToJSON IdeError
-instance FromJSON IdeError

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -87,9 +87,11 @@ liftToGhc = lift . lift
 
 data IdeState = IdeState
   { moduleCache :: GhcModuleCache
+  -- | A queue of actions to be performed once the module is loaded
+  , actionQueue :: Map.Map FilePath [CachedModule -> IdeM ()]
   , idePlugins  :: IdePlugins
   , extensibleState :: !(Map.Map TypeRep Dynamic)
-  , ghcSession  :: (Maybe (IORef HscEnv))
+  , ghcSession  :: Maybe (IORef HscEnv)
   }
 
 instance HasGhcModuleCache IdeM where

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -87,7 +87,7 @@ liftToGhc = lift . lift
 
 data IdeState = IdeState
   { moduleCache :: GhcModuleCache
-  -- | A queue of actions to be performed once the module is loaded
+  -- | A queue of actions to be performed once a module is loaded
   , actionQueue :: Map.Map FilePath [CachedModule -> IdeM ()]
   , idePlugins  :: IdePlugins
   , extensibleState :: !(Map.Map TypeRep Dynamic)

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -287,6 +287,9 @@ filterUnrefactorableDiagnostics uri diags = do
       Left err -> return $ Left err
       Right ideas ->
         let hasRefactoring :: Diagnostic -> Bool
-            hasRefactoring diag = let matches = filter ((== diag) . hintToDiagnostic) ideas
-                in null matches || (not . null . ideaRefactoring) $ head matches
+            hasRefactoring diag =
+              let matches = filter ((== diag) . hintToDiagnostic) ideas
+              -- by default we don't want to throw away refactorings just because we can't find a match
+              -- otherwise make sure the matched idea has a possible refactoring
+                in null matches || (not . null . ideaRefactoring) (head matches)
             in return $ IdeResponseOk $ filter hasRefactoring diags

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -288,9 +288,5 @@ filterUnrefactorableDiagnostics uri diags = do
       Right ideas ->
         let hasRefactoring :: Diagnostic -> Bool
             hasRefactoring diag = let matches = filter ((== diag) . hintToDiagnostic) ideas
-                in if null matches
-                  -- by default we don't want to throw away refactorings just because we can't find a match
-                  then True
-                  -- otherwise make sure the matched idea has a possible refactoring
-                  else (not . null . ideaRefactoring) $ head matches
+                in null matches || (not . null . ideaRefactoring) $ head matches
             in return $ IdeResponseOk $ filter hasRefactoring diags

--- a/src/Haskell/Ide/Engine/Plugin/Base.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Base.hs
@@ -62,13 +62,13 @@ commandDetailCmd :: CommandFunc (T.Text, T.Text) T.Text
 commandDetailCmd = CmdSync $ \(p,command) -> do
   IdePlugins plugins <- getPlugins
   case Map.lookup p plugins of
-    Nothing -> return $ IdeResponseError $ IdeError
+    Nothing -> return $ IdeResponseFail $ IdeError
       { ideCode = UnknownPlugin
       , ideMessage = "Can't find plugin:" <> p
       , ideInfo = toJSON p
       }
     Just pl -> case find (\cmd -> command == (commandName cmd) ) pl of
-      Nothing -> return $ IdeResponseError $ IdeError
+      Nothing -> return $ IdeResponseFail $ IdeError
         { ideCode = UnknownCommand
         , ideMessage = "Can't find command:" <> command
         , ideInfo = toJSON command

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -92,13 +92,6 @@ logDiag rfm eref dref df _reason sev spn style msg = do
       modifyIORef' eref (msgTxt:)
       return ()
 
-unhelpfulSrcSpanErr :: T.Text -> IdeFailure
-unhelpfulSrcSpanErr err =
-  IdeRFail $
-    IdeError PluginError
-             ("Unhelpful SrcSpan" <> ": \"" <> err <> "\"")
-             Null
-
 srcErrToDiag :: MonadIO m
   => DynFlags
   -> (FilePath -> FilePath)
@@ -219,7 +212,7 @@ instance ToJSON TypeParams where
   toJSON = genericToJSON customOptions
 
 typeCmd :: CommandFunc TypeParams [(Range,T.Text)]
-typeCmd = CmdSync $ \(TP _bool uri pos) -> liftToGhc $ newTypeCmd pos uri
+typeCmd = CmdSync $ \(TP _bool uri pos) -> liftIdeGhcM $ newTypeCmd pos uri
 
 newTypeCmd :: Position -> Uri -> IdeM (IdeResponse [(Range, T.Text)])
 newTypeCmd newPos uri =

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -227,8 +227,7 @@ newTypeCmd newPos uri =
   pluginGetFile "newTypeCmd: " uri $ \fp -> do
       mcm <- getCachedModule fp
       return $ case mcm of
-        ModuleCached cm -> IdeResponseOk $ pureTypeCmd newPos cm
-        ModuleStale cm -> IdeResponseOk $ pureTypeCmd newPos cm
+        ModuleCached cm _ -> IdeResponseOk $ pureTypeCmd newPos cm
         _ -> IdeResponseOk []
 
 pureTypeCmd :: Position -> CachedModule -> [(Range,T.Text)]

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -154,7 +154,6 @@ myLogger rfm action = do
 setTypecheckedModule :: Uri -> IdeGhcM (IdeResponse (Diagnostics, AdditionalErrs))
 setTypecheckedModule uri =
   pluginGetFile "setTypecheckedModule: " uri $ \fp -> do
-    markCacheStale fp
     fileMap <- GM.getMMappedFiles
     debugm $ "setTypecheckedModule: file mapping state is: " ++ show fileMap
     rfm <- GM.mkRevRedirMapFunc

--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -101,7 +101,7 @@ instance ModuleCache NameMapData where
 -- ---------------------------------------------------------------------
 
 getSymbols :: Uri -> (IdeResponse [J.SymbolInformation] -> IdeM ()) -> IdeM ()
-getSymbols uri callback = do
+getSymbols uri callback =
   case uriToFilePath uri of 
     Nothing -> callback $ IdeResponseFail (IdeError PluginError ("getSymbols" <> "Couldn't resolve uri" <> getUri uri) Null)
     Just file -> do

--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -102,98 +102,87 @@ instance ModuleCache NameMapData where
 
 getSymbols :: Uri -> IdeGhcM (IdeResponse [J.SymbolInformation])
 getSymbols uri = pluginGetFile "getSymbols: " uri $ \file -> do
-    mcm <- getCachedModule file
-    case mcm of
-      Nothing -> do
-        -- module may not have been cached yet, so do it now
-        _ <- setTypecheckedModule uri
-        mNewcm <- getCachedModule file
-        case mNewcm of
-          Nothing -> return $ IdeResponseOk []
-          Just newCm -> liftToGhc $ getSymbolsFromModule newCm
-      Just cm -> liftToGhc $ getSymbolsFromModule cm
+  let noCache = return $ nonExistentCacheErr "getSymbols"
+  withCachedModule file noCache $ \cm -> liftToGhc $ do
+    let tm = tcMod cm
+        rfm = revMap cm
+        hsMod = unLoc $ pm_parsed_source $ tm_parsed_module tm
+        imports = hsmodImports hsMod
+        imps  = concatMap (goImport . unLoc) imports
+        decls = concatMap (go . unLoc) $ hsmodDecls hsMod
+        s x = showName <$> x
 
-getSymbolsFromModule :: CachedModule -> IdeM (IdeResponse [J.SymbolInformation])
-getSymbolsFromModule cm = do
-  let tm = tcMod cm
-      rfm = revMap cm
-      hsMod = unLoc $ pm_parsed_source $ tm_parsed_module tm
-      imports = hsmodImports hsMod
-      imps  = concatMap (goImport . unLoc) imports
-      decls = concatMap (go . unLoc) $ hsmodDecls hsMod
-      s x = showName <$> x
+        go :: HsDecl GM.GhcPs -> [(J.SymbolKind,Located T.Text,Maybe T.Text)]
+        go (TyClD FamDecl { tcdFam = FamilyDecl { fdLName = n } }) = pure (J.SkClass, s n, Nothing)
+        go (TyClD SynDecl { tcdLName = n }) = pure (J.SkClass, s n, Nothing)
+        go (TyClD DataDecl { tcdLName = n, tcdDataDefn = HsDataDefn { dd_cons = cons } }) =
+          (J.SkClass, s n, Nothing) : concatMap (processCon (unLoc $ s n) . unLoc) cons
+        go (TyClD ClassDecl { tcdLName = n, tcdSigs = sigs, tcdATs = fams }) =
+          (J.SkInterface, sn, Nothing) :
+                concatMap (processSig (unLoc sn) . unLoc) sigs
+            ++  concatMap (map setCnt . go . TyClD . FamDecl . unLoc) fams
+          where sn = s n
+                setCnt (k,n',_) = (k,n',Just (unLoc sn))
+        go (ValD FunBind { fun_id = ln }) = pure (J.SkFunction, s ln, Nothing)
+        go (ValD PatBind { pat_lhs = p }) =
+          map (\n ->(J.SkMethod, s n, Nothing)) $ hsNamessRdr p
+        go (ForD ForeignImport { fd_name = n }) = pure (J.SkFunction, s n, Nothing)
+        go _ = []
 
-      go :: HsDecl GM.GhcPs -> [(J.SymbolKind,Located T.Text,Maybe T.Text)]
-      go (TyClD FamDecl { tcdFam = FamilyDecl { fdLName = n } }) = pure (J.SkClass, s n, Nothing)
-      go (TyClD SynDecl { tcdLName = n }) = pure (J.SkClass, s n, Nothing)
-      go (TyClD DataDecl { tcdLName = n, tcdDataDefn = HsDataDefn { dd_cons = cons } }) =
-        (J.SkClass, s n, Nothing) : concatMap (processCon (unLoc $ s n) . unLoc) cons
-      go (TyClD ClassDecl { tcdLName = n, tcdSigs = sigs, tcdATs = fams }) =
-        (J.SkInterface, sn, Nothing) :
-              concatMap (processSig (unLoc sn) . unLoc) sigs
-          ++  concatMap (map setCnt . go . TyClD . FamDecl . unLoc) fams
-        where sn = s n
-              setCnt (k,n',_) = (k,n',Just (unLoc sn))
-      go (ValD FunBind { fun_id = ln }) = pure (J.SkFunction, s ln, Nothing)
-      go (ValD PatBind { pat_lhs = p }) =
-        map (\n ->(J.SkMethod, s n, Nothing)) $ hsNamessRdr p
-      go (ForD ForeignImport { fd_name = n }) = pure (J.SkFunction, s n, Nothing)
-      go _ = []
+        processSig :: T.Text
+                  -> Sig GM.GhcPs
+                  -> [(J.SymbolKind, Located T.Text, Maybe T.Text)]
+        processSig cnt (ClassOpSig False names _) =
+          map (\n ->(J.SkMethod,s n, Just cnt)) names
+        processSig _ _ = []
 
-      processSig :: T.Text
-                 -> Sig GM.GhcPs
-                 -> [(J.SymbolKind, Located T.Text, Maybe T.Text)]
-      processSig cnt (ClassOpSig False names _) =
-        map (\n ->(J.SkMethod,s n, Just cnt)) names
-      processSig _ _ = []
+        processCon :: T.Text
+                  -> ConDecl GM.GhcPs
+                  -> [(J.SymbolKind, Located T.Text, Maybe T.Text)]
+        processCon cnt ConDeclGADT { con_names = names } =
+          map (\n -> (J.SkConstructor, s n, Just cnt)) names
+        processCon cnt ConDeclH98 { con_name = name, con_details = dets } =
+          (J.SkConstructor, sn, Just cnt) : xs
+          where
+            sn = s name
+            xs = case dets of
+              RecCon (L _ rs) -> concatMap (map (f . rdrNameFieldOcc . unLoc)
+                                          . cd_fld_names
+                                          . unLoc) rs
+                                  where f ln = (J.SkField, s ln, Just (unLoc sn))
+              _ -> []
 
-      processCon :: T.Text
-                 -> ConDecl GM.GhcPs
-                 -> [(J.SymbolKind, Located T.Text, Maybe T.Text)]
-      processCon cnt ConDeclGADT { con_names = names } =
-        map (\n -> (J.SkConstructor, s n, Just cnt)) names
-      processCon cnt ConDeclH98 { con_name = name, con_details = dets } =
-        (J.SkConstructor, sn, Just cnt) : xs
-        where
-          sn = s name
-          xs = case dets of
-            RecCon (L _ rs) -> concatMap (map (f . rdrNameFieldOcc . unLoc)
-                                         . cd_fld_names
-                                         . unLoc) rs
-                                 where f ln = (J.SkField, s ln, Just (unLoc sn))
-            _ -> []
+        goImport :: ImportDecl GM.GhcPs -> [(J.SymbolKind, Located T.Text, Maybe T.Text)]
+        goImport ImportDecl { ideclName = lmn, ideclAs = as, ideclHiding = meis } = a ++ xs
+          where
+            im = (J.SkModule, lsmn, Nothing)
+            lsmn = s lmn
+            smn = unLoc lsmn
+            a = case as of
+                      Just a' -> [(J.SkNamespace, lsmn, Just $ showName a')]
+                      Nothing -> [im]
+            xs = case meis of
+                  Just (False, eis) -> concatMap (f . unLoc) (unLoc eis)
+                  _ -> []
+            f (IEVar n) = pure (J.SkFunction, s n, Just smn)
+            f (IEThingAbs n) = pure (J.SkClass, s n, Just smn)
+            f (IEThingAll n) = pure (J.SkClass, s n, Just smn)
+            f (IEThingWith n _ vars fields) =
+              let sn = s n in
+              (J.SkClass, sn, Just smn) :
+                  map (\n' -> (J.SkFunction, s n', Just (unLoc sn))) vars
+                ++ map (\f' -> (J.SkField   , s f', Just (unLoc sn))) fields
+            f _ = []
 
-      goImport :: ImportDecl GM.GhcPs -> [(J.SymbolKind, Located T.Text, Maybe T.Text)]
-      goImport ImportDecl { ideclName = lmn, ideclAs = as, ideclHiding = meis } = a ++ xs
-        where
-          im = (J.SkModule, lsmn, Nothing)
-          lsmn = s lmn
-          smn = unLoc lsmn
-          a = case as of
-                    Just a' -> [(J.SkNamespace, lsmn, Just $ showName a')]
-                    Nothing -> [im]
-          xs = case meis of
-                 Just (False, eis) -> concatMap (f . unLoc) (unLoc eis)
-                 _ -> []
-          f (IEVar n) = pure (J.SkFunction, s n, Just smn)
-          f (IEThingAbs n) = pure (J.SkClass, s n, Just smn)
-          f (IEThingAll n) = pure (J.SkClass, s n, Just smn)
-          f (IEThingWith n _ vars fields) =
-            let sn = s n in
-            (J.SkClass, sn, Just smn) :
-                 map (\n' -> (J.SkFunction, s n', Just (unLoc sn))) vars
-              ++ map (\f' -> (J.SkField   , s f', Just (unLoc sn))) fields
-          f _ = []
-
-      declsToSymbolInf :: (J.SymbolKind, Located T.Text, Maybe T.Text)
-                       -> IdeM (Either T.Text J.SymbolInformation)
-      declsToSymbolInf (kind, L l nameText, cnt) = do
-        eloc <- srcSpan2Loc rfm l
-        case eloc of
-          Left x -> return $ Left x
-          Right loc -> return $ Right $ J.SymbolInformation nameText kind loc cnt
-  symInfs <- mapM declsToSymbolInf (imps ++ decls)
-  return $ IdeResponseOk $ rights symInfs
+        declsToSymbolInf :: (J.SymbolKind, Located T.Text, Maybe T.Text)
+                        -> IdeM (Either T.Text J.SymbolInformation)
+        declsToSymbolInf (kind, L l nameText, cnt) = do
+          eloc <- srcSpan2Loc rfm l
+          case eloc of
+            Left x -> return $ Left x
+            Right loc -> return $ Right $ J.SymbolInformation nameText kind loc cnt
+    symInfs <- mapM declsToSymbolInf (imps ++ decls)
+    return $ IdeResponseOk $ rights symInfs
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -60,7 +60,7 @@ initializeHoogleDb = do
     return Nothing
 
 infoCmd :: CommandFunc T.Text T.Text
-infoCmd = CmdSync $ \expr -> liftToGhc $
+infoCmd = CmdSync $ \expr -> liftIdeGhcM $
   bimap hoogleErrorToIdeError id <$> infoCmd' expr
 
 infoCmd' :: T.Text -> IdeM (Either HoogleError T.Text)
@@ -104,7 +104,7 @@ renderTarget t = T.intercalate "\n\n" $
 ------------------------------------------------------------------------
 
 lookupCmd :: CommandFunc T.Text [T.Text]
-lookupCmd = CmdSync $ \term -> liftToGhc $
+lookupCmd = CmdSync $ \term -> liftIdeGhcM $
       bimap hoogleErrorToIdeError id <$> lookupCmd' 10 term
 
 lookupCmd' :: Int -> T.Text -> IdeM (Either HoogleError [T.Text])

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -62,6 +62,7 @@ data ReactorInput =
 
 data ReactorOutput = ReactorOutput
   { _resId    :: Int
+  --TODO Change to something more safe than IdeResponse, since we can't use IdeResponseError
   , _response :: IdeResponse J.Value
   } deriving (Eq, Show, Generic, J.ToJSON, J.FromJSON)
 

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -824,6 +824,7 @@ requestDiagnostics cin file ver = do
         callbackl (IdeResponseOk  diags) =
           case diags of
             (PublishDiagnosticsParams fp (List ds)) -> sendOne "hlint" (fp, ds)
+        -- TODO: handleIdeResponseDeferred
         callbackl _ = error "impossible"
     liftIO $ atomically $ writeTChan cin reql
 
@@ -840,6 +841,7 @@ requestDiagnostics cin file ver = do
         case ds of
           [] -> sendEmpty
           _ -> mapM_ (sendOneGhc "ghcmod") ds
+      -- TODO: handleIdeResponseDeferred
       callbackg _ = error "impossible"
 
   liftIO $ atomically $ writeTChan cin reqg

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -647,7 +647,7 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp = do
               case mquery of
                 Nothing -> return Nothing
                 Just query -> do
-                  res <- lift $ liftToGhc $ Hoogle.infoCmd' query
+                  res <- lift $ liftIdeGhcM $ Hoogle.infoCmd' query
                   case res of
                     Right x -> return $ Just x
                     _ -> return Nothing
@@ -822,7 +822,6 @@ requestDiagnostics cin file ver = do
     let reql = GReq (Just file) (Just (file,ver)) Nothing (flip runReaderT lf . callbackl)
                  $ ApplyRefact.lintCmd' file
         callbackl (IdeResponseFail  err) = liftIO $ U.logs $ "got err" ++ show err
-        callbackl (IdeResponseError err) = liftIO $ U.logs $ "got err" ++ show err
         callbackl (IdeResponseOk  diags) =
           case diags of
             (PublishDiagnosticsParams fp (List ds)) -> sendOne "hlint" (fp, ds)
@@ -833,7 +832,6 @@ requestDiagnostics cin file ver = do
   let reqg = GReq (Just file) (Just (file,ver)) Nothing (flip runReaderT lf . callbackg)
                $ GhcMod.setTypecheckedModule file
       callbackg (IdeResponseFail  err) = liftIO $ U.logs $ "got err" ++ show err
-      callbackg (IdeResponseError err) = liftIO $ U.logs $ "got err" ++ show err
       callbackg (IdeResponseOk    (pd, errs)) = do
         forM_ errs $ \e -> do
           reactorSend $
@@ -857,7 +855,6 @@ hieResponseHelper lid action = do
   return $ \res -> flip runReaderT lf $
     case res of
       IdeResponseFail  err -> sendErrorResponse lid J.InternalError (T.pack $ show err)
-      IdeResponseError err -> sendErrorResponse lid J.InternalError (T.pack $ show err)
       IdeResponseOk r -> action r
       _ -> error "impossible"
 

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -437,9 +437,12 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp = do
             J.List changes = params ^. J.contentChanges
         mapFileFromVfs versionTVar cin vtdi
         -- Important - Call this before requestDiagnostics
-        makeRequest $ GReq (Just uri) Nothing Nothing (const $ return ())
-                        $ updatePositionMap uri changes
-        markCacheStale 
+        makeRequest $ GReq (Just uri) Nothing Nothing (const $ return ()) $
+                        -- mark this module's cache as stale
+                        pluginGetFile "markCacheStale:" uri $ \fp -> do
+                          markCacheStale fp
+                          updatePositionMap uri changes
+
         requestDiagnostics cin uri ver
 
       Core.NotDidCloseTextDocument notification -> do

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -252,19 +252,22 @@ _unmapFileFromVfs verTVar cin uri = do
 updatePositionMap :: Uri -> [J.TextDocumentContentChangeEvent] -> IdeGhcM (IdeResponse ())
 updatePositionMap uri changes = pluginGetFile "updatePositionMap: " uri $ \file -> do
   mcm <- getCachedModule file
+  
+  let handleCache cm = do
+        let n2oOld = newPosToOld cm
+            o2nOld = oldPosToNew cm
+            (n2o,o2n) = foldr go (n2oOld, o2nOld) changes
+            go (J.TextDocumentContentChangeEvent (Just r) _ txt) (n2o', o2n') =
+              (n2o' <=< newToOld r txt, oldToNew r txt <=< o2n')
+            go _ _ = (const Nothing, const Nothing)
+            cm' = cm {newPosToOld = n2o, oldPosToNew = o2n}
+        cacheModuleNoClear file cm'
+        return $ IdeResponseOk ()
+
   case mcm of
-    Just cm -> do
-      let n2oOld = newPosToOld cm
-          o2nOld = oldPosToNew cm
-          (n2o,o2n) = foldr go (n2oOld, o2nOld) changes
-          go (J.TextDocumentContentChangeEvent (Just r) _ txt) (n2o', o2n') =
-            (n2o' <=< newToOld r txt, oldToNew r txt <=< o2n')
-          go _ _ = (const Nothing, const Nothing)
-      let cm' = cm {newPosToOld = n2o, oldPosToNew = o2n}
-      cacheModuleNoClear file cm'
-      return $ IdeResponseOk ()
-    Nothing ->
-      return $ IdeResponseOk ()
+    ModuleCached cm -> handleCache cm
+    ModuleStale cm -> handleCache cm
+    _ -> return $ IdeResponseOk ()
   where
     f (+/-) (J.Range (Position sl _) (Position el _)) txt p@(Position l c)
       | l < sl = Just p
@@ -727,8 +730,11 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp = do
         callback <- hieResponseHelper (req ^. J.id) $ \docSymbols -> do
           let rspMsg = Core.makeResponseMessage req $ J.List docSymbols
           reactorSend rspMsg
-        let hreq = GReq (Just uri) Nothing (Just $ req ^. J.id) callback
-                   $ Hie.getSymbols uri
+
+        -- there is no immediate response,but rather
+        -- a callback that we pass into the request
+        let hreq = IReq (req ^. J.id) return
+                   $ Hie.getSymbols uri (liftIO . callback)
         makeRequest hreq
 
       -- -------------------------------

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -725,10 +725,10 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp = do
         liftIO $ U.logs $ "reactor:got Document symbol request:" ++ show req
         let uri = req ^. J.params . J.textDocument . J.uri
         callback <- hieResponseHelper (req ^. J.id) $ \docSymbols -> do
-            let rspMsg = Core.makeResponseMessage req $ J.List docSymbols
-            reactorSend rspMsg
-        let hreq = IReq (req ^. J.id) callback
-                 $ Hie.getSymbols uri
+          let rspMsg = Core.makeResponseMessage req $ J.List docSymbols
+          reactorSend rspMsg
+        let hreq = GReq (Just uri) Nothing (Just $ req ^. J.id) callback
+                   $ Hie.getSymbols uri
         makeRequest hreq
 
       -- -------------------------------

--- a/src/Haskell/Ide/Engine/Types.hs
+++ b/src/Haskell/Ide/Engine/Types.hs
@@ -17,8 +17,8 @@ pattern GReq :: Maybe Uri
                 -> PluginRequest
 pattern GReq a b c d e = Right (GhcRequest   a b c d e)
 
-pattern IReq :: J.LspId -> (a -> IO ()) -> IdeM a -> Either IdeRequest b
-pattern IReq a b c     = Left  (IdeRequest a b c)
+pattern IReq :: J.LspId -> (IdeResponse a -> IO ()) -> IdeM (IdeResponse a) -> PluginRequest
+pattern IReq a b c     = Left (IdeRequest a b c)
 
 type PluginRequest = Either IdeRequest GhcRequest
 
@@ -32,6 +32,6 @@ data GhcRequest = forall a. GhcRequest
 
 data IdeRequest = forall a. IdeRequest
   { pureReqId :: J.LspId
-  , pureReqCallback :: a -> IO ()
-  , pureReq :: IdeM a
+  , pureReqCallback :: IdeResponse a -> IO ()
+  , pureReq :: IdeM (IdeResponse a)
   }

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -68,7 +68,7 @@ startServer = do
   cin  <- atomically newTChan
 
   let dispatcherProc dispatcherEnv
-        = void $ forkIO $ runIdeGhcM testOptions (IdeState emptyModuleCache plugins Map.empty Nothing) (dispatcherP dispatcherEnv cin)
+        = void $ forkIO $ runIdeGhcM testOptions (IdeState emptyModuleCache Map.empty plugins Map.empty Nothing) (dispatcherP dispatcherEnv cin)
   cancelTVar      <- atomically $ newTVar S.empty
   wipTVar         <- atomically $ newTVar S.empty
   versionTVar     <- atomically $ newTVar Map.empty

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -82,7 +82,7 @@ ghcmodSpec = do
       let uri = filePathToUri fp
           act = do
             _ <- setTypecheckedModule uri
-            liftToGhc $ newTypeCmd (toPos (5,9)) uri
+            liftIdeGhcM $ newTypeCmd (toPos (5,9)) uri
           arg = TP False uri (toPos (5,9))
           res = IdeResponseOk
             [(Range (toPos (5,9)) (toPos (5,10)), "Int")
@@ -101,7 +101,7 @@ ghcmodSpec = do
         let uri = filePathToUri fp
         let act = do
               _ <- setTypecheckedModule uri
-              liftToGhc $ newTypeCmd (toPos (5,9)) uri
+              liftIdeGhcM $ newTypeCmd (toPos (5,9)) uri
         let arg = TP False uri (toPos (5,9))
         let res = IdeResponseOk
               [(Range (toPos (5,9)) (toPos (5,10)), "Int")

--- a/test/HooglePluginSpec.hs
+++ b/test/HooglePluginSpec.hs
@@ -47,13 +47,13 @@ hoogleSpec = do
 
   describe "hoogle plugin commands(new plugin api)" $ do
     it "runs the info command" $ do
-      let req = liftToGhc $ infoCmd' "head"
+      let req = liftIdeGhcM $ infoCmd' "head"
       r <- dispatchRequestP $ initializeHoogleDb >> req
       r `shouldBe` Right "head :: [a] -> a\nbase Prelude\nExtract the first element of a list, which must be non-empty.\n\n"
 
     -- ---------------------------------
 
     it "runs the lookup command" $ do
-      let req = liftToGhc $ lookupCmd' 1 "[a] -> a"
+      let req = liftIdeGhcM $ lookupCmd' 1 "[a] -> a"
       r <- dispatchRequestP $ initializeHoogleDb >> req
       r `shouldBe` Right ["Prelude head :: [a] -> a"]

--- a/test/IdeResponseSpec.hs
+++ b/test/IdeResponseSpec.hs
@@ -1,0 +1,40 @@
+module IdeResponseSpec where
+
+import Test.Hspec
+import Data.Aeson
+import Data.Text
+import Haskell.Ide.Engine.PluginsIdeMonads
+    
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "IdeResponseOk" $ do
+    it "works with >>= IdeResponseOk" $ do
+      (IdeResponseOk (42 :: Int) >>= \_ -> IdeResponseOk 32)
+        `shouldBe` ((IdeResponseOk 32) :: IdeResponse Int)
+
+    it "works with >>= IdeResponseFail" $ do
+      (IdeResponseOk (42 :: Int) >>= \_ -> (IdeResponseFail pluginError) :: IdeResponse Int)
+        `shouldBe` ((IdeResponseFail pluginError))
+
+    it "works with >>= IdeResponseDeferred" $ do
+      (IdeResponseOk (42 :: Int) >>= \_ ->
+        IdeResponseDeferred "path" (\_ -> return $ IdeResponseOk "blah"))
+        `shouldSatisfy` \x ->
+          case x of
+            IdeResponseDeferred "path" _ -> True
+            _ -> False
+
+  describe "IdeResponseFail" $ do
+    it "works with >>= IdeResponseOk" $ do
+      (IdeResponseFail pluginError >>= \_ -> IdeResponseOk 42 :: IdeResponse Int)
+        `shouldBe` (IdeResponseFail pluginError)
+        
+    it "works with >>= IdeResponseDeferred" $ do
+      (IdeResponseFail pluginError >>= \_ ->
+        IdeResponseDeferred "path" (\_ -> return $ IdeResponseOk "blah"))
+        `shouldBe` (IdeResponseFail pluginError)
+  
+  where pluginError = IdeError OtherError (pack "woops") Null

--- a/test/MainDispatcher.hs
+++ b/test/MainDispatcher.hs
@@ -61,7 +61,7 @@ dispatcherSpec = do
           req2 = GReq Nothing Nothing                          (Just $ J.IdInt 2) (atomically . writeTChan outChan) $ return $ IdeResponseOk $ T.pack "text2"
           req3 = GReq Nothing (Just (filePathToUri "test", 2)) Nothing            (atomically . writeTChan outChan) $ return $ IdeResponseOk $ T.pack "text3"
           req4 = GReq Nothing Nothing                          (Just $ J.IdInt 3) (atomically . writeTChan outChan) $ return $ IdeResponseOk $ T.pack "text4"
-      pid <- forkIO $ runIdeGhcM testOptions (IdeState emptyModuleCache (pluginDescToIdePlugins []) Map.empty Nothing)
+      pid <- forkIO $ runIdeGhcM testOptions (IdeState emptyModuleCache Map.empty (pluginDescToIdePlugins []) Map.empty Nothing)
                               (dispatcherP (DispatcherEnv cancelTVar wipTVar versionTVar) inChan)
       atomically $ writeTChan inChan req1
       atomically $ modifyTVar cancelTVar (S.insert (J.IdInt 2))

--- a/test/TestUtils.hs
+++ b/test/TestUtils.hs
@@ -67,7 +67,7 @@ makeRequest :: ToJSON a => PluginId -> CommandName -> a -> IdeGhcM (IdeResponse 
 makeRequest plugin com arg = runPluginCommand plugin com (toJSON arg)
 
 runIGM :: IdePlugins -> IdeGhcM a -> IO a
-runIGM testPlugins = runIdeGhcM testOptions (IdeState emptyModuleCache testPlugins Map.empty Nothing)
+runIGM testPlugins = runIdeGhcM testOptions (IdeState emptyModuleCache Map.empty testPlugins Map.empty Nothing)
 
 withTestLogging :: IO a -> IO a
 withTestLogging = withFileLogging "./test-main.log"


### PR DESCRIPTION
This allows for requests that depend on a cached module to receive a callback whenever the cached module is ready. As an example, if a document symbols request is made right as HIE is started, it will no longer immediately return an empty list but will now return the correct response as soon as the module has been loaded.

It adds an extra field to `IdeState` to keep track of which modules have which actions queued, and changes getCachedModule to return more information about if it's stale, loading or failed. 

- [ ] Figure out how to tell if module loading failed?
- [ ] Handle JSON of IdeDeferredResponse
- [ ] Bring back discarded ExceptT transformers in the form of IdeResponseT
- [ ] Go through for `error "impossible"`s and add matches for IdeDeferredResponse