### PR TITLE
Refactor Code Actions

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -27,7 +27,7 @@ import           Haskell.Ide.Engine.MonadTypes
 
 pluginDescToIdePlugins :: [(PluginId,PluginDescriptor)] -> IdePlugins
 pluginDescToIdePlugins = IdePlugins . foldr (uncurry Map.insert . f) Map.empty
-  where f = fmap pluginCommands
+  where f = fmap (\x -> (pluginCommands x, pluginCodeActions x))
 
 type DynamicJSON = CD.ConstrainedDynamic ToJSON
 
@@ -48,7 +48,7 @@ runPluginCommand p com arg = do
   case Map.lookup p m of
     Nothing -> return $
       IdeResultFail $ IdeError UnknownPlugin ("Plugin " <> p <> " doesn't exist") Null
-    Just xs -> case find ((com ==) . commandName) xs of
+    Just (xs, _) -> case find ((com ==) . commandName) xs of
       Nothing -> return $ IdeResultFail $
         IdeError UnknownCommand ("Command " <> com <> " isn't defined for plugin " <> p <> ". Legal commands are: " <> T.pack(show $ map commandName xs)) Null
       Just (PluginCommand _ _ (CmdSync f)) -> case fromJSON arg of

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginDescriptor.hs
@@ -27,7 +27,7 @@ import           Haskell.Ide.Engine.MonadTypes
 
 pluginDescToIdePlugins :: [(PluginId,PluginDescriptor)] -> IdePlugins
 pluginDescToIdePlugins = IdePlugins . foldr (uncurry Map.insert . f) Map.empty
-  where f = fmap (\x -> (pluginCommands x, pluginCodeActions x))
+  where f = fmap (\x -> (pluginCommands x, pluginCodeActionProvider x))
 
 type DynamicJSON = CD.ConstrainedDynamic ToJSON
 

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -69,7 +69,9 @@ import           Haskell.Ide.Engine.MultiThreadState
 import           Haskell.Ide.Engine.GhcModuleCache
 
 import           Language.Haskell.LSP.Types.Capabilities
