### PR TITLE
[WIP] ghc-mod code actions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,8 @@
 
 [submodule "submodules/haskell-lsp"]
 	path = submodules/haskell-lsp
-	url = https://github.com/alanz/haskell-lsp.git
+	url = https://github.com/Bubba/haskell-lsp.git
+	# url = https://github.com/alanz/haskell-lsp.git
 [submodule "submodules/haskell-lsp-test"]
 	path = submodules/haskell-lsp-test
 	url = https://github.com/Bubba/haskell-lsp-test.git

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Haskell IDE Engine
+<img src="https://github.com/haskell/haskell-ide-engine/raw/master/logos/HIE_logo_512.png" width="256" style="margin:25px;" align="right"/>
+
 [![License BSD3][badge-license]][license]
+[![CircleCI][badge-circleci]][circleci]
 
 [badge-license]: https://img.shields.io/badge/license-BSD3-green.svg?dummy
 [license]: https://github.com/haskell/haskell-ide-engine/blob/master/LICENSE
+[badge-circleci]: https://img.shields.io/circleci/project/github/haskell/haskell-ide-engine.svg
+[circleci]: https://circleci.com/gh/haskell/haskell-ide-engine/
 
 
 This project aims to be __the universal interface__ to __a growing number of Haskell tools__, providing a __full-featured and easy to query backend__ for editors and IDEs that require Haskell-specific functionality.

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -37,6 +37,7 @@ import           Haskell.Ide.Engine.Plugin.Example2
 import           Haskell.Ide.Engine.Plugin.GhcMod
 import           Haskell.Ide.Engine.Plugin.HaRe
 import           Haskell.Ide.Engine.Plugin.Hoogle
+import           Haskell.Ide.Engine.Plugin.HsImport
 
 -- ---------------------------------------------------------------------
 
@@ -51,6 +52,7 @@ plugins = pluginDescToIdePlugins
   ,("hare"       , hareDescriptor)
   ,("base"       , baseDescriptor)
   ,("hoogle"     , hoogleDescriptor)
+  ,("hsimport"   , hsimportDescriptor)
   ]
 
 -- ---------------------------------------------------------------------

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -38,6 +38,7 @@ import           Haskell.Ide.Engine.Plugin.GhcMod
 import           Haskell.Ide.Engine.Plugin.HaRe
 import           Haskell.Ide.Engine.Plugin.Hoogle
 import           Haskell.Ide.Engine.Plugin.HsImport
+import           Haskell.Ide.Engine.Plugin.Package
 
 -- ---------------------------------------------------------------------
 
@@ -53,6 +54,7 @@ plugins = pluginDescToIdePlugins
   ,("base"       , baseDescriptor)
   ,("hoogle"     , hoogleDescriptor)
   ,("hsimport"   , hsimportDescriptor)
+  ,("package"    , packageDescriptor)
   ]
 
 -- ---------------------------------------------------------------------

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -81,6 +81,7 @@ library
                      , tagsoup
                      , text
                      , transformers
+                     , unordered-containers
                      , yaml
                      , yi-rope
   if os(windows)
@@ -139,6 +140,7 @@ test-suite haskell-ide-test
   main-is:             Main.hs
   other-modules:       ApplyRefactPluginSpec
                        BrittanySpec
+                       CodeActionsSpec
                        ExtensibleStateSpec
                        GhcModPluginSpec
                        HaRePluginSpec
@@ -176,6 +178,7 @@ test-suite haskell-ide-dispatcher-test
   main-is:             MainDispatcher.hs
   other-modules:       ApplyRefactPluginSpec
                        BrittanySpec
+                       CodeActionsSpec
                        ExtensibleStateSpec
                        GhcModPluginSpec
                        HaRePluginSpec

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -36,6 +36,7 @@ library
                        Haskell.Ide.Engine.Plugin.HieExtras
                        Haskell.Ide.Engine.Plugin.Hoogle
                        Haskell.Ide.Engine.Plugin.HsImport
+                       Haskell.Ide.Engine.Plugin.Package
                        Haskell.Ide.Engine.Transport.JsonStdio
                        Haskell.Ide.Engine.Transport.LspStdio
                        Haskell.Ide.Engine.Types
@@ -51,6 +52,7 @@ library
                      , bimap
                      , brittany
                      , bytestring
+                     , Cabal
                      , cabal-helper >= 0.8.0.4
                      , containers
                      , data-default

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -32,6 +32,7 @@ library
                        Haskell.Ide.Engine.Plugin.Haddock
                        Haskell.Ide.Engine.Plugin.HieExtras
                        Haskell.Ide.Engine.Plugin.Hoogle
+                       Haskell.Ide.Engine.Plugin.HsImport
                        Haskell.Ide.Engine.Transport.JsonStdio
                        Haskell.Ide.Engine.Transport.LspStdio
                        Haskell.Ide.Engine.Types
