### PR TITLE
Use standard parameter form for caseSplit command.

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -7,7 +7,6 @@ module Haskell.Ide.Engine.Plugin.GhcMod where
 
 import           Bag
 import           Control.Monad.IO.Class
-import           Control.Lens.Getter ((^.))
 import           Control.Lens.Setter ((%~))
 import           Control.Lens.Traversal (traverseOf)
 import           Data.Aeson
@@ -43,6 +42,7 @@ import qualified GhcMod.Exe.CaseSplit              as GM
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils
+import           Haskell.Ide.Engine.Plugin.HaRe (HarePoint(..))
 import           Haskell.Ide.Engine.ArtifactMap
 import           HscTypes
 import qualified Language.Haskell.LSP.Types        as LSP
@@ -298,9 +298,9 @@ isSubRangeOf :: Range -> Range -> Bool
 isSubRangeOf (Range sa ea) (Range sb eb) = sb <= sa && eb >= ea
 
 
-splitCaseCmd :: CommandFunc LSP.TextDocumentPositionParams WorkspaceEdit
-splitCaseCmd = CmdSync $ \posParams -> do
-    splitCaseCmd' (posParams ^. LSP.textDocument . LSP.uri) (posParams ^. LSP.position)
+splitCaseCmd :: CommandFunc HarePoint WorkspaceEdit
+splitCaseCmd = CmdSync $ \(HP uri pos) -> do
+    splitCaseCmd' uri pos
 
 splitCaseCmd' :: Uri -> Position -> IdeGhcM (IdeResult WorkspaceEdit)
 splitCaseCmd' uri newPos =

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -416,7 +416,7 @@ reactor (DispatcherEnv cancelReqTVar wipTVar versionTVar) cin inp commandMap = d
                       ++ "\nYou may want to use hie-wrapper. Check the README for more information"
             reactorSend $ NotShowMessage $ fmServerShowMessageNotification J.MtWarning msg
             reactorSend $ NotLogMessage $ fmServerLogMessageNotification J.MtWarning msg
-                  
+
 
           lf <- ask
           let hreq = GReq tn Nothing Nothing Nothing callback $ IdeResultOk <$> Hoogle.initializeHoogleDb

--- a/test/GhcModPluginSpec.hs
+++ b/test/GhcModPluginSpec.hs
@@ -14,7 +14,8 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.Plugin.GhcMod
-import           Language.Haskell.LSP.Types (TextEdit(..), TextDocumentPositionParams(..), TextDocumentIdentifier(..))
+import           Haskell.Ide.Engine.Plugin.HaRe ( HarePoint(..) )
+import           Language.Haskell.LSP.Types     ( TextEdit(..) )
 import           System.Directory
 import           TestUtils
 
@@ -123,7 +124,7 @@ ghcmodSpec =
           act = do
             _ <- setTypecheckedModule uri
             splitCaseCmd' uri (toPos (5,5))
-          arg = TextDocumentPositionParams (TextDocumentIdentifier uri) (toPos (5,5))
+          arg = HP uri (toPos (5,5))
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri
                                 $ List [TextEdit (Range (Position 4 0) (Position 4 10))
@@ -142,7 +143,7 @@ ghcmodSpec =
             act = do
               _ <- setTypecheckedModule uri
               splitCaseCmd' uri (toPos (5,5))
-            arg = TextDocumentPositionParams (TextDocumentIdentifier uri) (toPos (5,5))
+            arg = HP uri (toPos (5,5))
             res = IdeResultOk $ WorkspaceEdit
               (Just $ H.singleton uri
                                   $ List [TextEdit (Range (Position 4 0) (Position 4 10))


### PR DESCRIPTION
Should perhaps rename HarePoint type