-import           Language.Haskell.LSP.Types (Diagnostic (..),
+import           Language.Haskell.LSP.Types (CodeAction(..),
+                                             CodeActionParams(..),
+                                             Diagnostic (..),
                                              DiagnosticSeverity (..),
                                              List (..),
                                              Location (..),
@@ -99,7 +101,8 @@ data PluginDescriptor =
   PluginDescriptor { pluginName :: T.Text
                    , pluginDesc :: T.Text
                    , pluginCommands :: [PluginCommand]
-                   } deriving (Show,Generic)
+                   , pluginCodeActions :: CodeActionParams -> IdeM [CodeAction]
+                   } deriving (Generic)
 
 instance Show PluginCommand where
   show (PluginCommand name _ _) = "PluginCommand { name = " ++ T.unpack name ++ " }"

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -139,22 +139,6 @@ handleCodeActionReq tn commandMap req = do
 
 -- TODO: make context specific commands for all sorts of things, such as refactorings          
 
-isImportableDiag :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
-isImportableDiag diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractImportableTerm msg
-isImportableDiag _ = Nothing
-
-extractImportableTerm :: T.Text -> Maybe T.Text
-extractImportableTerm dirtyMsg = T.strip <$> asum
-  [T.stripPrefix "Variable not in scope: " msg,
-  T.init <$> T.stripPrefix "Not in scope: type constructor or class ‘" msg]
-  where msg = head
-              -- Get rid of the rename suggestion parts
-              $ T.splitOn "Perhaps you meant "
-              $ T.replace "\n" " "
-              -- Get rid of trailing/leading whitespace on each individual line
-              $ T.unlines $ map T.strip $ T.lines
-              $ T.replace "• " "" dirtyMsg
-
 isPackageAddableDiag :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
 isPackageAddableDiag diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractModuleName msg
 isPackageAddableDiag _ = Nothing

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -7,188 +7,140 @@ import Control.Lens
 import Control.Monad.Reader
 import qualified Data.Aeson as J
 import qualified Data.Bimap as BM
-import qualified Data.HashMap.Strict as HM
+-- import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import Data.Maybe
-import Data.Monoid ((<>))
+-- import Data.Monoid ((<>))
 import Data.Foldable
 import Haskell.Ide.Engine.LSP.Reactor
-import qualified Haskell.Ide.Engine.Plugin.ApplyRefact as ApplyRefact
-import qualified Haskell.Ide.Engine.Plugin.Hoogle as Hoogle
-import qualified Haskell.Ide.Engine.Plugin.HsImport as HsImport
+-- import qualified Haskell.Ide.Engine.Plugin.ApplyRefact as ApplyRefact
+-- import qualified Haskell.Ide.Engine.Plugin.Hoogle as Hoogle
+-- import qualified Haskell.Ide.Engine.Plugin.HsImport as HsImport
 import Haskell.Ide.Engine.Types
 import qualified Language.Haskell.LSP.Core as Core
 import qualified Language.Haskell.LSP.Types as J
 import qualified Language.Haskell.LSP.Types.Capabilities as C
 import Language.Haskell.LSP.VFS
 import Language.Haskell.LSP.Messages
-import Haskell.Ide.Engine.Plugin.Package
+-- import Haskell.Ide.Engine.Plugin.Package
 import Haskell.Ide.Engine.IdeFunctions
-import Haskell.Ide.Engine.MonadFunctions
-import Haskell.Ide.Engine.MonadTypes
+import Haskell.Ide.Engine.PluginsIdeMonads
+-- import Haskell.Ide.Engine.MonadFunctions
+-- import Haskell.Ide.Engine.MonadTypes
 
 handleCodeActionReq :: TrackingNumber -> BM.Bimap T.Text T.Text -> J.CodeActionRequest -> R ()
 handleCodeActionReq tn commandMap req = do
 
-  let getProviders :: IdeM (IdeResponse [J.CodeActionParams -> IdeM (IdeResponse [J.CodeAction])])
+  maybeRootDir <- asksLspFuncs Core.rootPath
+
+  vfsFunc <- asksLspFuncs Core.getVirtualFileFunc
+  docVersion <- fmap _version <$> liftIO (vfsFunc docUri)
+  let docId = J.VersionedTextDocumentIdentifier docUri docVersion
+
+  let getProviders :: IdeM (IdeResponse [CodeActionProvider])
       getProviders = do
         IdePlugins m <- lift getPlugins
-        debugm "asdf"
         return $ IdeResponseOk $ map snd $ toList m
-      providersCb _ = return ()
+
+      providersCb :: [CodeActionProvider] -> R ()
+      providersCb providers =
+        collectRequests' (map (uncurry . uncurry . uncurry) providers)
+                         (((docId, maybeRootDir), params ^. J.range), params ^. J.context)
+                         cb
+
+      cb :: [[J.CodeAction]] -> R ()
+      cb = send . concat
   makeRequest (IReq tn (req ^. J.id) providersCb getProviders)
 
 
-  vfsFunc <- asksLspFuncs Core.getVirtualFileFunc
-  docVersion <- fmap _version <$> liftIO (vfsFunc doc)
-  let docId = J.VersionedTextDocumentIdentifier doc docVersion
+--   let hlintActions = mapMaybe mkHlintAction $ filter validCommand diags
+--       -- |Some hints do not have an associated refactoring
+--       validCommand (J.Diagnostic _ _ (Just code) (Just "hlint") _ _) =
+--         case code of
+--           "Eta reduce" -> False
+--           _            -> True
+--       validCommand _ = False
 
-  maybeRootDir <- asksLspFuncs Core.rootPath
+--       plainActions = renamableActions ++ hlintActions ++ redundantImportActions
 
-  let hlintActions = mapMaybe mkHlintAction $ filter validCommand diags
-      -- |Some hints do not have an associated refactoring
-      validCommand (J.Diagnostic _ _ (Just code) (Just "hlint") _ _) =
-        case code of
-          "Eta reduce" -> False
-          _            -> True
-      validCommand _ = False
-
-      renamableActions = map (uncurry (mkRenamableAction docId)) $
-        concatMap isRenamableDiag diags
-      redundantImportActions = concatMap (uncurry (mkRedundantImportActions docId)) $
-        mapMaybe isRedundantImportDiag diags
-
-      plainActions = renamableActions ++ hlintActions ++ redundantImportActions
-
-      -- For these diagnostics need to search hoogle before we can make code actions
-      addPackageDiags = mapMaybe isPackageAddableDiag diags
-      importableDiags = mapMaybe isImportableDiag diags
+--       -- For these diagnostics need to search hoogle before we can make code actions
+--       addPackageDiags = mapMaybe isPackageAddableDiag diags
+--       importableDiags = mapMaybe isImportableDiag diags
 
 
-
-  makeSearches Hoogle.searchPackages (mkAddPackageAction maybeRootDir) addPackageDiags $ \addPackageActions ->
-    makeSearches Hoogle.searchModules mkImportAction importableDiags $ \importActions ->
-      if null importActions
-        then
-          -- If we don't get any results, try relaxing the Hoogle search:
-          -- myFunc :: Int -> String
-          -- will go to:
-          -- myFunc
-          let relaxed = map (bimap id (head . T.words)) importableDiags
-              allActions = ((plainActions ++ addPackageActions) ++)
-          in makeSearches Hoogle.searchModules mkImportAction relaxed (send . allActions)
-        else send (plainActions ++ addPackageActions ++ importActions)
+--   makeSearches Hoogle.searchPackages (mkAddPackageAction maybeRootDir) addPackageDiags $ \addPackageActions ->
+--     makeSearches Hoogle.searchModules mkImportAction importableDiags $ \importActions ->
+--       if null importActions
+--         then
+--           -- If we don't get any results, try relaxing the Hoogle search:
+--           -- myFunc :: Int -> String
+--           -- will go to:
+--           -- myFunc
+--           let relaxed = map (bimap id (head . T.words)) importableDiags
+--               allActions = ((plainActions ++ addPackageActions) ++)
+--           in makeSearches Hoogle.searchModules mkImportAction relaxed (send . allActions)
+--         else send (plainActions ++ addPackageActions ++ importActions)
 
   where
   params = req ^. J.params
-  doc = params ^. J.textDocument . J.uri
-  (J.List diags) = params ^. J.context . J.diagnostics
+  docUri = params ^. J.textDocument . J.uri
 
-  wrapCodeAction :: (J.CodeAction, J.Command) -> R (Maybe J.CommandOrCodeAction)
-  wrapCodeAction (action, cmd) = do
+  wrapCodeAction :: J.CodeAction -> R (Maybe J.CommandOrCodeAction)
+  wrapCodeAction action = do
     (C.ClientCapabilities _ textDocCaps _) <- asksLspFuncs Core.clientCapabilities
     let literalSupport = textDocCaps >>= C._codeAction >>= C._codeActionLiteralSupport
     case literalSupport of
-      Nothing -> return $ Just (J.CommandOrCodeActionCommand cmd)
-      -- We only need the workspace edit, command gets applied as well if we provide it
+      Nothing ->
+        case (action ^. J.edit, action ^. J.command) of
+          (Just e, _) -> 
+            let cmd = J.Command (action ^. J.title) cmdName (Just cmdParams)
+                cmdName = commandMap BM.! "hie:applyWorkspaceEdit"
+                cmdParams = J.toJSON [J.ApplyWorkspaceEditParams e]
+            in return $ Just (J.CommandOrCodeActionCommand cmd)
+          (_, Just cmd) -> return $ Just (J.CommandOrCodeActionCommand cmd)
+          _ -> error "A code action needs either a workspace edit or a command"
       Just _ -> return $ Just (J.CommandOrCodeActionCodeAction action)
 
-  send :: [(J.CodeAction, J.Command)] -> R ()
+  send :: [J.CodeAction] -> R ()
   send codeActions = do
     body <- J.List . catMaybes <$> mapM wrapCodeAction codeActions
     reactorSend $ RspCodeAction $ Core.makeResponseMessage req body
 
-  -- mkXActions need to return both a code action and a command for fallbacks to older clients
-  -- that don't support code action kinds
-  mkHlintAction :: J.Diagnostic -> Maybe (J.CodeAction, J.Command)
-  mkHlintAction diag@(J.Diagnostic (J.Range start _) _s (Just code) (Just "hlint") m _) = Just (codeAction, cmd)
-    where
-      codeAction = J.CodeAction title (Just J.CodeActionRefactor) (Just (J.List [diag])) Nothing (Just cmd)
-      title :: T.Text
-      title = "Apply hint:" <> head (T.lines m)
-      -- NOTE: the cmd needs to be registered via the InitializeResponse message. See hieOptions above
-      cmd = J.Command title cmdName cmdparams
-      cmdName = commandMap BM.! "applyrefact:applyOne"
-      -- need 'file', 'start_pos' and hint title (to distinguish between alternative suggestions at the same location)
-      args = J.toJSON [ApplyRefact.AOP doc start code]
-      cmdparams = Just args
-  mkHlintAction (J.Diagnostic _r _s _c _source _m _) = Nothing
+--  -- mkXActions need to return both a code action and a command for fallbacks to older clients
+--  -- that don't support code action kinds
+--  mkHlintAction :: J.Diagnostic -> Maybe (J.CodeAction, J.Command)
+--  mkHlintAction diag@(J.Diagnostic (J.Range start _) _s (Just code) (Just "hlint") m _) = Just (codeAction, cmd)
+--    where
+--      codeAction = J.CodeAction title (Just J.CodeActionRefactor) (Just (J.List [diag])) Nothing (Just cmd)
+--      title :: T.Text
+--      title = "Apply hint:" <> head (T.lines m)
+--      -- NOTE: the cmd needs to be registered via the InitializeResponse message. See hieOptions above
+--      cmd = J.Command title cmdName cmdparams
+--      cmdName = commandMap BM.! "applyrefact:applyOne"
+--      -- need 'file', 'start_pos' and hint title (to distinguish between alternative suggestions at the same location)
+--      args = J.toJSON [ApplyRefact.AOP doc start code]
+--      cmdparams = Just args
+--  mkHlintAction (J.Diagnostic _r _s _c _source _m _) = Nothing
 
-  mkRenamableAction :: J.VersionedTextDocumentIdentifier -> J.Diagnostic -> T.Text -> (J.CodeAction, J.Command)
-  mkRenamableAction docId diag replacement = (codeAction, cmd)
-    where
-      title = "Replace with " <> replacement
+--  --TODO: Check if package is already installed
+--  mkImportAction :: J.Diagnostic -> T.Text -> Maybe (J.CodeAction, J.Command)
+--  mkImportAction diag modName = Just (codeAction, cmd)
+--    where
+--      codeAction = J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd)
+--      cmd = J.Command title cmdName (Just cmdParams)
+--      title = "Import module " <> modName
+--      cmdName = commandMap BM.! "hsimport:import"
+--      cmdParams = J.toJSON [HsImport.ImportParams doc modName]
 