@@ -64,6 +65,7 @@ library
                      , hie-plugin-api
                      , hlint >= 2.0.11
                      , hoogle >= 5.0.13
+                     , hsimport
                      , hslogger
                      , lens >= 4.15.2
                      , monad-control

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -21,6 +21,9 @@ library
   hs-source-dirs:      src
   exposed-modules:     Haskell.Ide.Engine.Plugin.Base
                        Haskell.Ide.Engine.Dispatcher
+                       Haskell.Ide.Engine.LSP.CodeActions
+                       Haskell.Ide.Engine.LSP.Config
+                       Haskell.Ide.Engine.LSP.Reactor
                        Haskell.Ide.Engine.Options
                        Haskell.Ide.Engine.Plugin.ApplyRefact
                        Haskell.Ide.Engine.Plugin.Brittany

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -81,7 +81,6 @@ library
                      , tagsoup
                      , text
                      , transformers
-                     , vector
                      , yaml
                      , yi-rope
   if os(windows)

--- a/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
@@ -7,6 +7,7 @@ module Haskell.Ide.Engine.MonadFunctions
     logm
   , debugm
   , warningm
+  , errorm
   , ExtensionClass(..)
   , put
   , modify
@@ -34,6 +35,9 @@ debugm s = liftIO $ debugM "hie" s
 
 warningm :: MonadIO m => String -> m ()
 warningm s = liftIO $ warningM "hie" s
+
+errorm :: MonadIO m => String -> m ()
+errorm s = liftIO $ warningM "hie" s
 
 -- ---------------------------------------------------------------------
 -- Extensible state, based on

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -9,6 +9,7 @@ module Haskell.Ide.Engine.PluginUtils
     mapEithers
   , pluginGetFile
   , pluginGetFileResponse
+  , makeDiffResult
   , diffText
   , srcSpan2Range
   , srcSpan2Loc
@@ -32,6 +33,8 @@ import           Data.Algorithm.DiffOutput
 import qualified Data.HashMap.Strict                   as H
 import           Data.Monoid
 import qualified Data.Text                             as T
+import qualified Data.Text.IO                          as T
+import qualified GhcMod.Utils                          as GM
 import           FastString
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.MonadFunctions
@@ -133,6 +136,14 @@ mapEithers f (x:xs) = case mapEithers f xs of
 mapEithers _ _ = Right []
 
 -- ---------------------------------------------------------------------
+
+-- | Generate a 'WorkspaceEdit' value from an original file and text to replace it.
+makeDiffResult :: FilePath -> T.Text -> (FilePath -> FilePath) -> IO WorkspaceEdit
+makeDiffResult orig new fileMap = do
+  origText <- T.readFile orig
+  let fp' = fileMap orig
+  fp <- GM.makeAbsolute' fp'
+  return $ diffText (filePathToUri fp,origText) new
 
 -- |Generate a 'WorkspaceEdit' value from a pair of source Text
 diffText :: (Uri,T.Text) -> T.Text -> WorkspaceEdit

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -204,7 +204,7 @@ instance MonadTrans IdeResultT where
 data IdeResponse' m a = IdeResponseDeferred FilePath (CachedModule -> m (IdeResponse' m a))
                       | IdeResponseResult (IdeResult a)
 
-type IdeResponse a = IdeResponse' (IdeM) a
+type IdeResponse a = IdeResponse' IdeM a
 
 pattern IdeResponseOk :: a -> IdeResponse' m a
 pattern IdeResponseOk a = IdeResponseResult (IdeResultOk a)

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -29,6 +29,7 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Types
 import           Haskell.Ide.Engine.Monad
 import qualified Language.Haskell.LSP.Types            as J
