### PR TITLE
Use local bin path provided by stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BASEDIR=$(CURDIR)
+STACKLOCALBINDIR != stack path --local-bin
 
 build: hie-8.2.1 hie-8.2.2 hie-8.4.2
 # build: hie-8.0.2 hie-8.2.1 hie-8.2.2 hie-8.4.2
@@ -22,29 +23,28 @@ build-all: | build build-docs
 .PHONY: build
 
 # ------------------------------------------------------
-
 hie-8.0.2:
-	stack --stack-yaml=stack-8.0.2.yaml install                  \
-		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.0      \
-		&& cp ~/.local/bin/hie-8.0.2 ~/.local/bin/hie-8.2
+	stack --stack-yaml=stack-8.0.2.yaml install                                \
+		&& cp '$(STACKLOCALBINDIR)/hie' '$(STACKLOCALBINDIR)/hie-8.0'      \
+		&& cp '$(STACKLOCALBINDIR)/hie-8.0.2' '$(STACKLOCALBINDIR)hie-8.2'
 .PHONY: hie-8.0.2
 
 hie-8.2.1:
-	stack --stack-yaml=stack-8.2.1.yaml install                  \
-		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.1      \
-		&& cp ~/.local/bin/hie-8.2.1 ~/.local/bin/hie-8.2
+	stack --stack-yaml=stack-8.2.1.yaml install                                \
+		&& cp '$(STACKLOCALBINDIR)/hie' '$(STACKLOCALBINDIR)/hie-8.2.1'    \
+		&& cp '$(STACKLOCALBINDIR)/hie-8.2.1' '$(STACKLOCALBINDIR)/hie-8.2'
 .PHONY: hie-8.2.1
 
 hie-8.2.2:
-	stack --stack-yaml=stack-8.2.2.yaml install                  \
-		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.2.2      \
-		&& cp ~/.local/bin/hie-8.2.2 ~/.local/bin/hie-8.2
+	stack --stack-yaml=stack-8.2.2.yaml install                                \
+		&& cp '$(STACKLOCALBINDIR)/hie' '$(STACKLOCALBINDIR)/hie-8.2.2'    \
+		&& cp '$(STACKLOCALBINDIR)/hie-8.2.2' '$(STACKLOCALBINDIR)/hie-8.2'
 .PHONY: hie-8.2.2
 
 hie-8.4.2:
-	stack --stack-yaml=stack.yaml install                  \
-		&& cp ~/.local/bin/hie ~/.local/bin/hie-8.4.2      \
-		&& cp ~/.local/bin/hie-8.4.2 ~/.local/bin/hie-8.4
+	stack --stack-yaml=stack.yaml install                                      \
+		&& cp '$(STACKLOCALBINDIR)\hie' '$(STACKLOCALBINDIR)\hie-8.4.2'    \
+		&& cp '$(STACKLOCALBINDIR)\hie-8.4.2' '$(STACKLOCALBINDIR)\hie-8.4'
 .PHONY: hie-8.4.2
 
 # ------------------------------------------------------


### PR DESCRIPTION
Fixes #537 

Notes: 
`!=` is used to capture output of shell command. `$(shell cmd)` is GNU extension, so probably something will break on OSX. Paths are quoted otherwise make thinks that slashes are escaping on Windows.