-      workspaceEdit = J.WorkspaceEdit (Just changes) (Just docChanges)
-      changes = HM.singleton doc (J.List [textEdit])
-      docChanges = J.List [textDocEdit]
-      textDocEdit = J.TextDocumentEdit docId (J.List [textEdit])
-      textEdit = J.TextEdit (diag ^. J.range) replacement
-
-      cmd = J.Command title cmdName (Just cmdParams)
-      cmdName = commandMap BM.! "hie:applyWorkspaceEdit"
-      --TODO: Support the name parameter in J.Applyworkspaceeditparams
-      cmdParams = J.toJSON [J.ApplyWorkspaceEditParams workspaceEdit]
-
-      codeAction = J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) (Just workspaceEdit) Nothing
-
-  mkRedundantImportActions :: J.VersionedTextDocumentIdentifier -> J.Diagnostic -> T.Text -> [(J.CodeAction, J.Command)]
-  mkRedundantImportActions docId diag moduleName = [(removeAction, removeCmd), (importAction, importCmd)]
-    where
-      removeAction = J.CodeAction "Remove redundant import"
-                                  (Just J.CodeActionQuickFix)
-                                  (Just (J.List [diag]))
-                                  (Just removeEdit)
-                                  Nothing
-
-      removeCmd = cmd "Remove redundant import" removeEdit
-
-      removeEdit = workspaceEdit (J.TextEdit range "")
-        where
-          range = J.Range (diag ^. J.range . J.start)
-                          (J.Position ((diag ^. J.range . J.start . J.line) + 1) 0)
-
-      importAction = J.CodeAction "Import instances"
-                                  (Just J.CodeActionQuickFix)
-                                  (Just (J.List [diag]))
-                                  (Just importEdit)
-                                  Nothing
-      importCmd = cmd "Import instances" importEdit
-          --TODO: Use hsimport to preserve formatting/whitespace
-      importEdit = workspaceEdit tEdit
-        where
-          tEdit = J.TextEdit (diag ^. J.range) ("import " <> moduleName <> "()")
-
-      workspaceEdit textEdit = J.WorkspaceEdit (Just changes) (Just docChanges)
-        where
-          changes = HM.singleton doc (J.List [textEdit])
-          docChanges = J.List [textDocEdit]
-          textDocEdit = J.TextDocumentEdit docId (J.List [textEdit])
-
-
-      cmd title wEdit = J.Command title cmdName (Just (cmdParams wEdit))
-      cmdName = commandMap BM.! "hie:applyWorkspaceEdit"
-      cmdParams wEdit = J.toJSON [J.ApplyWorkspaceEditParams wEdit]
-
-  --TODO: Check if package is already installed
-  mkImportAction :: J.Diagnostic -> T.Text -> Maybe (J.CodeAction, J.Command)
-  mkImportAction diag modName = Just (codeAction, cmd)
-    where
-      codeAction = J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd)
-      cmd = J.Command title cmdName (Just cmdParams)
-      title = "Import module " <> modName
-      cmdName = commandMap BM.! "hsimport:import"
-      cmdParams = J.toJSON [HsImport.ImportParams doc modName]
-
-  mkAddPackageAction :: Maybe FilePath -> J.Diagnostic -> T.Text -> Maybe (J.CodeAction, J.Command)
-  mkAddPackageAction (Just rootDir) diag packageName = case J.uriToFilePath doc of
-    Just docFp ->
-      let title = "Add " <> packageName <> " as a dependency"
-          cmd = J.Command title (commandMap BM.! "package:add") (Just cmdParams)
-          cmdParams = J.toJSON [AddParams rootDir docFp packageName]
-      in Just $ (J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd), cmd)
-    _ -> Nothing
-  mkAddPackageAction _ _ _ = Nothing
+--  mkAddPackageAction :: Maybe FilePath -> J.Diagnostic -> T.Text -> Maybe (J.CodeAction, J.Command)
+--  mkAddPackageAction (Just rootDir) diag packageName = case J.uriToFilePath doc of
+--    Just docFp ->
+--      let title = "Add " <> packageName <> " as a dependency"
+--          cmd = J.Command title (commandMap BM.! "package:add") (Just cmdParams)
+--          cmdParams = J.toJSON [AddParams rootDir docFp packageName]
+--      in Just (J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd), cmd)
+--    _ -> Nothing
+--  mkAddPackageAction _ _ _ = Nothing
 
   -- | Execute multiple ide requests sequentially
   collectRequests :: (a -> IdeM (IdeResponse b)) -- ^ The requests to make