+import           Control.Exception
 
 data DispatcherEnv = DispatcherEnv
   { cancelReqsTVar     :: !(TVar (S.Set J.LspId))
@@ -54,8 +55,17 @@ dispatcherP inChan plugins ghcModOptions env errorHandler callbackHandler =
     gchan <- liftIO $ do
       ghcChan <- newTChanIO
       ideChan <- newTChanIO
+
       _ <- forkIO $ mainDispatcher inChan ghcChan ideChan
-      _ <- forkIO $ runReaderT (ideDispatcher env errorHandler callbackHandler ideChan) stateVar
+
+      mainThread <- myThreadId
+      let exceptionHandler e = do
+            --TODO: Use async's link
+            errorm $ show (e :: SomeException)
+            throwTo mainThread e
+          ideLoop = handle exceptionHandler
+                           (runReaderT (ideDispatcher env errorHandler callbackHandler ideChan) stateVar)
+      _ <- forkIO ideLoop
       return ghcChan
     ghcDispatcher env errorHandler callbackHandler gchan
 

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
+module Haskell.Ide.Engine.LSP.CodeActions where
+  
+import Control.Lens
+import qualified Data.Aeson as J
+import qualified Data.Bimap as BM
+import qualified Data.Text as T
+--TODO: Can we get rid of this?
+import qualified Data.Vector as V
+import Data.Maybe
+import Data.Foldable
+import Haskell.Ide.Engine.LSP.Reactor
+import qualified Haskell.Ide.Engine.Plugin.ApplyRefact as ApplyRefact
+import qualified Haskell.Ide.Engine.Plugin.Hoogle as Hoogle
+import qualified Haskell.Ide.Engine.Plugin.HsImport as HsImport
+import Haskell.Ide.Engine.Types
+import qualified Language.Haskell.LSP.Core as Core
+import qualified Language.Haskell.LSP.Types as J
+import Language.Haskell.LSP.Messages
+
+handleCodeActionReq :: TrackingNumber -> BM.Bimap T.Text T.Text -> (PluginRequest R -> R ()) -> J.CodeActionRequest -> R ()
+handleCodeActionReq tn commandMap makeRequest req = do
+
+  let params = req ^. J.params
+      doc = params ^. J.textDocument . J.uri
+      (J.List diags) = params ^. J.context . J.diagnostics
+
+  let
+    mkHlintCmd (J.Diagnostic (J.Range start _) _s (Just code) (Just "hlint") m _) = [J.Command title cmd cmdparams]
+      where
+        title :: T.Text
+        title = "Apply hint:" <> head (T.lines m)
+        -- NOTE: the cmd needs to be registered via the InitializeResponse message. See hieOptions above
+        cmd = commandMap BM.! "applyrefact:applyOne"
+        -- need 'file', 'start_pos' and hint title (to distinguish between alternative suggestions at the same location)
+        args = J.Array $ V.singleton $ J.toJSON $ ApplyRefact.AOP doc start code
+        cmdparams = Just args
+
+    mkHlintCmd (J.Diagnostic _r _s _c _source _m _) = []
+
+    hlintActions = concatMap mkHlintCmd $ filter validCommand diags
+      where
+            -- |Some hints do not have an associated refactoring
+        validCommand (J.Diagnostic _ _ (Just code) (Just "hlint") _ _) =
+          case code of
+            "Eta reduce" -> False
+            _            -> True
+        validCommand _ = False
+
+    missingVars = mapMaybe isMissingDiag diags
+      where
+        isMissingDiag :: J.Diagnostic -> Maybe T.Text
+        isMissingDiag (J.Diagnostic _ _ _ (Just "ghcmod") msg _) = asum
+          [T.stripPrefix "Variable not in scope: " msg,
+            fmap T.init (T.stripPrefix "Not in scope: type constructor or class ‘" msg)]
+        isMissingDiag _ = Nothing
+
+    mkImportCmd modName = J.Command title cmd (Just cmdParams)
+      where
+        title = "Import module " <> modName
+        cmd = commandMap BM.! "hsimport:import"
+        cmdParams = J.toJSON [HsImport.ImportParams doc modName]
+
+    searchModules term callback = do
+      let searchReq = IReq tn (req ^. J.id)
+                              (callback . take 5)
+                              (Hoogle.searchModules term)
+      makeRequest searchReq
+
+    send codeActions =
+      reactorSend $ RspCodeAction $ Core.makeResponseMessage req (J.List codeActions)
+    in
+      -- If we have some possible import code actions
+      if not (null missingVars) then do
+        let -- Will look like myFunc :: Int -> String
+            variable = head missingVars
+            makeCmds = map mkImportCmd
+        searchModules variable $ \case
+          -- Try with just the name and no type
+          -- e.g. myFunc
+          [] -> searchModules (head (T.words variable)) (send . (++ hlintActions) . makeCmds)
+          -- We got some module sos use these
+          xs -> send $ makeCmds xs ++ hlintActions
+      else
+        send hlintActions
+-- TODO: make context specific commands for all sorts of things, such as refactorings          

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -7,8 +7,6 @@ import Control.Lens
 import qualified Data.Aeson as J
 import qualified Data.Bimap as BM
 import qualified Data.Text as T
---TODO: Can we get rid of this?
-import qualified Data.Vector as V
 import Data.Maybe
 import Data.Foldable
 import Haskell.Ide.Engine.LSP.Reactor
@@ -35,7 +33,7 @@ handleCodeActionReq tn commandMap makeRequest req = do
         -- NOTE: the cmd needs to be registered via the InitializeResponse message. See hieOptions above
         cmd = commandMap BM.! "applyrefact:applyOne"
         -- need 'file', 'start_pos' and hint title (to distinguish between alternative suggestions at the same location)
-        args = J.Array $ V.singleton $ J.toJSON $ ApplyRefact.AOP doc start code
+        args = J.toJSON [ApplyRefact.AOP doc start code]
         cmdparams = Just args
 
     mkHlintCmd (J.Diagnostic _r _s _c _source _m _) = []

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -152,6 +152,8 @@ extractRenamableTerms msg = mapMaybe extractReplacement replacementLines
 
   where noBullets = T.lines $ T.replace "• " "" msg
         replacementLines = tail noBullets
-        extractReplacement line = do
-          startOfTerm <- T.stripPrefix "Perhaps you meant ‘" line
-          return $ T.takeWhile (/= '’') startOfTerm
+        extractReplacement line =
+          let startOfTerm = T.dropWhile (/= '‘') line
+          in if startOfTerm == ""
+            then Nothing
+            else Just $ T.takeWhile (/= '’') (T.tail startOfTerm)

--- a/src/Haskell/Ide/Engine/LSP/Config.hs
+++ b/src/Haskell/Ide/Engine/LSP/Config.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Haskell.Ide.Engine.LSP.Config where
+
+import Data.Aeson
+import qualified Data.Text as T
+import Language.Haskell.LSP.Types
+
+-- | Callback from haskell-lsp core to convert the generic message to the
+-- specific one for hie
+getConfig :: DidChangeConfigurationNotification -> Either T.Text Config
+getConfig (NotificationMessage _ _ (DidChangeConfigurationParams p)) =
+  case fromJSON p of
+    Success c -> Right c
+    Error err -> Left $ T.pack err
+
+data Config =
+  Config
+    { hlintOn             :: Bool
+    , maxNumberOfProblems :: Int
+    } deriving (Show)
+
+instance FromJSON Config where
+  parseJSON = withObject "Config" $ \v -> do
+    s <- v .: "languageServerHaskell"
+    flip (withObject "Config.settings") s $ \o -> Config
+      <$> o .:? "hlintOn" .!= True
+      <*> o .: "maxNumberOfProblems"
+
+-- 2017-10-09 23:22:00.710515298 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"languageServerHaskell":{"maxNumberOfProblems":100,"hlintOn":true}}}}
+-- 2017-10-09 23:22:00.710667381 [ThreadId 15] - reactor:got didChangeConfiguration notification:
+-- NotificationMessage
+--   {_jsonrpc = "2.0"
+--   , _method = WorkspaceDidChangeConfiguration
+--   , _params = DidChangeConfigurationParams
+--                 {_settings = Object (fromList [("languageServerHaskell",Object (fromList [("hlintOn",Bool True)
+--                                                                                          ,("maxNumberOfProblems",Number 100.0)]))])}}

