### PR TITLE
Use stack library to work out stack ghc version

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -72,6 +72,7 @@ library
                      , optparse-simple >= 0.0.3
                      , process
                      , sorted-list >= 0.2.1.0
+                     , stack
                      , stm
                      , tagsoup
                      , text
@@ -232,6 +233,20 @@ test-suite haskell-ide-func-test
      ghc-options:      -Werror
   default-language:    Haskell2010
   build-tool-depends:  hspec-discover:hspec-discover
+
+test-suite hie-wrapper-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             HieWrapperSpec.hs
+  build-depends:       base
+                     , hspec
+                     , directory
+                     , process
+                     , haskell-ide-engine
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wredundant-constraints
+  if flag(pedantic)
+     ghc-options:      -Werror
+  default-language:    Haskell2010
 
 
 source-repository head

--- a/test/HieWrapperSpec.hs
+++ b/test/HieWrapperSpec.hs
@@ -1,0 +1,21 @@
+module Main where
+
+import Haskell.Ide.Engine.Plugin.Base
+import Test.Hspec
+import System.Directory
+import System.Process
+
+main :: IO ()
+main = hspec $
+  describe "version checking" $ do
+    it "picks up a stack.yaml with 8.2.1" $
+      withCurrentDirectory "test/testdata/wrapper/8.2.1" $
+        getProjectGhcVersion `shouldReturn` "8.2.1"
+    it "picks up a stack.yaml with 8.2.2" $
+      withCurrentDirectory "test/testdata/wrapper/lts-11.14" $
+        getProjectGhcVersion `shouldReturn` "8.2.2"
+    it "picks up whatever version of ghc is on this machine" $
+      withCurrentDirectory "test/testdata/wrapper/ghc" $ do
+        ghcDisplayVer <- readCreateProcess (shell "ghc --version") ""
+        ghcVer <- getProjectGhcVersion
+        init ghcDisplayVer `shouldEndWith` ghcVer

--- a/test/testdata/wrapper/8.2.1/stack.yaml
+++ b/test/testdata/wrapper/8.2.1/stack.yaml
@@ -1,0 +1,1 @@
+resolver: ghc-8.2.1

--- a/test/testdata/wrapper/lts-11.14/stack.yaml
+++ b/test/testdata/wrapper/lts-11.14/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-11.14


### PR DESCRIPTION
Checks for a `stack.yaml`, and if it exists hands it off to stack to work it out. Will still call GHC via the shell otherwise