@@ -202,15 +154,11 @@ handleCodeActionReq tn commandMap req = do
         let reqCallback result = go (acc ++ [(x, result)]) ideReq xs callback
         in makeRequest $ IReq tn (req ^. J.id) reqCallback (ideReq x)
 
-  -- | Make multiple hoogle searches at once to construct code actions
-  makeSearches :: (T.Text -> IdeM (IdeResponse [T.Text]))                    -- ^ The search function
-             -> (J.Diagnostic -> T.Text -> Maybe (J.CodeAction, J.Command))  -- ^ A function to construct actions
-             -> [(J.Diagnostic, T.Text)]                                     -- ^ Input diagnostics and search terms
-             -> ([(J.CodeAction, J.Command)] -> R ())                        -- ^ Callback
-             -> R ()
-  makeSearches search maker xs callback = collectRequests (search . snd) xs $ \allResults -> do
-    let actions = concatMap (\((diag, _), results) -> mapMaybe (maker diag) results) allResults
-    callback actions
+  collectRequests' :: [a -> IdeM (IdeResponse b)] -> a -> ([b] -> R ()) -> R ()
+  collectRequests' reqs x cb = collectRequests (\(f, a) -> f a)
+                                               (zip reqs (repeat x))
+                                               (cb . map snd)
+
 
 -- TODO: make context specific commands for all sorts of things, such as refactorings          
 
@@ -230,23 +178,6 @@ extractImportableTerm dirtyMsg = T.strip <$> asum
               $ T.unlines $ map T.strip $ T.lines
               $ T.replace "• " "" dirtyMsg
 
-isRenamableDiag :: J.Diagnostic -> [(J.Diagnostic, T.Text)]
-isRenamableDiag diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = map (diag,) $ extractRenamableTerms msg
-isRenamableDiag _ = []
-
-extractRenamableTerms :: T.Text -> [T.Text]
-extractRenamableTerms msg
-  | "Variable not in scope: " `T.isPrefixOf` head noBullets = mapMaybe extractReplacement replacementLines
-  | otherwise = []
-
-  where noBullets = T.lines $ T.replace "• " "" msg
-        replacementLines = tail noBullets
-        extractReplacement line =
-          let startOfTerm = T.dropWhile (/= '‘') line
-          in if startOfTerm == ""
-            then Nothing
-            else Just $ T.takeWhile (/= '’') (T.tail startOfTerm)
-
 isPackageAddableDiag :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
 isPackageAddableDiag diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractModuleName msg
 isPackageAddableDiag _ = Nothing
@@ -258,15 +189,3 @@ extractModuleName msg
   where line = T.replace "\n" "" msg
         nameAndQuotes = T.dropWhileEnd (/= '’') $ T.dropWhile (/= '‘') line
 
-isRedundantImportDiag :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
-isRedundantImportDiag diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractRedundantImport msg
-isRedundantImportDiag _ = Nothing
-
--- TODO: Make code actions for this warning
-extractRedundantImport :: T.Text -> Maybe T.Text
-extractRedundantImport msg =
-  if ("The import of " `T.isPrefixOf` firstLine || "The qualified import of " `T.isPrefixOf` firstLine)
-      && " is redundant" `T.isSuffixOf` firstLine
-    then Just $ T.init $ T.tail $ T.dropWhileEnd (/= '’') $ T.dropWhile (/= '‘') firstLine
-    else Nothing
-  where firstLine = head (T.lines msg)

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -23,10 +23,21 @@ import qualified Language.Haskell.LSP.Types.Capabilities as C
 import Language.Haskell.LSP.VFS
 import Language.Haskell.LSP.Messages
 import Haskell.Ide.Engine.Plugin.Package
+import Haskell.Ide.Engine.IdeFunctions
+import Haskell.Ide.Engine.MonadFunctions
 import Haskell.Ide.Engine.MonadTypes
 
 handleCodeActionReq :: TrackingNumber -> BM.Bimap T.Text T.Text -> J.CodeActionRequest -> R ()
 handleCodeActionReq tn commandMap req = do
+
+  let getProviders :: IdeM (IdeResponse [J.CodeActionParams -> IdeM (IdeResponse [J.CodeAction])])
+      getProviders = do
+        IdePlugins m <- lift getPlugins
+        debugm "asdf"
+        return $ IdeResponseOk $ map snd $ toList m
+      providersCb _ = return ()
+  makeRequest (IReq tn (req ^. J.id) providersCb getProviders)
+
 
   vfsFunc <- asksLspFuncs Core.getVirtualFileFunc
   docVersion <- fmap _version <$> liftIO (vfsFunc doc)

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -1,32 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TupleSections #-}
 module Haskell.Ide.Engine.LSP.CodeActions where
 
 import Control.Lens
 import Control.Monad.Reader
 import qualified Data.Aeson as J
 import qualified Data.Bimap as BM
--- import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import Data.Maybe
--- import Data.Monoid ((<>))
 import Data.Foldable
 import Haskell.Ide.Engine.LSP.Reactor
--- import qualified Haskell.Ide.Engine.Plugin.ApplyRefact as ApplyRefact
--- import qualified Haskell.Ide.Engine.Plugin.Hoogle as Hoogle
--- import qualified Haskell.Ide.Engine.Plugin.HsImport as HsImport
 import Haskell.Ide.Engine.Types
 import qualified Language.Haskell.LSP.Core as Core
 import qualified Language.Haskell.LSP.Types as J
 import qualified Language.Haskell.LSP.Types.Capabilities as C
 import Language.Haskell.LSP.VFS
 import Language.Haskell.LSP.Messages