--- a/src/Haskell/Ide/Engine/LSP/Reactor.hs
+++ b/src/Haskell/Ide/Engine/LSP/Reactor.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE FlexibleContexts #-}
+module Haskell.Ide.Engine.LSP.Reactor where
+
+import Control.Monad.Reader
+import qualified Language.Haskell.LSP.Core as Core
+import Language.Haskell.LSP.Messages
+import Haskell.Ide.Engine.LSP.Config
+
+-- | The monad used in the reactor
+type R = ReaderT (Core.LspFuncs Config) IO
+
+-- ---------------------------------------------------------------------
+-- reactor monad functions
+-- ---------------------------------------------------------------------
+
+reactorSend :: (MonadIO m, MonadReader (Core.LspFuncs Config) m) => FromServerMessage -> m ()
+reactorSend msg = do
+  sf <- asks Core.sendFunc
+  liftIO $ sf msg
+
+-- ---------------------------------------------------------------------
+
+reactorSend' :: (MonadIO m, MonadReader (Core.LspFuncs Config) m)
+  => (Core.SendFunc -> IO ()) -> m ()
+reactorSend' f = do
+  lf <- ask
+  liftIO $ f (Core.sendFunc lf)
+
+-- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -10,7 +10,6 @@ import           Control.Monad.Trans.Except
 import           Data.Aeson                        hiding (Error)
 import           Data.Monoid                       ((<>))
 import qualified Data.Text                         as T
-import qualified Data.Text.IO                      as T
 import           GHC.Generics
 import qualified GhcMod.Utils                      as GM
 import           Haskell.Ide.Engine.MonadFunctions
@@ -266,10 +265,3 @@ runHlint fp args =
 showParseError :: Hlint.ParseError -> String
 showParseError (Hlint.ParseError location message content) =
   unlines [show location, message, content]
-
-makeDiffResult :: FilePath -> T.Text -> (FilePath -> FilePath) -> IO WorkspaceEdit
-makeDiffResult orig new fileMap = do
-  origText <- T.readFile orig
-  let fp' = fileMap orig
-  fp <- GM.makeAbsolute' fp'
-  return $ diffText (filePathToUri fp,origText) new

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -218,7 +218,7 @@ makeRefactorResult changedFiles = do
       -- TODO: remove this logging once we are sure we have a working solution
       logm $ "makeRefactorResult:groupedDiff = " ++ show (getGroupedDiff (lines $ T.unpack origText) (lines $ T.unpack newText))
       logm $ "makeRefactorResult:diffops = " ++ show (diffToLineRanges $ getGroupedDiff (lines $ T.unpack origText) (lines $ T.unpack newText))
