### PR TITLE
Add lower bound on yaml version

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -77,7 +77,7 @@ library
                      , text
                      , transformers
                      , vector
-                     , yaml
+                     , yaml >= 0.8.31
                      , yi-rope
   if os(windows)
     build-depends:     Win32


### PR DESCRIPTION
Module `Haskell.Ide.Engine.Plugin.Build` uses `decodeThrow` which was added to the yaml package in version 0.8.31.