### PR TITLE
Fix typo "win32" on haskell-ide-engine.cabal

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -82,7 +82,7 @@ library
                      , yaml
                      , yi-rope
   if os(windows)
-    build-depends:     win32
+    build-depends:     Win32
   else
     build-depends:     unix
   ghc-options:         -Wall -Wredundant-constraints


### PR DESCRIPTION
I have encountered this error

> In the dependencies for haskell-ide-engine-0.2.0.0(+pedantic):
>     **win32** needed, but the stack configuration has no specified version (no package with that name
>           found, perhaps there is a typo in a package's build-depends or an omission from the
>           stack.yaml packages list?)
> needed since haskell-ide-engine is a build target.
> 
> Some different approaches to resolving this:
> 
>   * Consider trying 'stack solver', which uses the cabal-install solver to attempt to find some
>     working build configuration. This can be convenient when dealing with many complicated
>     constraint errors, but results may be unpredictable.