-      return $ diffText (filePathToUri fp, origText) newText
+      return $ diffText (filePathToUri fp, origText) newText False
   diffs <- mapM diffOne changedFiles
   return $ Core.reverseSortEdit $ fold diffs
 

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -198,7 +198,7 @@ genApplicativeCommand  = CmdSync $ \(HP uri pos) ->
 
 genApplicativeCommand' :: Uri -> Position -> IdeGhcM (IdeResult WorkspaceEdit)
 genApplicativeCommand' uri pos =
-  pluginGetFile "genapplicative: " uri $ \file -> do
+  pluginGetFile "genapplicative: " uri $ \file ->
       runHareCommand "genapplicative" (compGenApplicative file (unPos pos))
 
 

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -106,6 +106,18 @@ renderTarget t = T.intercalate "\n\n" $
 
 ------------------------------------------------------------------------
 
+searchModules :: T.Text -> IdeM (IdeResponse [T.Text])
+searchModules modul = do
+  HoogleDb mdb <- get
+  case mdb of
+    Nothing -> return $ IdeResponseOk []
+    Just db -> do
+      targets <- liftIO (searchHoogle db modul)
+      let modules = mapMaybe targetModule targets
+      return $ IdeResponseOk $ map (T.pack . fst) modules
+
+------------------------------------------------------------------------
+
 lookupCmd :: CommandFunc T.Text [T.Text]
 lookupCmd = CmdSync $ \term -> do
   res <- liftToGhc $ bimap hoogleErrorToIdeError id <$> lookupCmd' 10 term
@@ -129,4 +141,5 @@ runHoogleQuery (Just db) quer f = do
 
 searchHoogle :: FilePath -> T.Text -> IO [Target]
 searchHoogle dbf quer = withDatabase dbf (return . flip searchDatabase (T.unpack quer))
