### PR TITLE
Check GHC version on launch

### DIFF
--- a/app/HieWrapper.hs
+++ b/app/HieWrapper.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP             #-}
-{-# LANGUAGE TemplateHaskell #-}
 -- | This module is based on the hie-wrapper.sh script in
 -- https://github.com/alanz/vscode-hie-server
 module Main where
@@ -35,7 +34,7 @@ main = do
         compiler :: Parser (a -> a)
         compiler =
             infoOption
-                hieCompilerVersion
+                hieGhcDisplayVersion
                 (long "compiler" <>
                  help "Show only compiler and version supported")
     -- Parse the options and run
@@ -70,9 +69,7 @@ run opts = do
   d <- getCurrentDirectory
   logm $ "Current directory:" ++ d
 
-  ghcVersionString <- getProjectGhcVersion
-  let
-    ghcVersion = crackGhcVersion ghcVersionString
+  ghcVersion <- getProjectGhcVersion
   logm $ "Project GHC version:" ++ ghcVersion
 
   let
@@ -96,26 +93,6 @@ run opts = do
       callProcess e args
       logm "done"
   
--- ---------------------------------------------------------------------
-
-getProjectGhcVersion :: IO String
-getProjectGhcVersion = do
-  isStack <- doesDirectoryExist ".stack-work"
-  cmd <- if isStack
-    then do
-      logm "Using stack GHC version"
-      return "stack ghc -- --version"
-    else do
-      logm "Using plain GHC version"
-      return "ghc --version"
-  readCreateProcess (shell cmd) ""
-
-
--- "The Glorious Glasgow Haskell Compilation System, version 8.4.3\n"
--- "The Glorious Glasgow Haskell Compilation System, version 8.4.2\n"
-crackGhcVersion :: String -> String
-crackGhcVersion st = reverse $ takeWhile (/=' ') $ tail $ reverse st
-
 -- ---------------------------------------------------------------------
 
 {-

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -97,7 +97,7 @@ run opts = do
   
   projGhcVersion <- getProjectGhcVersion
   when (projGhcVersion /= hieGhcVersion) $
-    warningm $ "Mismatched GHC versions: Project is " ++ projGhcVersion
+    warningm $ "Mismatching GHC versions: Project is " ++ projGhcVersion
              ++ ", HIE is " ++ hieGhcVersion
 
   when (optEkg opts) $ do

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -67,7 +67,7 @@ main = do
         compiler :: Parser (a -> a)
         compiler =
             infoOption
-                hieCompilerVersion
+                hieGhcDisplayVersion
                 (long "compiler" <>
                  help "Show only compiler and version supported")
     -- Parse the options and run
@@ -94,6 +94,11 @@ run opts = do
                    else L.INFO
 
   Core.setupLogger mLogFileName ["hie"] logLevel
+  
+  projGhcVersion <- getProjectGhcVersion
+  when (projGhcVersion /= hieGhcVersion) $
+    warningm $ "Mismatched GHC versions: Project is " ++ projGhcVersion
+             ++ ", HIE is " ++ hieGhcVersion
 
   when (optEkg opts) $ do
     logm $ "Launching EKG server on port " ++ show (optEkgPort opts)
@@ -104,7 +109,7 @@ run opts = do
   maybe (pure ()) setCurrentDirectory $ projectRoot opts
 
   progName <- getProgName
-  logm $  "run entered for HIE(" ++ progName ++ ") " ++ version
+  logm $  "Run entered for HIE(" ++ progName ++ ") " ++ version
   d <- getCurrentDirectory
   logm $ "Current directory:" ++ d
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -101,6 +101,7 @@ executable hie
                      , hie-plugin-api
                      , hslogger
                      , optparse-simple
+                     , process
                      , stm
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wredundant-constraints
                        -with-rtsopts=-T

--- a/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
@@ -6,6 +6,7 @@ module Haskell.Ide.Engine.MonadFunctions
   -- * Logging functions
     logm
   , debugm
+  , warningm
   , ExtensionClass(..)
   , put
   , modify
@@ -30,6 +31,9 @@ logm s = liftIO $ infoM "hie" s
 
 debugm :: MonadIO m => String -> m ()
 debugm s = liftIO $ debugM "hie" s
+
+warningm :: MonadIO m => String -> m ()
+warningm s = liftIO $ warningM "hie" s
 
 -- ---------------------------------------------------------------------
 -- Extensible state, based on

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -43,6 +43,7 @@ library
                      , hslogger
                      , monad-control
                      , mtl
+                     , process
                      , stm
                      , syb
                      , text

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -43,7 +43,6 @@ library
                      , hslogger
                      , monad-control
                      , mtl
-                     , process
                      , stm
                      , syb
                      , text

--- a/src/Haskell/Ide/Engine/Plugin/Base.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Base.hs
@@ -6,12 +6,9 @@
 {-# LANGUAGE TemplateHaskell       #-}
 module Haskell.Ide.Engine.Plugin.Base where
 
-import           Control.Monad
 import           Data.Aeson
 import           Data.Foldable
-import           Data.List
 import qualified Data.Map                        as Map
-import           Data.Monoid
 import qualified Data.Text                       as T
 import           Development.GitRev              (gitCommitCount)
 import           Distribution.System             (buildArch)
@@ -20,8 +17,11 @@ import           Haskell.Ide.Engine.IdeFunctions
 import           Haskell.Ide.Engine.MonadTypes
 import           Options.Applicative.Simple      (simpleVersion)
 import qualified Paths_haskell_ide_engine        as Meta
-import           Prelude                         hiding (log)
+
+import           System.Directory
 import           System.Info
+import           System.Process
+import qualified System.Log.Logger as L
 
 -- ---------------------------------------------------------------------
 
@@ -87,12 +87,32 @@ version =
     , [" (" ++ commitCount ++ " commits)" | commitCount /= ("1"::String) &&
                                             commitCount /= ("UNKNOWN" :: String)]
     , [" ", display buildArch]
-    , [" ", hieCompilerVersion]
+    , [" ", hieGhcDisplayVersion]
     ]
 
 -- ---------------------------------------------------------------------
 
-hieCompilerVersion :: String
-hieCompilerVersion = compilerName ++ "-" ++ VERSION_ghc
+hieGhcDisplayVersion :: String
+hieGhcDisplayVersion = compilerName ++ "-" ++ VERSION_ghc
+
+getProjectGhcVersion :: IO String
+getProjectGhcVersion = do
+  isStack <- doesDirectoryExist ".stack-work"
+  cmd <- if isStack
+    then do
+      L.infoM "hie" "Using stack GHC version"
+      return "stack ghc -- --version"
+    else do
+      L.infoM "hie" "Using plain GHC version"
+      return "ghc --version"
+  crackGhcVersion <$> readCreateProcess (shell cmd) ""
+  where
+    -- "The Glorious Glasgow Haskell Compilation System, version 8.4.3\n"
+    -- "The Glorious Glasgow Haskell Compilation System, version 8.4.2\n"
+    crackGhcVersion :: String -> String
+    crackGhcVersion st = reverse $ takeWhile (/=' ') $ tail $ reverse st
+
+hieGhcVersion :: String
+hieGhcVersion = VERSION_ghc
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Base.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Base.hs
@@ -9,6 +9,9 @@ module Haskell.Ide.Engine.Plugin.Base where
 import           Data.Aeson
 import           Data.Foldable
 import qualified Data.Map                        as Map
+#if __GLASGOW_HASKELL__ < 804
+import           Data.Semigroup
+#endif
 import qualified Data.Text                       as T
 import           Development.GitRev              (gitCommitCount)
 import           Distribution.System             (buildArch)

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -409,6 +409,15 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp commandMap = d
           reactorSend $ NotLogMessage $
                   fmServerLogMessageNotification J.MtLog $ "Using hie version: " <> T.pack version
 
+          -- Check for mismatching GHC versions
+          projGhcVersion <- liftIO getProjectGhcVersion
+          when (projGhcVersion /= hieGhcVersion) $ do
+            let msg = T.pack $ "Mismatching GHC versions: Project is " ++ projGhcVersion ++ ", HIE is " ++ hieGhcVersion
+                      ++ "\nYou may want to use hie-wrapper. Check the README for more information"
+            reactorSend $ NotShowMessage $ fmServerShowMessageNotification J.MtWarning msg
+            reactorSend $ NotLogMessage $ fmServerLogMessageNotification J.MtWarning msg
+                  
+
           lf <- ask
           let hreq = GReq tn Nothing Nothing Nothing callback $ IdeResultOk <$> Hoogle.initializeHoogleDb
               callback Nothing = flip runReaderT lf $


### PR DESCRIPTION
Logs to the hie log, logs to the lsp log and shows a message to the user if the HIE ghc version doesn't match up with the project ghc version, should hopefully close #459 and #414, and many more support requests