### PR TITLE
Use just plain process IDs instead of UUIDs to unique commands

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -71,13 +71,11 @@ library
                      , mtl
                      , optparse-simple >= 0.0.3
                      , process
-                     , random
                      , sorted-list >= 0.2.1.0
                      , stm
                      , tagsoup
                      , text
                      , transformers
-                     , uuid
                      , vector
                      , yaml
                      , yi-rope


### PR DESCRIPTION
Realised that there's no need for UUIDs if we're basing it off of process IDs