+
 

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -19,7 +19,7 @@ import           System.IO
 hsimportDescriptor :: PluginDescriptor
 hsimportDescriptor = PluginDescriptor
   { pluginName = "hsimport"
-  , pluginDesc = "hsimport a tool for extending the import list of a Haskell source file."
+  , pluginDesc = "A tool for extending the import list of a Haskell source file."
   , pluginCommands = [PluginCommand "import" "Import a module" importCmd]
   }
 

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+module Haskell.Ide.Engine.Plugin.HsImport where
+
+import           Control.Monad.IO.Class
+import           Data.Aeson
+import qualified Data.Text                     as T
+import qualified Data.Text.IO                  as T
+import qualified GHC.Generics                  as Generics
+import qualified GhcMod.Utils                  as GM
+import           HsImport
+import           Haskell.Ide.Engine.MonadTypes
+import qualified Language.Haskell.LSP.Types    as J
+import           Haskell.Ide.Engine.PluginUtils
+import           System.Directory
+import           System.IO
+
+hsimportDescriptor :: PluginDescriptor
+hsimportDescriptor = PluginDescriptor
+  { pluginName = "hsimport"
+  , pluginDesc = "hsimport a tool for extending the import list of a Haskell source file."
+  , pluginCommands = [PluginCommand "import" "Import a module" importCmd]
+  }
+
+data ImportParams = ImportParams Uri T.Text
+  deriving (Show, Eq, Generics.Generic, ToJSON, FromJSON)
+
+importCmd :: CommandFunc ImportParams J.WorkspaceEdit
+importCmd = CmdSync $ \(ImportParams uri modName) -> importModule uri modName
+
+importModule :: Uri -> T.Text -> IdeGhcM (IdeResult J.WorkspaceEdit)
+importModule uri modName =
+  pluginGetFile "hsimport cmd: " uri $ \origInput -> do
+
+    fileMap <- GM.mkRevRedirMapFunc
+    GM.withMappedFile origInput $ \input -> liftIO $ do
+
+      tmpDir            <- getTemporaryDirectory
+      (output, outputH) <- openTempFile tmpDir "hsimportOutput"
+      hClose outputH
+
+      let args = defaultArgs { moduleName    = T.unpack modName
+                             , inputSrcFile  = input
+                             , outputSrcFile = output
+                             }
+      maybeErr <- liftIO $ hsimportWithArgs defaultConfig args
+      case maybeErr of
+        Just err -> do
+          removeFile output
+          let msg = T.pack $ show err
+          return $ IdeResultFail (IdeError PluginError msg Null)
+        Nothing -> do
+          newText <- T.readFile output
+          removeFile output
+          workspaceEdit <- makeDiffResult input newText fileMap
+          return $ IdeResultOk workspaceEdit

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE RankNTypes #-}
+module Haskell.Ide.Engine.Plugin.Package where
+
+import           Haskell.Ide.Engine.MonadTypes
+import           Haskell.Ide.Engine.MonadFunctions (logm)
+import           Haskell.Ide.Engine.PluginUtils
+import           GHC.Generics
+import           Data.Aeson
+import           Control.Lens
+import           Data.List
+import qualified Data.Text                     as T
+import           Data.Maybe
+import           Distribution.PackageDescription.Parsec
+import           Distribution.Types.Dependency
+import           Distribution.Types.PackageName
+import           Distribution.Types.VersionRange
+import qualified Language.Haskell.LSP.Types    as J
+import           Distribution.Verbosity
+import           System.FilePath
+import           Control.Monad.IO.Class
+import           System.Directory
+import qualified GhcMod.Utils                  as GM
+import qualified Distribution.Types.GenericPackageDescription.Lens as L
+import           Distribution.Types.GenericPackageDescription
+import           Distribution.Types.CondTree
+import qualified Distribution.PackageDescription.PrettyPrint as PP
+import qualified Distribution.Types.BuildInfo.Lens as L
+
+packageDescriptor :: PluginDescriptor
+packageDescriptor = PluginDescriptor
+  { pluginName     = "package"
+  , pluginDesc     = "Tools for editing .cabal and package.yaml files."
+  , pluginCommands = [PluginCommand "add" "Add a packge" addCmd]
+  }
+
+data AddParams = AddParams FilePath -- ^ The root directory.
+                           FilePath -- ^ A path to a module inside the
+                                    -- library/executable/test-suite you want to
+                                    -- add the package to.
+                           T.Text -- ^ The name of the package to add.
+  deriving (Eq, Show, Read, Generic, ToJSON, FromJSON)
+
+addCmd :: CommandFunc AddParams J.WorkspaceEdit
+addCmd = CmdSync $ \(AddParams rootDir modulePath pkg) -> do
+  --TODO: Package.yaml
+
+  logm $ "Got args: " ++ show rootDir ++ show pkg
+  fileMap <- GM.mkRevRedirMapFunc
+
+  files <- liftIO $ getDirectoryContents rootDir
+  let maybeCabal = listToMaybe $ filter (isExtensionOf "cabal") files
+  case maybeCabal of
+    Just cabal -> liftIO $ do
+      absCabal <- canonicalizePath cabal
+      newPackage <- editPackage absCabal modulePath (T.unpack pkg)
+      edit <- makeAdditiveDiffResult absCabal (T.pack newPackage) fileMap
+      return $ IdeResultOk edit
+    _           -> error "No .cabal"
+
+
+-- | Takes a cabal file and a path to a module in the dependency you want to edit.
+editPackage :: FilePath -> FilePath ->  String -> IO String
+editPackage file modulePath pkgName = do
+
+  package <- liftIO $ readGenericPackageDescription normal file
+
+  let newMainLib = fmap updateTree $ package ^. L.condLibrary
+      swappedMainLib = L.condLibrary .~ newMainLib $ package
+      newPackage = applyLens L.condSubLibraries
+                    $ applyLens L.condTestSuites
+                    $ applyLens L.condExecutables
+                    $ applyLens L.condBenchmarks swappedMainLib
+
+  return $ PP.showGenericPackageDescription newPackage
+
+  where relModulePath = makeRelative (takeDirectory file) modulePath
+
+        applyLens :: L.HasBuildInfo a => Lens' GenericPackageDescription [(b, CondTree v c a)]
+                  -> GenericPackageDescription -> GenericPackageDescription
+        applyLens l pkg =
+          let old = pkg ^. l
+              new = map (\(name, tree) -> (name, updateTree tree)) old
+          in l .~ new $ pkg
+
+        updateTree :: L.HasBuildInfo a => CondTree v c a -> CondTree v c a
+        updateTree = mapIfHasModule relModulePath (addDep pkgName)
+
+
+mapIfHasModule :: L.HasBuildInfo a => FilePath -> (a -> a) -> CondTree v c a -> CondTree v c a
+mapIfHasModule modFp f = mapTreeData g
+  where g x = if hasThisModule x
+                then f x
+                else x
+        hasThisModule x = any (`isPrefixOf` modFp) (x ^. L.buildInfo . L.hsSourceDirs)
+
+addDep :: L.HasBuildInfo a => String -> a -> a
+addDep dep x = L.buildInfo . L.targetBuildDepends .~ newDeps $ x
+  where oldDeps = x ^. L.buildInfo . L.targetBuildDepends
+        -- Add it to the bottom of the dependencies list
+        newDeps = oldDeps ++ [Dependency (mkPackageName dep) anyVersion]

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -136,7 +136,7 @@ run dispatcherProc cin _origDir captureFp = flip E.catches handlers $ do
   someExcept (e :: E.SomeException) = print e >> return 1
   getCommandMap = do
     pid <- T.pack . show <$> getProcessID