--- import Haskell.Ide.Engine.Plugin.Package
 import Haskell.Ide.Engine.IdeFunctions
 import Haskell.Ide.Engine.PluginsIdeMonads
--- import Haskell.Ide.Engine.MonadFunctions
--- import Haskell.Ide.Engine.MonadTypes
 
 handleCodeActionReq :: TrackingNumber -> BM.Bimap T.Text T.Text -> J.CodeActionRequest -> R ()
 handleCodeActionReq tn commandMap req = do
@@ -44,109 +35,50 @@ handleCodeActionReq tn commandMap req = do
 
       providersCb :: [CodeActionProvider] -> R ()
       providersCb providers =
-        collectRequests' (map (uncurry . uncurry . uncurry) providers)
-                         (((docId, maybeRootDir), params ^. J.range), params ^. J.context)
-                         cb
+        let reqs = map (\f -> f docId maybeRootDir range context) providers
+        in collectRequests reqs (send . concat)
 
-      cb :: [[J.CodeAction]] -> R ()
-      cb = send . concat
   makeRequest (IReq tn (req ^. J.id) providersCb getProviders)
-
-
---       -- For these diagnostics need to search hoogle before we can make code actions
---       addPackageDiags = mapMaybe isPackageAddableDiag diags
---       importableDiags = mapMaybe isImportableDiag diags
-
-
---   makeSearches Hoogle.searchPackages (mkAddPackageAction maybeRootDir) addPackageDiags $ \addPackageActions ->
---     makeSearches Hoogle.searchModules mkImportAction importableDiags $ \importActions ->
---       if null importActions
---         then
---           -- If we don't get any results, try relaxing the Hoogle search:
---           -- myFunc :: Int -> String
---           -- will go to:
---           -- myFunc
---           let relaxed = map (bimap id (head . T.words)) importableDiags
---               allActions = ((plainActions ++ addPackageActions) ++)
---           in makeSearches Hoogle.searchModules mkImportAction relaxed (send . allActions)
---         else send (plainActions ++ addPackageActions ++ importActions)
-
+  
   where
-  params = req ^. J.params
-  docUri = params ^. J.textDocument . J.uri
+    params = req ^. J.params
+    docUri = params ^. J.textDocument . J.uri
+    range = params ^. J.range
+    context = params ^. J.context
 
-  wrapCodeAction :: J.CodeAction -> R (Maybe J.CommandOrCodeAction)
-  wrapCodeAction action = do
-    (C.ClientCapabilities _ textDocCaps _) <- asksLspFuncs Core.clientCapabilities
-    let literalSupport = textDocCaps >>= C._codeAction >>= C._codeActionLiteralSupport
-    case literalSupport of
-      Nothing ->
-        case (action ^. J.edit, action ^. J.command) of
-          (Just e, _) -> 
-            let cmd = J.Command (action ^. J.title) cmdName (Just cmdParams)
-                cmdName = commandMap BM.! "hie:applyWorkspaceEdit"
-                cmdParams = J.toJSON [J.ApplyWorkspaceEditParams e]
-            in return $ Just (J.CommandOrCodeActionCommand cmd)
-          (_, Just (J.Command title cmdName args)) -> do
-            let cmd = J.Command title (commandMap BM.! cmdName) args
-            return $ Just (J.CommandOrCodeActionCommand cmd)
-          _ -> error "A code action needs either a workspace edit or a command"
-      Just _ -> return $ Just (J.CommandOrCodeActionCodeAction action)
+    wrapCodeAction :: J.CodeAction -> R (Maybe J.CommandOrCodeAction)
+    wrapCodeAction action = do
+      (C.ClientCapabilities _ textDocCaps _) <- asksLspFuncs Core.clientCapabilities
+      let literalSupport = textDocCaps >>= C._codeAction >>= C._codeActionLiteralSupport
+      case literalSupport of
+        Nothing ->
+          case (action ^. J.edit, action ^. J.command) of
+            (Just e, _) -> 
+              let cmd = J.Command (action ^. J.title) cmdName (Just cmdParams)
+                  cmdName = commandMap BM.! "hie:applyWorkspaceEdit"
+                  cmdParams = J.toJSON [J.ApplyWorkspaceEditParams e]
+              in return $ Just (J.CommandOrCodeActionCommand cmd)
+            (_, Just (J.Command title cmdName args)) -> do
+              let cmd = J.Command title (commandMap BM.! cmdName) args
+              return $ Just (J.CommandOrCodeActionCommand cmd)
+            _ -> error "A code action needs either a workspace edit or a command"
+        Just _ -> return $ Just (J.CommandOrCodeActionCodeAction action)
 
-  send :: [J.CodeAction] -> R ()
-  send codeActions = do
-    body <- J.List . catMaybes <$> mapM wrapCodeAction codeActions
-    reactorSend $ RspCodeAction $ Core.makeResponseMessage req body
+    send :: [J.CodeAction] -> R ()
+    send codeActions = do
+      body <- J.List . catMaybes <$> mapM wrapCodeAction codeActions
+      reactorSend $ RspCodeAction $ Core.makeResponseMessage req body
 
+    -- | Execute multiple ide requests sequentially
+    collectRequests :: [IdeM (IdeResponse a)] -- ^ The requests to make
+                    -> ([a] -> R ())     -- ^ Callback with the request inputs and results
+                    -> R ()
+    collectRequests = go []
+      where
+        go acc [] callback = callback acc
+        go acc (x:xs) callback =
+          let reqCallback result = go (acc ++ [result]) xs callback
+          in makeRequest $ IReq tn (req ^. J.id) reqCallback x
 
