### PR TITLE
Canonicalize uri for dummy diags

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -157,7 +157,8 @@ setTypecheckedModule uri =
     debugm $ "setTypecheckedModule: file mapping state is: " ++ show fileMap
     rfm <- GM.mkRevRedirMapFunc
     ((diags', errs), mtm) <- GM.getTypecheckedModuleGhc' (myLogger rfm) fp
-    let diags = Map.insertWith Set.union uri Set.empty diags'
+    canonUri <- canonicalizeUri uri
+    let diags = Map.insertWith Set.union canonUri Set.empty diags'
     case mtm of
       Nothing -> do
         debugm $ "setTypecheckedModule: Didn't get typechecked module for: " ++ show fp


### PR DESCRIPTION
`getTypecheckedModuleGhc'` returns diags with canonicalized URIs so dummy diags with un-canonicalized URI is always inserted to diags map.
Which leads to LSP client overwriting actual diags with dummy ones because both URI are treated the same.

Fixes #560