-    let cmds = ["hare:demote", "applyrefact:applyOne", "hsimport:import", "hie:applyWorkspaceEdit"]
+    let cmds = ["hare:demote", "applyrefact:applyOne", "hsimport:import", "package:add", "hie:applyWorkspaceEdit"]
         newCmds = map (T.append pid . T.append ":") cmds
     return $ BM.fromList (zip cmds newCmds)
 
@@ -743,6 +743,7 @@ requestDiagnostics tn cin file ver = do
   mc <- liftIO $ Core.config lf
   let
     -- | If there is a GHC error, flush the hlint diagnostics
+    -- TODO: Just flush the parse error diagnostics
     sendOneGhc :: J.DiagnosticSource -> (Uri, [Diagnostic]) -> R ()
     sendOneGhc pid (fileUri,ds) = do
       if any (hasSeverity J.DsError) ds

--- a/src/Haskell/Ide/Engine/Types.hs
+++ b/src/Haskell/Ide/Engine/Types.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE OverloadedStrings #-}
 module Haskell.Ide.Engine.Types where
 
 import           Haskell.Ide.Engine.MonadTypes

--- a/stack.yaml
+++ b/stack.yaml
@@ -38,6 +38,7 @@ extra-deps:
 - haddock-library-1.6.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
+- hsimport-0.8.6
 
 flags:
   haskell-ide-engine:

--- a/test/CodeActionsSpec.hs
+++ b/test/CodeActionsSpec.hs
@@ -16,19 +16,29 @@ spec = do
     it "pick up variable not in scope with 'perhaps you meant'" $
       let msg =  "• Variable not in scope: msgs :: T.Text\n• Perhaps you meant ‘msg’ (line 90)"
         in extractImportableTerm msg `shouldBe` Just "msgs :: T.Text"
+    it "pick up multi-line variable not in scope" $
+      let msg = "Variable not in scope:\nliftIO\n:: IO [FilePath]\n-> GhcMod.Monad.Newtypes.GmT\n                (GhcMod.Monad.Newtypes.GmOutT IdeM) [[t0]]"
+        in extractImportableTerm msg `shouldBe` Just "liftIO :: IO [FilePath] -> GhcMod.Monad.Newtypes.GmT (GhcMod.Monad.Newtypes.GmOutT IdeM) [[t0]]"
 
   describe "rename code actions" $ do
     it "pick up variable not in scope perhaps you meant" $
       let msg = "• Variable not in scope: fromBust\n• Perhaps you meant ‘fromJust’ (imported from Data.Maybe)"
         in extractRenamableTerms msg `shouldBe` ["fromJust"]
+    it "pick up multiline perhaps you meant" $
+      let msg = "• Variable not in scope: fromBust :: [Char] -> t\n• Perhaps you meant one of these:\n‘fromJust’ (imported from Data.Maybe),\n‘BM.fromList’ (imported from Data.Bimap),\n‘HM.fromList’ (imported from Data.HashMap.Strict)"
+        in extractRenamableTerms msg `shouldBe` ["fromJust", "BM.fromList", "HM.fromList"]
+    it "doen't pick up irrelvant messages" $
+      let msg = "The import of ‘Control.Exception’ is redundant\n      except perhaps to import instances from ‘Control.Exception’"
+        in extractRenamableTerms msg `shouldBe` []
       
     it "picks up variable not in scope with multiple suggestions" $
       let msg = "• Variable not in scope: uri\n• Perhaps you meant one of these:\n‘J.uri’ (imported from Language.Haskell.LSP.Types),\ndata constructor ‘J.Uri’ (imported from Language.Haskell.LSP.Types)"
         in extractRenamableTerms msg `shouldBe` ["J.uri", "J.Uri"]
 
-        -- TODO: write a test for this:
-        -- "Variable not in scope:
-        -- asks
-        --   :: (Core.LspFuncs c0 -> J.Uri -> IO (Maybe VirtualFile))
-        --      -> Control.Monad.Trans.Reader.ReaderT
-        --           (Core.LspFuncs Haskell.Ide.Engine.LSP.Config.Config) IO (t1 -> t0)"
+  describe "missing package code actions" $ do
+    it "pick up relevant messages" $ 
+      let msg = "Could not find module ‘Foo.Bar’\n      Use -v to see a list of the files searched for."
+        in extractModuleName msg `shouldBe` Just "Foo.Bar"
+    it "don't pick up irrelevant messages" $ 
+      let msg = "Could not find modulez ‘Foo.Bar’\n      Use -v to see a list of the files searched for."
+        in extractModuleName msg `shouldBe` Nothing