---  --TODO: Check if package is already installed
---  mkImportAction :: J.Diagnostic -> T.Text -> Maybe (J.CodeAction, J.Command)
---  mkImportAction diag modName = Just (codeAction, cmd)
---    where
---      codeAction = J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd)
---      cmd = J.Command title cmdName (Just cmdParams)
---      title = "Import module " <> modName
---      cmdName = commandMap BM.! "hsimport:import"
---      cmdParams = J.toJSON [HsImport.ImportParams doc modName]
-
---  mkAddPackageAction :: Maybe FilePath -> J.Diagnostic -> T.Text -> Maybe (J.CodeAction, J.Command)
---  mkAddPackageAction (Just rootDir) diag packageName = case J.uriToFilePath doc of
---    Just docFp ->
---      let title = "Add " <> packageName <> " as a dependency"
---          cmd = J.Command title (commandMap BM.! "package:add") (Just cmdParams)
---          cmdParams = J.toJSON [AddParams rootDir docFp packageName]
---      in Just (J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd), cmd)
---    _ -> Nothing
---  mkAddPackageAction _ _ _ = Nothing
-
-  -- | Execute multiple ide requests sequentially
-  collectRequests :: (a -> IdeM (IdeResponse b)) -- ^ The requests to make
-                  -> [a]                         -- ^ The inputs to the requests
-                  -> ([(a, b)] -> R ())          -- ^ Callback with the request inputs and results
-                  -> R ()
-  collectRequests = go []
-    where
-      go acc _ [] callback = callback acc
-      go acc ideReq (x:xs) callback =
-        let reqCallback result = go (acc ++ [(x, result)]) ideReq xs callback
-        in makeRequest $ IReq tn (req ^. J.id) reqCallback (ideReq x)
-
-  collectRequests' :: [a -> IdeM (IdeResponse b)] -> a -> ([b] -> R ()) -> R ()
-  collectRequests' reqs x cb = collectRequests (\(f, a) -> f a)
-                                               (zip reqs (repeat x))
-                                               (cb . map snd)
-
-
--- TODO: make context specific commands for all sorts of things, such as refactorings          
-
-isPackageAddableDiag :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
-isPackageAddableDiag diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractModuleName msg
-isPackageAddableDiag _ = Nothing
-
-extractModuleName :: T.Text -> Maybe T.Text
-extractModuleName msg
-  | T.isPrefixOf "Could not find module " msg = Just $ T.tail $ T.init nameAndQuotes
-  | otherwise = Nothing
-  where line = T.replace "\n" "" msg
-        nameAndQuotes = T.dropWhileEnd (/= '’') $ T.dropWhile (/= '‘') line
+  -- TODO: make context specific commands for all sorts of things, such as refactorings          
 

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -39,6 +39,7 @@ applyRefactDescriptor = PluginDescriptor
       , PluginCommand "applyAll" "Apply all hints to the file" applyAllCmd
       , PluginCommand "lint" "Run hlint on the file to generate hints" lintCmd
       ]
+  , pluginCodeActions = \_ -> return []
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -39,7 +39,7 @@ applyRefactDescriptor = PluginDescriptor
       , PluginCommand "applyAll" "Apply all hints to the file" applyAllCmd
       , PluginCommand "lint" "Run hlint on the file to generate hints" lintCmd
       ]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -39,7 +39,7 @@ applyRefactDescriptor = PluginDescriptor
       , PluginCommand "applyAll" "Apply all hints to the file" applyAllCmd
       , PluginCommand "lint" "Run hlint on the file to generate hints" lintCmd
       ]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Base.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Base.hs
@@ -41,6 +41,7 @@ baseDescriptor = PluginDescriptor
       , PluginCommand "commands" "list available commands for a given plugin" commandsCmd
       , PluginCommand "commandDetail" "list parameters required for a given command" commandDetailCmd
       ]
+  , pluginCodeActions = \_ -> return []
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Base.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Base.hs
@@ -41,7 +41,7 @@ baseDescriptor = PluginDescriptor
       , PluginCommand "commands" "list available commands for a given plugin" commandsCmd
       , PluginCommand "commandDetail" "list parameters required for a given command" commandDetailCmd
       ]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
 
 -- ---------------------------------------------------------------------
@@ -62,7 +62,7 @@ commandsCmd = CmdSync $ \p -> do
       , ideMessage = "Can't find plugin:" <> p
       , ideInfo = toJSON p
       }
-    Just pl -> return $ IdeResultOk $ map commandName pl
+    Just pl -> return $ IdeResultOk $ map commandName $ fst pl
 
 commandDetailCmd :: CommandFunc (T.Text, T.Text) T.Text
 commandDetailCmd = CmdSync $ \(p,command) -> do
@@ -73,7 +73,7 @@ commandDetailCmd = CmdSync $ \(p,command) -> do
       , ideMessage = "Can't find plugin:" <> p
       , ideInfo = toJSON p
       }
-    Just pl -> case find (\cmd -> command == (commandName cmd) ) pl of
+    Just pl -> case find (\cmd -> command == commandName cmd) (fst pl) of
       Nothing -> return $ IdeResultFail $ IdeError
         { ideCode = UnknownCommand
         , ideMessage = "Can't find command:" <> command
@@ -115,7 +115,7 @@ getProjectGhcVersion = do
     else do
       L.infoM "hie" "Using plain GHC version"
       tryCommand "ghc --version"
-          
+
   where
     tryCommand cmd =
       crackGhcVersion <$> readCreateProcess (shell cmd) ""

--- a/src/Haskell/Ide/Engine/Plugin/Base.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Base.hs
@@ -41,7 +41,7 @@ baseDescriptor = PluginDescriptor
       , PluginCommand "commands" "list available commands for a given plugin" commandsCmd
       , PluginCommand "commandDetail" "list parameters required for a given command" commandDetailCmd
       ]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -32,7 +32,7 @@ brittanyDescriptor = PluginDescriptor
                                      "Format a range of text or document"
                                      cmd
                      ]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
  where
   cmd :: CommandFunc FormatParams [J.TextEdit]

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -32,6 +32,7 @@ brittanyDescriptor = PluginDescriptor
                                      "Format a range of text or document"
                                      cmd
                      ]
+  , pluginCodeActions = \_ -> return []
   }
  where
   cmd :: CommandFunc FormatParams [J.TextEdit]

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -32,7 +32,7 @@ brittanyDescriptor = PluginDescriptor
                                      "Format a range of text or document"
                                      cmd
                      ]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
  where
   cmd :: CommandFunc FormatParams [J.TextEdit]

--- a/src/Haskell/Ide/Engine/Plugin/Build.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Build.hs
@@ -150,6 +150,7 @@ buildPluginDescriptor = PluginDescriptor
                       "Builds specified cabal or stack component"
                       buildTarget
       ]
+  , pluginCodeActions = \_ -> return []
   }
 
 data OperationMode = StackMode | CabalMode

