### PR TITLE
Fall back to a default config when there is none specified in settings.json

### DIFF
--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -319,7 +319,7 @@ publishDiagnostics :: (MonadIO m, MonadReader (Core.LspFuncs Config) m)
   => Int -> J.Uri -> Maybe J.TextDocumentVersion -> DiagnosticsBySource -> m ()
 publishDiagnostics maxToSend uri' mv diags = do
   lf <- ask
-  liftIO $ (Core.publishDiagnosticsFunc lf) maxToSend uri' mv diags
+  liftIO $ Core.publishDiagnosticsFunc lf maxToSend uri' mv diags
 
 -- ---------------------------------------------------------------------
 
@@ -327,7 +327,7 @@ flushDiagnosticsBySource :: (MonadIO m, MonadReader (Core.LspFuncs Config) m)
   => Int -> Maybe J.DiagnosticSource -> m ()
 flushDiagnosticsBySource maxToSend msource = do
   lf <- ask
-  liftIO $ (Core.flushDiagnosticsBySourceFunc lf) maxToSend msource
+  liftIO $ Core.flushDiagnosticsBySourceFunc lf maxToSend msource
 
 -- ---------------------------------------------------------------------
 
@@ -570,7 +570,7 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp commandMap = d
                     else return (IdeResponseOk (Nothing,[],Nothing))
           makeRequest hreq
 
-          liftIO $ U.logs $ "reactor:HoverRequest done"
+          liftIO $ U.logs "reactor:HoverRequest done"
 
         -- -------------------------------
 


### PR DESCRIPTION
This was a problem in LanguageClient-neovim since it would send a didChangeConfiguration notification with an empty settings file. Now if the `languageServerHaskell` field isn't defined in the object it will fall back, but still throw an error if the parsing fails in another way