### PR TITLE
Add Windows batch equivalent of `make build-all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ we talk to clients.__
    ![Renaming](https://i.imgur.com/z03G2a5.gif)
 
  - Adding chosen import and the package dependencies (vscode only)
- 
+
    ![Adding import & deps](https://user-images.githubusercontent.com/1387653/40287051-b6f987fe-5c5f-11e8-980f-ed7bfa1b2aec.gif)
 
 ## Installation
@@ -169,6 +169,9 @@ stack --stack-yaml=stack-8.0.2.yaml install
 ```
 
 #### Installation on Windows
+
+The Windows batch file `make-build-all.bat` can substitute for `make build-all` on
+systems without the `make` command.
 
 In order to avoid problems with long paths you can do the following:
 

--- a/make-build-all.bat
+++ b/make-build-all.bat
@@ -1,0 +1,61 @@
+@REM Windows batch file script that replicates the function of 'make build-all'.
+
+@ECHO OFF
+
+SETLOCAL
+FOR /F "delims=" %%F IN ('stack path --local-bin') DO (
+SET STACKLOCALBINDIR=%%F
+)
+
+REM build-all
+CALL :build
+CALL :build-docs
+EXIT /B
+
+:build
+CALL :hie-8.2.1
+CALL :hie-8.2.2
+CALL :hie-8.4.2
+CALL :hie-8.4.3
+EXIT /B
+
+:hie-8.2.1
+CALL :submodules
+stack --stack-yaml=stack-8.2.1.yaml install happy
+stack --stack-yaml=stack-8.2.1.yaml install
+COPY "%STACKLOCALBINDIR%\hie.exe" "%STACKLOCALBINDIR%\hie-8.2.1.exe"
+COPY "%STACKLOCALBINDIR%\hie-8.2.1.exe" "%STACKLOCALBINDIR%\hie-8.2.exe"
+EXIT /B
+
+:hie-8.2.2
+CALL :submodules
+stack --stack-yaml=stack-8.2.2.yaml install happy
+stack --stack-yaml=stack-8.2.2.yaml install
+COPY "%STACKLOCALBINDIR%\hie.exe" "%STACKLOCALBINDIR%%\hie-8.2.2.exe"
+COPY "%STACKLOCALBINDIR%\hie-8.2.2.exe" "%STACKLOCALBINDIR%\hie-8.2.exe"
+EXIT /B
+
+:hie-8.4.2
+CALL :submodules
+stack --stack-yaml=stack-8.4.2.yaml install
+COPY "%STACKLOCALBINDIR%\hie.exe" "%STACKLOCALBINDIR%\hie-8.4.2.exe"
+COPY "%STACKLOCALBINDIR%\hie-8.4.2.exe" "%STACKLOCALBINDIR%\hie-8.4.exe"
+EXIT /B
+
+:hie-8.4.3
+CALL :submodules
+stack --stack-yaml=stack.yaml install
+COPY "%STACKLOCALBINDIR%\hie.exe" "%STACKLOCALBINDIR%\hie-8.4.3.exe"
+COPY "%STACKLOCALBINDIR%\hie-8.4.3.exe" "%STACKLOCALBINDIR%\hie-8.4.exe"
+EXIT /B
+
+:submodules
+git submodule update --init
+EXIT /B
+
+:build-docs
+stack --stack-yaml=stack-8.2.1.yaml exec hoogle generate
+stack --stack-yaml=stack-8.2.2.yaml exec hoogle generate
+stack --stack-yaml=stack-8.4.2.yaml exec hoogle generate
+stack --stack-yaml=stack.yaml exec hoogle generate
+EXIT /B


### PR DESCRIPTION
The command `make build-all` does not work on 'out of the box' Windows. There are work-arounds, for example the Cygwin installer has the option of including a `make` command. This pull request suggests taking the approach of providing a Windows batch file that replicates the function of `make build-all`.  

`README.md` is updated, accordingly.