### PR TITLE
Ignore hlint errors instead of flushing all hlints 

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -247,10 +247,7 @@ filterIdeas (OneHint (Position l c) title) ideas =
   let
     title' = T.unpack title
     ideaPos = (srcSpanStartLine &&& srcSpanStartColumn) . ideaSpan
-    satisfiesAll preds i = foldl (\acc p -> acc && p i) False preds
-    predicates = [ \i -> ideaHint i == title'
-                 , \i -> ideaPos i == (l+1, c+1)]
-  in filter (satisfiesAll predicates) ideas
+  in filter (\i -> ideaHint i == title' && ideaPos i == (l+1, c+1)) ideas
 
 hlintOpts :: FilePath -> Maybe Position -> [String]
 hlintOpts lintFile mpos =

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -158,6 +158,7 @@ getConfig (J.NotificationMessage _ _ (J.DidChangeConfigurationParams p)) =
 data Config =
   Config
     { hlintOn             :: Bool
+    , hlintHideOnError    :: Bool
     , maxNumberOfProblems :: Int
     } deriving (Show)
 
@@ -166,6 +167,7 @@ instance J.FromJSON Config where
     s <- v .: "languageServerHaskell"
     flip (J.withObject "Config.settings") s $ \o -> Config
       <$> o .:? "hlintOn" .!= True
+      <*> o .:? "hlintHideOnError" .!= True
       <*> o .: "maxNumberOfProblems"
 
 -- 2017-10-09 23:22:00.710515298 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"languageServerHaskell":{"maxNumberOfProblems":100,"hlintOn":true}}}}
@@ -810,12 +812,14 @@ requestDiagnostics tn cin file ver = do
   lf <- ask
   mc <- liftIO $ Core.config lf
   let
-    sendOne pid (fileUri,ds) = do
-      publishDiagnostics maxToSend fileUri Nothing (Map.fromList [(Just pid,SL.toSortedList ds)])
-    sendEmpty = publishDiagnostics maxToSend file Nothing (Map.fromList [(Just "ghcmod",SL.toSortedList [])])
+    sendHlint = maybe True hlintOn mc
+    flushHlintOnError = maybe True hlintHideOnError mc
     maxToSend = maybe 50 maxNumberOfProblems mc
 
-  let sendHlint = maybe True hlintOn mc
+    sendOne pid (fileUri,ds) = do
+      publishDiagnostics maxToSend fileUri Nothing (Map.fromList [(Just pid,SL.toSortedList ds)])
+    sendEmpty pid = publishDiagnostics maxToSend file Nothing (Map.fromList [(Just pid,SL.toSortedList [])])
+
   when sendHlint $ do
     -- get hlint diagnostics
     let reql = GReq tn (Just file) (Just (file,ver)) Nothing callbackl
@@ -834,8 +838,10 @@ requestDiagnostics tn cin file ver = do
               $ "Got error while processing diagnostics: " <> e
         let ds = Map.toList $ S.toList <$> pd
         case ds of
-          [] -> sendEmpty
-          _ -> mapM_ (sendOne "ghcmod") ds
+          [] -> sendEmpty "hie"
+          _ -> forM_ ds $ \d -> do
+                when flushHlintOnError $ sendEmpty "hlint"
+                sendOne "ghcmod" d
 
   liftIO $ atomically $ writeTChan cin reqg
 

--- a/test/ApplyRefactPluginSpec.hs
+++ b/test/ApplyRefactPluginSpec.hs
@@ -93,7 +93,7 @@ applyRefactSpec = do
 
     -- ---------------------------------
 
-    it "returns hlint parse error as DsInfo ignored diagnostic" $ do
+    it "does not return hlint parse errors" $ do
       filePath  <- filePathToUri <$> makeAbsolute "./test/testdata/HlintParseFail.hs"
 
       let act = lintCmd' arg
