### PR TITLE
Go to definition for project imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@
 /test/testdata/addPackageTest/**/stack.yaml
 /test/testdata/redundantImportTest/stack.yaml
 /test/testdata/completion/stack.yaml
+/test/testdata/definition/stack.yaml
 TAGS
 cabal-dev/
 cabal.sandbox.config

--- a/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
@@ -81,7 +81,7 @@ genImportMap tm = importMap
     (_, locImports, _, _) = fromJust $ GHC.tm_renamed_source tm
     importMap :: ImportMap
     importMap = foldl go IM.empty locImports
-    go :: ImportMap -> GHC.LImportDecl GHC.GhcRn -> ImportMap
+    go :: ImportMap -> GHC.LImportDecl a -> ImportMap
     go acc (GHC.L (GHC.RealSrcSpan r) i) = IM.insert (rspToInt r) (GHC.unLoc $ GHC.ideclName i) acc
     go acc _ = acc
 

--- a/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
@@ -80,7 +80,11 @@ genImportMap tm = moduleMap
   where
     (_, lImports, mlies, _) = fromJust $ GHC.tm_renamed_source tm
 
+    #if __GLASGOW_HASKELL__ > 802
     lies = map fst $ fromMaybe [] mlies
+    #else
+    lies = fromMaybe [] mlies
+    #endif
 
     moduleMap :: ModuleMap
     moduleMap = foldl goImp IM.empty lImports `IM.union` foldl goExp IM.empty lies

--- a/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
@@ -82,7 +82,7 @@ genImportMap tm = moduleMap
 
 #if __GLASGOW_HASKELL__ > 802
     lies = map fst $ fromMaybe [] mlies
-    #else
+#else
     lies = fromMaybe [] mlies
 #endif
 

--- a/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
@@ -80,11 +80,11 @@ genImportMap tm = moduleMap
   where
     (_, lImports, mlies, _) = fromJust $ GHC.tm_renamed_source tm
 
-    #if __GLASGOW_HASKELL__ > 802
+#if __GLASGOW_HASKELL__ > 802
     lies = map fst $ fromMaybe [] mlies
     #else
     lies = fromMaybe [] mlies
-    #endif
+#endif
 
     moduleMap :: ModuleMap
     moduleMap = foldl goImp IM.empty lImports `IM.union` foldl goExp IM.empty lies

