### PR TITLE
Update for LTS-12.0, bump resolvers where possible.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,11 @@ jobs:
 
   ghc-8.4.3:
     environment:
+      - STACK_FILE: "stack-8.4.3.yaml"
+    <<: *defaults
+
+  ghc-nightly:
+    environment:
       - STACK_FILE: "stack.yaml"
     <<: *defaults
 
@@ -116,4 +121,5 @@ workflows:
       - ghc-8.2.2
       - ghc-8.4.2
       - ghc-8.4.3
+      - ghc-nightly
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ hie-8.4.2: submodules
 .PHONY: hie-8.2.2
 
 hie-8.4.3: submodules
-	stack --stack-yaml=stack.yaml install                                      \
+	stack --stack-yaml=stack-8.4.3.yaml install                                      \
 		&& cp '$(STACKLOCALBINDIR)/hie' '$(STACKLOCALBINDIR)/hie-8.4.3'    \
 		&& cp '$(STACKLOCALBINDIR)/hie-8.4.3' '$(STACKLOCALBINDIR)/hie-8.4'
 .PHONY: hie-8.4.3
@@ -45,7 +45,7 @@ build-docs:
 	stack --stack-yaml=stack-8.2.1.yaml exec hoogle generate \
 	&& stack --stack-yaml=stack-8.2.2.yaml exec hoogle generate \
 	&& stack --stack-yaml=stack-8.4.2.yaml exec hoogle generate \
-	&& stack --stack-yaml=stack.yaml exec hoogle generate
+	&& stack --stack-yaml=stack-8.4.3.yaml exec hoogle generate
 .PHONY: build-docs
 
 
@@ -55,14 +55,14 @@ test: submodules
 	stack --stack-yaml=stack-8.2.1.yaml test \
 	&& stack --stack-yaml=stack-8.2.2.yaml test \
 	&& stack --stack-yaml=stack-8.4.2.yaml test \
-	&& stack --stack-yaml=stack.yaml test
+	&& stack --stack-yaml=stack-8.4.3.yaml test
 .PHONY: test
 
 build-copy-compiler-tool: submodules
 	stack --stack-yaml=stack-8.2.1.yaml build --copy-compiler-tool \
 	&& stack --stack-yaml=stack-8.2.2.yaml build --copy-compiler-tool \
 	&& stack --stack-yaml=stack-8.4.2.yaml build --copy-compiler-tool \
-	&& stack --stack-yaml=stack.yaml       build --copy-compiler-tool
+	&& stack --stack-yaml=stack-8.4.3.yaml build --copy-compiler-tool
 .PHONY: build-copy-compiler-tool
 
 icu-macos-fix: icu-macos-fix-install icu-macos-fix-build
@@ -77,13 +77,13 @@ icu-macos-fix-build:
 	  --extra-lib-dirs=/usr/local/opt/icu4c/lib            \
 	  --extra-include-dirs=/usr/local/opt/icu4c/include    \
 	&& stack --stack-yaml=stack-8.2.2.yaml build text-icu  \
-         --extra-lib-dirs=/usr/local/opt/icu4c/lib         \
-         --extra-include-dirs=/usr/local/opt/icu4c/include \
+	  --extra-lib-dirs=/usr/local/opt/icu4c/lib            \
+	  --extra-include-dirs=/usr/local/opt/icu4c/include    \
 	&& stack --stack-yaml=stack-8.4.2.yaml build text-icu  \
-         --extra-lib-dirs=/usr/local/opt/icu4c/lib         \
-         --extra-include-dirs=/usr/local/opt/icu4c/include \
-	&& stack --stack-yaml=stack.yaml build text-icu        \
-         --extra-lib-dirs=/usr/local/opt/icu4c/lib         \
-         --extra-include-dirs=/usr/local/opt/icu4c/include
+	  --extra-lib-dirs=/usr/local/opt/icu4c/lib            \
+	  --extra-include-dirs=/usr/local/opt/icu4c/include    \
+	&& stack --stack-yaml=stack-8.4.3.yaml build text-icu  \
+	  --extra-lib-dirs=/usr/local/opt/icu4c/lib            \
+	  --extra-include-dirs=/usr/local/opt/icu4c/include
 .PHONY: icu-macos-fix-build
 

--- a/src/Haskell/Ide/Engine/Plugin/Build.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Build.hs
@@ -482,7 +482,7 @@ isLocal _ = False
 
 getStackLocalPackages :: FilePath -> IO [String]
 getStackLocalPackages stackYamlFile = withBinaryFileContents stackYamlFile $ \contents -> do
-  let (Just (StackYaml stackYaml)) = decode contents
+  let (Just (StackYaml stackYaml)) = decodeThrow contents
       stackLocalPackages = map stackPackageName $ filter isLocal stackYaml
   return stackLocalPackages
 

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -39,8 +39,10 @@ extra-deps:
 - haddock-api-2.18.1
 - haddock-library-1.4.4
 - hlint-2.0.11
+# - hlint-2.1.8
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
+- yaml-0.8.32
 
 flags:
   haskell-ide-engine:

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.14
+resolver: lts-11.17 # last one for GHC 8.2.2
 packages:
 - .
 - hie-plugin-api

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -36,8 +36,10 @@ extra-deps:
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.20.0
 - haddock-library-1.6.0
+- hlint-2.1.8
 - syz-0.2.0.0
 - temporary-1.2.1.1
+- yaml-0.8.32
 - yi-rope-0.11
 
 flags:

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-07-09 # GHC 8.4.3
+resolver: lts-12.0
 packages:
 - .
 - hie-plugin-api

--- a/test/Functional.hs
+++ b/test/Functional.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
@@ -177,13 +178,17 @@ spec = do
       let r = Range (Position 0 0) (Position 99 99)
           c = CodeActionContext (diagsRsp ^. params . diagnostics)
       _ <- sendRequest TextDocumentCodeAction (CodeActionParams doc r c)
-      
+
       rsp <- response :: Session CodeActionResponse
       let (List cmds) = fromJust $ rsp ^. result
           evaluateCmd = head cmds
       liftIO $ do
         length cmds `shouldBe` 1
+#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,2,2,0)))
+        evaluateCmd ^. title `shouldBe` "Apply hint:Redundant id"
+#else
         evaluateCmd ^. title `shouldBe` "Apply hint:Evaluate"
+#endif
 
   -- -----------------------------------
 

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -61,7 +61,11 @@ ghcmodSpec = do
       let uri = filePathToUri fp
           act = lintCmd' uri
           arg = uri
+#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,2,2,0)))
+          res = IdeResultOk (T.pack fp <> ":6:9: Warning: Redundant do\NULFound:\NUL  do return (3 + x)\NULPerhaps:\NUL  return (3 + x)\n")
+#else
           res = IdeResultOk (T.pack fp <> ":6:9: Warning: Redundant do\NULFound:\NUL  do return (3 + x)\NULWhy not:\NUL  return (3 + x)\n")
+#endif
       testCommand testPlugins act "ghcmod" "lint" arg res
 
     -- ---------------------------------


### PR DESCRIPTION
Also introduce `stack-8.4.3.yaml` to track the LTS version.
`stack.yaml` will track nightly, and in time GHC 8.6.1

Superseds #673 