@@ -101,15 +101,21 @@ applyRefactSpec = do
           res = IdeResultOk
             PublishDiagnosticsParams
              { _uri = filePath
-             , _diagnostics = List $
-               [Diagnostic {_range = Range { _start = Position {_line = 11, _character = 28}
+             , _diagnostics = List []
+               }
+      testCommand testPlugins act "applyrefact" "lint" arg res
+    
+    {-
+      The error diagnostic in question:
+    [Diagnostic {_range = Range { _start = Position {_line = 11, _character = 28}
                                            , _end = Position {_line = 11, _character = 100000}}
                            , _severity = Just DsInfo
                            , _code = Just "parser"
                            , _source = Just "hlint"
                            , _message = "Parse error: :~:\n  import           Data.Type.Equality            ((:~:) (..), (:~~:) (..))\n  \n> data instance Sing (z :: (a :~: b)) where\n      SRefl :: Sing Refl\n\n"
-                           , _relatedInformation = Nothing }]}
-      testCommand testPlugins act "applyrefact" "lint" arg res
+                           , _relatedInformation = Nothing }]
+    
+    -}
 
     -- ---------------------------------
 

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -192,16 +192,22 @@ spec = do
                                   -- $ runSession hieCommand "test/testdata" $ do
                                   $ runSession hieCommandVomit "test/testdata" $ do
       _doc <- openDoc "ApplyRefact2.hs" "haskell"
-      _diagsRspHlint <- skipManyTill anyNotification notification :: Session PublishDiagnosticsNotification
+      diagsRspHlint <- skipManyTill anyNotification notification :: Session PublishDiagnosticsNotification
       diagsRspGhc   <- skipManyTill anyNotification notification :: Session PublishDiagnosticsNotification
-      let (List diags) = diagsRspGhc ^. params . diagnostics
+      let (List diagsHlint) = diagsRspHlint ^. params . diagnostics
+          (List diagsGhc) = diagsRspGhc ^. params . diagnostics
 
-      liftIO $ length diags `shouldBe` 2
+      liftIO $ do
+        length diagsHlint `shouldBe` 2
+        length diagsGhc `shouldBe` 0
 
       _doc2 <- openDoc "HaReRename.hs" "haskell"
-      _diagsRspHlint2 <- skipManyTill anyNotification notification :: Session PublishDiagnosticsNotification
+      diagsRspHlint2 <- skipManyTill anyNotification notification :: Session PublishDiagnosticsNotification
       -- errMsg <- skipManyTill anyNotification notification :: Session ShowMessageNotification
-      diagsRsp2 <- skipManyTill anyNotification notification :: Session PublishDiagnosticsNotification
-      let (List diags2) = diagsRsp2 ^. params . diagnostics
+      diagsRspGhc2 <- skipManyTill anyNotification notification :: Session PublishDiagnosticsNotification
+      let (List diagsHlint2) = diagsRspHlint2 ^. params . diagnostics
+          (List diagsGhc2) = diagsRspGhc2 ^. params . diagnostics
 
-      liftIO $ show diags2 `shouldBe` "[]"
+      liftIO $ do
+        diagsHlint2 `shouldBe` []
+        diagsGhc2 `shouldBe` []

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -25,7 +25,7 @@ main = do
     cdAndDo "./test/testdata" $ hspec dispatchSpec
 
 spec :: Spec
-spec = parallel $ do
+spec = do
   describe "deferred responses" $ do
     it "do not affect hover requests" $ runSession hieCommand "test/testdata" $ do
       doc <- openDoc "FuncTest.hs" "haskell"

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -25,7 +25,7 @@ main = do
     cdAndDo "./test/testdata" $ hspec dispatchSpec
 
 spec :: Spec
-spec = do
+spec = parallel $ do
   describe "deferred responses" $ do
     it "do not affect hover requests" $ runSession hieCommand "test/testdata" $ do
       doc <- openDoc "FuncTest.hs" "haskell"


### PR DESCRIPTION
Whenever ghc-mod returns an error it currently flushes all hlint diagnostics, even if hlint didn't necessarily have a parse error. This changes it to not flush the diagnostics and instead filters out the hlint errors in the first place. Should still keep #490

- [x] Add a config option