### PR TITLE
Update haskell-lsp-test to no longer require an extra-dep on process-1.6.3

### DIFF
--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -39,7 +39,6 @@ extra-deps:
 - haddock-api-2.18.1
 - haddock-library-1.4.4
 - hlint-2.0.11
-- process-1.6.3.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -40,7 +40,6 @@ extra-deps:
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 - conduit-parse-0.2.1.0
-- process-1.6.3.0
 
 flags:
   haskell-ide-engine:

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -8,7 +8,7 @@ import Control.Monad
 import Data.Aeson
 import qualified Data.HashMap.Strict as H
 import Data.Maybe
-import Language.Haskell.LSP.Test
+import Language.Haskell.LSP.Test hiding (capabilities)
 import Language.Haskell.LSP.Types
 import qualified Language.Haskell.LSP.Types as LSP (error, id)
 import Test.Hspec


### PR DESCRIPTION
Should hopefully fix window builds on 8.2.1/8.2.2