--- a/src/Haskell/Ide/Engine/Plugin/Build.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Build.hs
@@ -150,7 +150,7 @@ buildPluginDescriptor = PluginDescriptor
                       "Builds specified cabal or stack component"
                       buildTarget
       ]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
 
 data OperationMode = StackMode | CabalMode

--- a/src/Haskell/Ide/Engine/Plugin/Build.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Build.hs
@@ -150,7 +150,7 @@ buildPluginDescriptor = PluginDescriptor
                       "Builds specified cabal or stack component"
                       buildTarget
       ]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 data OperationMode = StackMode | CabalMode

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -20,7 +20,7 @@ example2Descriptor = PluginDescriptor
       [ PluginCommand "sayHello" "say hello" sayHelloCmd
       , PluginCommand "sayHelloTo ""say hello to the passed in param" sayHelloToCmd
       ]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -20,6 +20,7 @@ example2Descriptor = PluginDescriptor
       [ PluginCommand "sayHello" "say hello" sayHelloCmd
       , PluginCommand "sayHelloTo ""say hello to the passed in param" sayHelloToCmd
       ]
+  , pluginCodeActions = \_ -> return []
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -20,7 +20,7 @@ example2Descriptor = PluginDescriptor
       [ PluginCommand "sayHello" "say hello" sayHelloCmd
       , PluginCommand "sayHelloTo ""say hello to the passed in param" sayHelloToCmd
       ]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -65,7 +65,7 @@ ghcmodDescriptor = PluginDescriptor
       , PluginCommand "type" "Get the type of the expression under (LINE,COL)" typeCmd
       , PluginCommand "casesplit" "Generate a pattern match for a binding under (LINE,COL)" splitCaseCmd
       ]
-  , pluginCodeActions = \_ -> return []      
+  , pluginCodeActions = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -65,6 +65,7 @@ ghcmodDescriptor = PluginDescriptor
       , PluginCommand "type" "Get the type of the expression under (LINE,COL)" typeCmd
       , PluginCommand "casesplit" "Generate a pattern match for a binding under (LINE,COL)" splitCaseCmd
       ]
+  , pluginCodeActions = \_ -> return []      
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -60,6 +60,7 @@ hareDescriptor = PluginDescriptor
       , PluginCommand "genapplicative" "Generalise a monadic function to use applicative"
           genApplicativeCommand
       ]
+  , pluginCodeActions = \_ -> return []
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -60,7 +60,7 @@ hareDescriptor = PluginDescriptor
       , PluginCommand "genapplicative" "Generalise a monadic function to use applicative"
           genApplicativeCommand
       ]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -60,7 +60,7 @@ hareDescriptor = PluginDescriptor
       , PluginCommand "genapplicative" "Generalise a monadic function to use applicative"
           genApplicativeCommand
       ]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -32,7 +32,7 @@ hoogleDescriptor = PluginDescriptor
       [ PluginCommand "info" "Look up the documentation for an identifier in the hoogle database" infoCmd
       , PluginCommand "lookup" "Search the hoogle database with a string" lookupCmd
       ]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -108,19 +108,19 @@ renderTarget t = T.intercalate "\n\n" $
 
 ------------------------------------------------------------------------
 
-searchModules :: T.Text -> IdeM (IdeResponse [T.Text])
-searchModules = fmap (fmap (nub . take 5)) . searchTargets (fmap (T.pack . fst) . targetModule)
+searchModules :: T.Text -> IdeM [T.Text]
+searchModules = fmap (nub . take 5) . searchTargets (fmap (T.pack . fst) . targetModule)
 
-searchPackages :: T.Text -> IdeM (IdeResponse [T.Text])
-searchPackages = fmap (fmap (nub . take 5)) . searchTargets (fmap (T.pack . fst) . targetPackage)
+searchPackages :: T.Text -> IdeM [T.Text]
+searchPackages = fmap (nub . take 5) . searchTargets (fmap (T.pack . fst) . targetPackage)
 
-searchTargets :: (Target -> Maybe a) -> T.Text -> IdeM (IdeResponse [a])
+searchTargets :: (Target -> Maybe a) -> T.Text -> IdeM [a]
 searchTargets f term = do
   HoogleDb mdb <- get
   res <- liftIO $ runHoogleQuery mdb term (Right . mapMaybe f . take 10)
   case bimap hoogleErrorToIdeError id res of
-    Left err -> return $ IdeResponseFail err
-    Right xs -> return $ IdeResponseOk xs
+    Left _ -> return []
+    Right xs -> return xs
 
 ------------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -32,7 +32,7 @@ hoogleDescriptor = PluginDescriptor
       [ PluginCommand "info" "Look up the documentation for an identifier in the hoogle database" infoCmd
       , PluginCommand "lookup" "Search the hoogle database with a string" lookupCmd
       ]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -32,6 +32,7 @@ hoogleDescriptor = PluginDescriptor
       [ PluginCommand "info" "Look up the documentation for an identifier in the hoogle database" infoCmd
       , PluginCommand "lookup" "Search the hoogle database with a string" lookupCmd
       ]
