### PR TITLE
Wrap exception handler around module loading.

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/Monad.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Monad.hs
@@ -5,6 +5,7 @@ import           Control.Monad.IO.Class
 import qualified GhcMod.Monad                  as GM
 import qualified GhcMod.Types                  as GM
 import           Haskell.Ide.Engine.MonadTypes
+
 -- ---------------------------------------------------------------------
 
 -- | runIdeGhcM with Cradle found from the current directory

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -809,7 +809,7 @@ requestDiagnostics cin file ver = do
       callbackg (pd, errs) = do
         forM_ errs $ \e -> do
           reactorSend $
-            fmServerLogMessageNotification J.MtError
+            fmServerShowMessageNotification J.MtError
               $ "Got error while processing diagnostics: " <> e
         let ds = Map.toList $ S.toList <$> pd
         case ds of


### PR DESCRIPTION
So that instead of a silent hang, we get an actuall error message
back, and operation continues.