--- a/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
@@ -29,6 +29,7 @@ data CachedModule = CachedModule
   { tcMod          :: !TypecheckedModule
   , locMap         :: !LocMap
   , typeMap        :: !TypeMap
+  , importMap      :: !ImportMap
   , revMap         :: !(FilePath -> FilePath)
   , newPosToOld    :: !(Position -> Maybe Position)
   , oldPosToNew    :: !(Position -> Maybe Position)

--- a/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
@@ -29,7 +29,7 @@ data CachedModule = CachedModule
   { tcMod          :: !TypecheckedModule
   , locMap         :: !LocMap
   , typeMap        :: !TypeMap
-  , importMap      :: !ImportMap
+  , moduleMap      :: !ModuleMap
   , revMap         :: !(FilePath -> FilePath)
   , newPosToOld    :: !(Position -> Maybe Position)
   , oldPosToNew    :: !(Position -> Maybe Position)

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -199,7 +199,7 @@ setTypecheckedModule uri =
         debugm $ "setTypecheckedModule: Did get typechecked module for: " ++ show fp
         typm <- GM.unGmlT $ genTypeMap tm
         sess <- fmap GM.gmgsSession . GM.gmGhcSession <$> GM.gmsGet
-        let cm = CachedModule tm (genLocMap tm) typm rfm return return
+        let cm = CachedModule tm (genLocMap tm) typm (genImportMap tm) rfm return return
         cacheModule fp cm
         modifyMTS (\s -> s {ghcSession = sess})
         debugm "setTypecheckedModule: done"

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -200,8 +200,11 @@ setTypecheckedModule uri =
         typm <- GM.unGmlT $ genTypeMap tm
         sess <- fmap GM.gmgsSession . GM.gmGhcSession <$> GM.gmsGet
         let cm = CachedModule tm (genLocMap tm) typm (genImportMap tm) rfm return return
-        cacheModule fp cm
+
+        -- set the session before we cache the module, so that deferred
+        -- responses triggered by cacheModule can access it
         modifyMTS (\s -> s {ghcSession = sess})
+        cacheModule fp cm
         debugm "setTypecheckedModule: done"
         return $ IdeResultOk (diags,errs)
 

--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -460,7 +460,7 @@ findDef uri pos = pluginGetFileResponse "findDef: " uri $ \file ->
           Just ((_,mn):_) -> findImport mn
           _ -> case symbolFromTypecheckedModule lm =<< oldPos of
             Nothing -> return $ IdeResponseOk []
-            Just (_, n) -> do
+            Just (_, n) ->
               case nameSrcSpan n of
                 UnhelpfulSpan _ -> return $ IdeResponseOk []
                 realSpan   -> do

--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -69,7 +69,6 @@ invert :: (Ord v) => Map.Map k v -> Map.Map v [k]
 invert m = Map.fromListWith (++) [(v,[k]) | (k,v) <- Map.toList m]
 
 instance ModuleCache NameMapData where
-  -- cacheDataProducer _ = pure $ NMD Map.empty
   cacheDataProducer cm = pure $ NMD inm
     where nm  = initRdrNameMap $ tcMod cm
           inm = invert nm

--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -59,7 +59,7 @@ getDynFlags :: Uri -> IdeM (IdeResponse DynFlags)
 getDynFlags uri =
   pluginGetFileResponse "getDynFlags: " uri $ \fp ->
     withCachedModule fp (return . IdeResponseOk . ms_hspp_opts . pm_mod_summary . tm_parsed_module . tcMod)
-    
+
 -- ---------------------------------------------------------------------
 
 data NameMapData = NMD
@@ -156,7 +156,7 @@ getSymbols uri = pluginGetFileResponse "getSymbols: " uri $ \file -> withCachedM
           Left x -> return $ Left x
           Right loc -> return $ Right $ J.SymbolInformation nameText kind loc cnt
   symInfs <- mapM declsToSymbolInf (imps ++ decls)
-  return $ IdeResponseOk $ rights symInfs   
+  return $ IdeResponseOk $ rights symInfs
 
 -- ---------------------------------------------------------------------
 
@@ -453,11 +453,11 @@ findDef uri pos = pluginGetFileResponse "findDef: " uri $ \file ->
       (\cm -> do
         let rfm = revMap cm
             lm = locMap cm
-            im = importMap cm
+            mm = moduleMap cm
             oldPos = newPosToOld cm pos
-        
-        case (\x -> Just $ getArtifactsAtPos x im) =<< oldPos of
-          Just ((_,mn):_) -> findImport mn
+
+        case (\x -> Just $ getArtifactsAtPos x mm) =<< oldPos of
+          Just ((_,mn):_) -> gotoModule mn
           _ -> case symbolFromTypecheckedModule lm =<< oldPos of
             Nothing -> return $ IdeResponseOk []
             Just (_, n) ->
@@ -483,8 +483,8 @@ findDef uri pos = pluginGetFileResponse "findDef: " uri $ \file ->
                                       ("hare:findDef" <> ": \"" <> x <> "\"")
                                       Null)))
   where
-    findImport :: ModuleName -> IdeM (IdeResponse [Location])
-    findImport mn = do
+    gotoModule :: ModuleName -> IdeM (IdeResponse [Location])
+    gotoModule mn = do
       hscEnvRef <- ghcSession <$> readMTS
       mHscEnv <- liftIO $ traverse readIORef hscEnvRef
       case mHscEnv of

--- a/test/functional/DefinitionSpec.hs
+++ b/test/functional/DefinitionSpec.hs
@@ -37,6 +37,16 @@ spec = describe "definitions" $ do
     liftIO $ do
       fp <- canonicalizePath "test/testdata/definition/Bar.hs"
       defs `shouldBe` [Location (filePathToUri fp) zeroRange]