+  , pluginCodeActions = \_ -> return []
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -21,7 +21,7 @@ hsimportDescriptor = PluginDescriptor
   { pluginName = "hsimport"
   , pluginDesc = "A tool for extending the import list of a Haskell source file."
   , pluginCommands = [PluginCommand "import" "Import a module" importCmd]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
 
 data ImportParams = ImportParams

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -1,10 +1,15 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE TupleSections #-}
 module Haskell.Ide.Engine.Plugin.HsImport where
 
+import           Control.Lens
 import           Control.Monad.IO.Class
 import           Data.Aeson
+import           Data.Bitraversable
+import           Data.Foldable
+import           Data.Maybe
 import qualified Data.Text                     as T
 import qualified Data.Text.IO                  as T
 import qualified GHC.Generics                  as Generics
@@ -13,6 +18,7 @@ import           HsImport
 import           Haskell.Ide.Engine.MonadTypes
 import qualified Language.Haskell.LSP.Types    as J
 import           Haskell.Ide.Engine.PluginUtils
+import qualified Haskell.Ide.Engine.Plugin.Hoogle as Hoogle
 import           System.Directory
 import           System.IO
 
@@ -21,7 +27,7 @@ hsimportDescriptor = PluginDescriptor
   { pluginName = "hsimport"
   , pluginDesc = "A tool for extending the import list of a Haskell source file."
   , pluginCommands = [PluginCommand "import" "Import a module" importCmd]
-  , pluginCodeActionProvider = noCodeActions
+  , pluginCodeActionProvider = codeActionProvider
   }
 
 data ImportParams = ImportParams
@@ -58,3 +64,48 @@ importModule uri modName =
           liftIO $ removeFile output
           workspaceEdit <- liftToGhc $ makeDiffResult input newText fileMap
           return $ IdeResultOk workspaceEdit
+
+codeActionProvider :: CodeActionProvider
+codeActionProvider docId _ _ context = do
+  let J.List diags = context ^. J.diagnostics
+      terms = mapMaybe getImportables diags
+
+  res <- mapM (bimapM return Hoogle.searchModules) terms
+  let actions = mapMaybe (uncurry mkImportAction) (concatTerms res)
+
+  if null actions
+     then do
+       let relaxedTerms = map (bimap id (head . T.words)) terms
+       relaxedRes <- mapM (bimapM return Hoogle.searchModules) relaxedTerms
+       let relaxedActions = mapMaybe (uncurry mkImportAction) (concatTerms relaxedRes)
+       return $ IdeResponseOk relaxedActions
+     else return $ IdeResponseOk actions
+
+  where
+    concatTerms = concatMap (\(d, ts) -> map (d,) ts)
+
+    --TODO: Check if package is already installed
+    mkImportAction :: J.Diagnostic -> T.Text -> Maybe J.CodeAction
+    mkImportAction diag modName = Just codeAction
+     where
+       codeAction = J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd)
+       cmd = J.Command title cmdName (Just cmdParams)
+       title = "Import module " <> modName
+       cmdName = "hsimport:import"
+       cmdParams = toJSON [ImportParams (docId ^. J.uri) modName]
+
+    getImportables :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
+    getImportables diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractImportableTerm msg
+    getImportables _ = Nothing
+
+extractImportableTerm :: T.Text -> Maybe T.Text
+extractImportableTerm dirtyMsg = T.strip <$> asum
+  [T.stripPrefix "Variable not in scope: " msg,
+  T.init <$> T.stripPrefix "Not in scope: type constructor or class ‘" msg]
+  where msg = head
+              -- Get rid of the rename suggestion parts
+              $ T.splitOn "Perhaps you meant "
+              $ T.replace "\n" " "
+              -- Get rid of trailing/leading whitespace on each individual line
+              $ T.unlines $ map T.strip $ T.lines
+              $ T.replace "• " "" dirtyMsg

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -10,6 +10,7 @@ import           Data.Aeson
 import           Data.Bitraversable
 import           Data.Foldable
 import           Data.Maybe
+import           Data.Monoid ((<>))
 import qualified Data.Text                     as T
 import qualified Data.Text.IO                  as T
 import qualified GHC.Generics                  as Generics

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -21,6 +21,7 @@ hsimportDescriptor = PluginDescriptor
   { pluginName = "hsimport"
   , pluginDesc = "A tool for extending the import list of a Haskell source file."
   , pluginCommands = [PluginCommand "import" "Import a module" importCmd]
+  , pluginCodeActions = \_ -> return []
   }
 
 data ImportParams = ImportParams

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -21,7 +21,7 @@ hsimportDescriptor = PluginDescriptor
   { pluginName = "hsimport"
   , pluginDesc = "A tool for extending the import list of a Haskell source file."
   , pluginCommands = [PluginCommand "import" "Import a module" importCmd]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 data ImportParams = ImportParams

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -50,7 +50,7 @@ packageDescriptor = PluginDescriptor
   { pluginName     = "package"
   , pluginDesc     = "Tools for editing .cabal and package.yaml files."
   , pluginCommands = [PluginCommand "add" "Add a packge" addCmd]
-  , pluginCodeActions = \_ -> return []
+  , pluginCodeActions = noCodeActions
   }
 
 data AddParams = AddParams

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -50,7 +50,7 @@ packageDescriptor = PluginDescriptor
   { pluginName     = "package"
   , pluginDesc     = "Tools for editing .cabal and package.yaml files."
   , pluginCommands = [PluginCommand "add" "Add a packge" addCmd]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 data AddParams = AddParams

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -50,6 +50,7 @@ packageDescriptor = PluginDescriptor
   { pluginName     = "package"
   , pluginDesc     = "Tools for editing .cabal and package.yaml files."
   , pluginCommands = [PluginCommand "add" "Add a packge" addCmd]
+  , pluginCodeActions = \_ -> return []
   }
 
 data AddParams = AddParams

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -21,6 +21,7 @@ import qualified Data.HashMap.Strict           as HM
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as T
 import           Data.Maybe
+import           Data.Monoid ((<>))
 #if MIN_VERSION_Cabal(2,2,0)
 import           Distribution.PackageDescription.Parsec
 import           Distribution.Types.VersionRange

--- a/test/unit/CodeActionsSpec.hs
+++ b/test/unit/CodeActionsSpec.hs
@@ -2,7 +2,9 @@
 module CodeActionsSpec where
 
 import Test.Hspec
-import Haskell.Ide.Engine.LSP.CodeActions
+import Haskell.Ide.Engine.Plugin.HsImport
+import Haskell.Ide.Engine.Plugin.GhcMod
+import Haskell.Ide.Engine.Plugin.Package
 
 main :: IO ()
 main = hspec spec

--- a/test/unit/ExtensibleStateSpec.hs
+++ b/test/unit/ExtensibleStateSpec.hs
@@ -42,7 +42,7 @@ testDescriptor = PluginDescriptor
         PluginCommand "cmd1" "description" cmd1
       , PluginCommand "cmd2" "description" cmd2
       ]
-  , pluginCodeActions = noCodeActions
+  , pluginCodeActionProvider = noCodeActions
   }
 
 -- ---------------------------------------------------------------------

--- a/test/unit/ExtensibleStateSpec.hs
+++ b/test/unit/ExtensibleStateSpec.hs
@@ -42,6 +42,7 @@ testDescriptor = PluginDescriptor
         PluginCommand "cmd1" "description" cmd1
       , PluginCommand "cmd2" "description" cmd2
       ]
+  , pluginCodeActions = noCodeActions
   }
 
 -- ---------------------------------------------------------------------


### PR DESCRIPTION
Code actions are now generated with a `CodeActionProvider` field on `PluginDescriptor`.
The first part of #701 