### PR TITLE
Do not register executeCommandProvider on startup

### DIFF
--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -869,7 +869,6 @@ hieOptions :: Core.Options
 hieOptions =
   def { Core.textDocumentSync       = Just syncOptions
       , Core.completionProvider     = Just (J.CompletionOptions (Just True) (Just ["."]))
-      , Core.executeCommandProvider = Just (J.ExecuteCommandOptions (J.List ["applyrefact:applyOne","hare:demote"]))
       }
 
 


### PR DESCRIPTION
This was a holdover from early experiments, and now breaks vscode.

Fixes https://github.com/alanz/vscode-hie-server/issues/65