### PR TITLE
Re #669: Extend docs about make tool on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ $ git submodule update --init
 
 To install HIE, you need Stack version >= 1.7.1
 
-To install all supported GHC versions, and name them as expected
-by the vscode plugin, and also build a local hoogle database, do
+To install all supported GHC versions, name them as expected by the VS Code
+plugin, and also build a local hoogle database, you need the `make` tool (on
+Windows, see the further advice below). Use the command:
 
 ```bash
 make build-all
@@ -123,7 +124,7 @@ Then add
 "languageServerHaskell.useHieWrapper": true
 ```
 
-to VSCode user settings.
+to VS Code user settings.
 
 Otherwise, do one of the following.
 
@@ -168,16 +169,40 @@ stack --stack-yaml=stack-8.2.1.yaml install
 stack --stack-yaml=stack-8.0.2.yaml install
 ```
 
-#### Installation on Windows
+### Installation on Windows
 
-The Windows batch file `make-build-all.bat` can substitute for `make build-all` on
-systems without the `make` command.
+#### The `make` tool
 
-In order to avoid problems with long paths you can do the following:
+If the `make` tool is not already available on your path (in Command Prompt, try
+commands `where make` or `stack exec where -- make` to investigate; in
+PowerShell, try `where.exe make` or `stack exec where -- make`), it can be added
+to the `stack` environment with the command:
 
-1. Edit the group policy: set "Enable Win32 long paths" to "Enabled". Works only for Windows 10
+```batch
+stack exec pacman -- -S make
+```
 
-2. Clone the `haskell-ide-engine` to the root of your logical drive (e.g. to `E:\hie`)
+The `make build-all` command is then accessible using the command:
+
+```batch
+stack exec make -- build-all
+```
+
+For users of [Cygwin](http://www.cygwin.com/), the Cygwin installer also
+provides the `make` tool as an option.
+
+Alternatively, the Windows batch file `make-build-all.bat` can substitute for
+`make build-all` on systems without the `make` command.
+
+#### Long paths
+
+In order to avoid problems with long paths on Windows you can do the following:
+
+1. Edit the group policy: set "Enable Win32 long paths" to "Enabled". Works
+   only for Windows 10
+
+2. Clone the `haskell-ide-engine` to the root of your logical drive (e.g. to
+   `E:\hie`)
 
 
 ### Installation with Nix


### PR DESCRIPTION
Note, this does not amend (correct) the advice in `README.md` about `"languageServerHaskell.useHieWrapper": true` (see https://github.com/alanz/vscode-hie-server/issues/97). I did not know if that advice was still good on unix-like operating systems.