--- a/test/CodeActionsSpec.hs
+++ b/test/CodeActionsSpec.hs
@@ -24,8 +24,9 @@ spec = do
       
     it "picks up variable not in scope with multiple suggestions" $
       let msg = "• Variable not in scope: uri\n• Perhaps you meant one of these:\n‘J.uri’ (imported from Language.Haskell.LSP.Types),\ndata constructor ‘J.Uri’ (imported from Language.Haskell.LSP.Types)"
-        in extractRenamableTerms msg `shouldBe` ["J.uri", "J.uri"]
+        in extractRenamableTerms msg `shouldBe` ["J.uri", "J.Uri"]
 
+        -- TODO: write a test for this:
         -- "Variable not in scope:
         -- asks
         --   :: (Core.LspFuncs c0 -> J.Uri -> IO (Maybe VirtualFile))

--- a/test/CodeActionsSpec.hs
+++ b/test/CodeActionsSpec.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+module CodeActionsSpec where
+
+import Test.Hspec
+import Haskell.Ide.Engine.LSP.CodeActions
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "import code actions" $ do
+    it "pick up variable not in scope" $
+      let msg =  "Variable not in scope: fromJust :: Maybe Integer -> t"
+        in extractImportableTerm msg `shouldBe` Just "fromJust :: Maybe Integer -> t"
+    it "pick up variable not in scope with 'perhaps you meant'" $
+      let msg =  "• Variable not in scope: msgs :: T.Text\n• Perhaps you meant ‘msg’ (line 90)"
+        in extractImportableTerm msg `shouldBe` Just "msgs :: T.Text"
+
+  describe "rename code actions" $ do
+    it "pick up variable not in scope perhaps you meant" $
+      let msg = "• Variable not in scope: fromBust\n• Perhaps you meant ‘fromJust’ (imported from Data.Maybe)"
+        in extractRenamableTerms msg `shouldBe` ["fromJust"]
+      
+    it "picks up variable not in scope with multiple suggestions" $
+      let msg = "• Variable not in scope: uri\n• Perhaps you meant one of these:\n‘J.uri’ (imported from Language.Haskell.LSP.Types),\ndata constructor ‘J.Uri’ (imported from Language.Haskell.LSP.Types)"
+        in extractRenamableTerms msg `shouldBe` ["J.uri", "J.uri"]
+
+        -- "Variable not in scope:
+        -- asks
+        --   :: (Core.LspFuncs c0 -> J.Uri -> IO (Maybe VirtualFile))
+        --      -> Control.Monad.Trans.Reader.ReaderT
+        --           (Core.LspFuncs Haskell.Ide.Engine.LSP.Config.Config) IO (t1 -> t0)"

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -175,15 +175,16 @@ spec = do
         reduceDiag ^. source `shouldBe` Just "hlint"
 
       let r = Range (Position 0 0) (Position 99 99)
-          c = CodeActionContext (diagsRsp ^. params . diagnostics)
+          c = CodeActionContext (diagsRsp ^. params . diagnostics) Nothing
       _ <- sendRequest TextDocumentCodeAction (CodeActionParams doc r c)
       
       rsp <- response :: Session CodeActionResponse
-      let (List cmds) = fromJust $ rsp ^. result
+      let (Just (List cmds)) = fromJust $ rsp ^. result
           evaluateCmd = head cmds
       liftIO $ do
         length cmds `shouldBe` 1
-        evaluateCmd ^. title `shouldBe` "Apply hint:Evaluate"
+        let (CommandOrCodeActionCommand cmd) = evaluateCmd
+        cmd ^. title `shouldBe` "Apply hint:Evaluate"
 
   -- -----------------------------------
 


### PR DESCRIPTION
This does some rudimentary string manipulation to read the warnings given out by ghc-mod, and provide contextual code actions for them. In the future we should probably add API in ghc-mod to directly give us the information to create these code actions. 

So far it adds these types of code actions:
- Renaming code actions for when something is misspelt (Perhaps you meant?)
- Importing missing modules by searching up symbols in Hoogle with Hsimport (based off of https://github.com/alanz/vscode-hie-server/pull/83)
- Add missing dependencies to the .cabal files (also based off of https://github.com/alanz/vscode-hie-server/pull/83 !)

It also adds support for the new code action types in LSP v3.8, so you can use quick fix and refactor keybindings and such inside VS Code. 

# Todo
- [ ] Add package.yaml support
- [ ] Add more code actions
- [ ] Add functional tests for all of this
- [ ] Possibly look at moving the `makeRequest` functions inside the reactor into functions in the `R` monad

# Also
This moves out the code action code (the logic that glues LSP and the various Haskell tools) into a separate module since it was getting pretty big, so some reactor types have also been moved out. 

It also introduces `Cabal` as a dependency to mechanically edit the .cabal file, and I'm not sure how much this affects build time. 
Its used to work out which library/executable should have the dependencies added to based on the module that the quick fix is being applied on.