+  
+  it "goto's imported modules that are loaded, and then closed" $
+    runSession hieCommand "test/testdata/definition" $ do
+      doc <- openDoc "Foo.hs" "haskell" 
+      otherDoc <- openDoc "Bar.hs" "haskell"
+      closeDoc otherDoc
+      defs <- getDefinitions doc (Position 2 8)
+      liftIO $ do
+        fp <- canonicalizePath "test/testdata/definition/Bar.hs"
+        defs `shouldBe` [Location (filePathToUri fp) zeroRange]
 
 zeroRange :: Range
 zeroRange = Range (Position 0 0) (Position 0 0)

--- a/test/functional/DefinitionSpec.hs
+++ b/test/functional/DefinitionSpec.hs
@@ -4,13 +4,39 @@ import Control.Lens
 import Control.Monad.IO.Class
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
+import System.Directory
 import Test.Hspec
 import TestUtils
 
 spec :: Spec
-spec = describe "definitions" $
-  it "works" $ runSession hieCommand "test/testdata" $ do
+spec = describe "definitions" $ do
+  it "goto's symbols" $ runSession hieCommand "test/testdata" $ do
     doc <- openDoc "References.hs" "haskell"
     defs <- getDefinitions doc (Position 7 8)
     let expRange = Range (Position 4 0) (Position 4 3)
     liftIO $ defs `shouldBe` [Location (doc ^. uri) expRange]
+
+  it "goto's imported modules" $ runSession hieCommand "test/testdata/definition" $ do
+    doc <- openDoc "Foo.hs" "haskell"
+    defs <- getDefinitions doc (Position 2 8)
+    liftIO $ do
+      fp <- canonicalizePath "test/testdata/definition/Bar.hs"
+      defs `shouldBe` [Location (filePathToUri fp) zeroRange]
+
+  it "goto's exported modules" $ runSession hieCommand "test/testdata/definition" $ do
+    doc <- openDoc "Foo.hs" "haskell"
+    defs <- getDefinitions doc (Position 0 15)
+    liftIO $ do
+      fp <- canonicalizePath "test/testdata/definition/Bar.hs"
+      defs `shouldBe` [Location (filePathToUri fp) zeroRange]
+
+  it "goto's imported modules that are loaded" $ runSession hieCommand "test/testdata/definition" $ do
+    doc <- openDoc "Foo.hs" "haskell"
+    _ <- openDoc "Bar.hs" "haskell"
+    defs <- getDefinitions doc (Position 2 8)
+    liftIO $ do
+      fp <- canonicalizePath "test/testdata/definition/Bar.hs"
+      defs `shouldBe` [Location (filePathToUri fp) zeroRange]
+
+zeroRange :: Range
+zeroRange = Range (Position 0 0) (Position 0 0)

--- a/test/testdata/definition/Bar.hs
+++ b/test/testdata/definition/Bar.hs
@@ -1,0 +1,3 @@
+module Bar where
+
+a = 42

--- a/test/testdata/definition/Foo.hs
+++ b/test/testdata/definition/Foo.hs
@@ -1,0 +1,3 @@
+module Foo (module Bar) where
+
+import Bar

--- a/test/testdata/definition/definitions.cabal
+++ b/test/testdata/definition/definitions.cabal
@@ -1,0 +1,10 @@
+name:          definitions
+version:       0.1.0.0
+cabal-version: >= 2.0
+build-type:    Simple
+
+library
+  exposed-modules:  Foo
+  other-modules:    Bar
+  default-language: Haskell2010
+  build-depends:    base

--- a/test/utils/TestUtils.hs
+++ b/test/utils/TestUtils.hs
@@ -106,6 +106,7 @@ files =
    , "./test/testdata/addPackageTest/hpack/"
    , "./test/testdata/redundantImportTest/"
    , "./test/testdata/completion/"
+   , "./test/testdata/definition/"
   ]
 
 stackYaml :: FilePath


### PR DESCRIPTION
This adds the ability to jump to a source file by making a goto definition request on an import statement. 
This also adds a map of imported module names to the GHC module cache to support it.
Closes #688 
# Todo
- [x] Write tests (waiting on #691)