### PR TITLE
Improve backwards compatible code actions, simplify command mapping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,28 +114,31 @@ jobs:
     <<: *defaults
 
   cabal:
-    docker: 
-      - image: haskell:8.4.3
+    working_directory: ~/build
+    docker:
+      - image: quay.io/haskell_works/ghc-8.4.3
     steps:
       - checkout
-      - run: git submodule update --recursive --init
+      - run:
+          command: git submodule sync --recursive
+      - run:
+          command: git submodule update --recursive --init
+
       - restore-cache:
-          keys: 
-            - cabal-{{ checksum "submodules" }}
+          keys:
+            - cabal-01
       - run:
           name: Update
           command: cabal new-update
       - run:
           name: Configure
-          command: cabal new-configure
+          command: cabal new-configure --enable-tests
       - run:
           name: Build
           command: cabal new-build -j2
       - save_cache:
-          key: cabal-{{ checksum "submodules" }}
+          key: cabal-01
           paths:
-            - dist
-            - new-dist
             - ~/.cabal
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,10 +120,14 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install zlib
+          command: apt-get update && apt-get install -y zlib1g-dev
+      - run:
+          name: Sync submodules
           command: git submodule sync --recursive
       - run:
+          name: Update submodules
           command: git submodule update --recursive --init
-
       - restore-cache:
           keys:
             - cabal-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,7 @@ jobs:
       - run: git submodule update --recursive --init
       - restore-cache:
           keys: 
-            - cabal
+            - cabal-{{ checksum "submodules" }}
       - run:
           name: Update
           command: cabal new-update
@@ -132,7 +132,7 @@ jobs:
           name: Build
           command: cabal new-build -j2
       - save_cache:
-          key: cabal
+          key: cabal-{{ checksum "submodules" }}
           paths:
             - dist
             - new-dist

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ dist
 tags
 test-logs/
 .DS_Store
+
+.hspec-failures

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -130,5 +130,5 @@ run opts = do
     jsonStdioTransport (dispatcherP pin plugins ghcModOptions) pin
   else do
     pin <- atomically newTChan
-    lspStdioTransport (dispatcherP pin plugins ghcModOptions) pin origDir (optCaptureFile opts)
+    lspStdioTransport (dispatcherP pin plugins ghcModOptions) pin origDir plugins (optCaptureFile opts)
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -49,7 +49,6 @@ library
                      , apply-refact
                      , async
                      , base >= 4.9 && < 5
-                     , bimap
                      , brittany
                      , bytestring
                      , Cabal

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -65,7 +65,7 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp >= 0.3.0
+                     , haskell-lsp >= 0.5
                      , haskell-src-exts
                      , hie-plugin-api
                      , hlint >= 2.0.11

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -243,6 +243,7 @@ test-suite func-test
                      , test/utils
   main-is:             Main.hs
   other-modules:       CompletionSpec
+                     , CommandSpec
                      , CodeActionsSpec
                      , DeferredSpec
                      , DefinitionSpec

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -39,7 +39,7 @@ library
                      , fingertree
                      , ghc
                      , ghc-mod-core >= 5.9.0.0
-                     , haskell-lsp >= 0.4.0.0
+                     , haskell-lsp >= 0.5
                      , hslogger
                      , monad-control
                      , mtl

--- a/src/Haskell/Ide/Engine/LSP/Reactor.hs
+++ b/src/Haskell/Ide/Engine/LSP/Reactor.hs
@@ -13,6 +13,7 @@ where
 import           Control.Concurrent.STM
 import           Control.Monad.Reader
 import qualified Data.Set                      as S
+import qualified Data.Text                     as T
 import qualified Language.Haskell.LSP.Core     as Core
 import qualified Language.Haskell.LSP.Messages as J
 import qualified Language.Haskell.LSP.Types    as J
@@ -22,9 +23,10 @@ import           Haskell.Ide.Engine.Types
 
 
 data REnv = REnv
-  { dispatcherEnv :: DispatcherEnv
-  , reqChanIn     :: TChan (PluginRequest R)
-  , lspFuncs      :: Core.LspFuncs Config
+  { dispatcherEnv   :: DispatcherEnv
+  , reqChanIn       :: TChan (PluginRequest R)
+  , lspFuncs        :: Core.LspFuncs Config
+  , commandPrefixer :: T.Text -> T.Text
   }
 
 -- | The monad used in the reactor
@@ -36,9 +38,11 @@ runReactor
   :: Core.LspFuncs Config
   -> DispatcherEnv
   -> TChan (PluginRequest R)
+  -> (T.Text -> T.Text)
   -> R a
   -> IO a
-runReactor lf de cin = flip runReaderT (REnv de cin lf)
+runReactor lf de cin prefixer =
+  flip runReaderT (REnv de cin lf prefixer)
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -294,6 +294,6 @@ codeActionProvider docId _ _ context = return $ IdeResponseOk hlintActions
        cmd = LSP.Command title cmdName cmdparams
        cmdName = "applyrefact:applyOne"
        -- need 'file', 'start_pos' and hint title (to distinguish between alternative suggestions at the same location)
-       args = toJSON [AOP (docId ^. LSP.uri) start code]
+       args = LSP.List [toJSON (AOP (docId ^. LSP.uri) start code)]
        cmdparams = Just args
     mkHlintAction (LSP.Diagnostic _r _s _c _source _m _) = Nothing

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -93,7 +93,7 @@ codeActionProvider docId _ _ context = do
        cmd = J.Command title cmdName (Just cmdParams)
        title = "Import module " <> modName
        cmdName = "hsimport:import"
-       cmdParams = toJSON [ImportParams (docId ^. J.uri) modName]
+       cmdParams = J.List [toJSON (ImportParams (docId ^. J.uri) modName)]
 
     getImportables :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
     getImportables diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractImportableTerm msg

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -245,7 +245,7 @@ codeActionProvider docId mRootDir _ context = do
      (Just rootDir, Just docFp) ->
        let title = "Add " <> pkgName <> " as a dependency"
            cmd = J.Command title "package:add" (Just cmdParams)
-           cmdParams = toJSON [AddParams rootDir docFp pkgName]
+           cmdParams = J.List [toJSON (AddParams rootDir docFp pkgName)]
        in Just (J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd))
      _ -> Nothing
     

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -26,7 +26,6 @@ import           Control.Monad.STM
 import           Control.Monad.Reader
 import qualified Data.Aeson as J
 import           Data.Aeson ( (.=) )
-import qualified Data.Bimap as BM
 import qualified Data.ByteString.Lazy as BL
 import           Data.Char (isUpper, isAlphaNum)
 import           Data.Default
@@ -84,10 +83,11 @@ lspStdioTransport
   :: (DispatcherEnv -> ErrorHandler -> CallbackHandler R -> ClientCapabilities -> IO ())
   -> TChan (PluginRequest R)
   -> FilePath
+  -> IdePlugins
   -> Maybe FilePath
   -> IO ()
-lspStdioTransport hieDispatcherProc cin origDir captureFp = do
-  run hieDispatcherProc cin origDir captureFp >>= \case
+lspStdioTransport hieDispatcherProc cin origDir plugins captureFp = do
+  run hieDispatcherProc cin origDir plugins captureFp >>= \case
     0 -> exitSuccess
     c -> exitWith . ExitFailure $ c
 
@@ -97,13 +97,14 @@ run
   :: (DispatcherEnv -> ErrorHandler -> CallbackHandler R -> ClientCapabilities -> IO ())
   -> TChan (PluginRequest R)
   -> FilePath
+  -> IdePlugins
   -> Maybe FilePath
   -> IO Int
-run dispatcherProc cin _origDir captureFp = flip E.catches handlers $ do
-
-  commandMap <- getCommandMap
+run dispatcherProc cin _origDir plugins captureFp = flip E.catches handlers $ do
 
   rin <- atomically newTChan :: IO (TChan ReactorInput)
+
+  prefix <- cmdPrefixer
 
   let dp lf = do
         cancelTVar  <- atomically $ newTVar S.empty
@@ -114,15 +115,15 @@ run dispatcherProc cin _origDir captureFp = flip E.catches handlers $ do
               , wipReqsTVar    = wipTVar
               , docVersionTVar = versionTVar
               }
-        let reactorFunc = runReactor lf dEnv cin $ reactor rin commandMap
+        let reactorFunc = runReactor lf dEnv cin prefix $ reactor rin
             caps = Core.clientCapabilities lf
 
         let errorHandler :: ErrorHandler
             errorHandler lid code e =
               Core.sendErrorResponseS (Core.sendFunc lf) (J.responseId lid) code e
             callbackHandler :: CallbackHandler R
-            callbackHandler f x = runReactor lf dEnv cin $ f x
-        
+            callbackHandler f x = runReactor lf dEnv cin prefix $ f x
+
 
         -- haskell lsp sets the current directory to the project root in the InitializeRequest
         -- We launch the dispatcher after that so that the defualt cradle is
@@ -130,18 +131,21 @@ run dispatcherProc cin _origDir captureFp = flip E.catches handlers $ do
         _ <- forkIO $ race_ (dispatcherProc dEnv errorHandler callbackHandler caps) reactorFunc
         return Nothing
 
+      commandIds = Map.foldlWithKey cmdFolder [] (fst <$> ipMap plugins)
+      cmdFolder :: [T.Text] -> T.Text -> [PluginCommand] -> [T.Text]
+      cmdFolder acc plugin cmds = acc ++ map prefix cmdIds
+        where cmdIds = map (\cmd -> plugin <> ":" <> commandName cmd) cmds
+
   flip E.finally finalProc $ do
-    CTRL.run (getConfigFromNotification, dp) (hieHandlers rin) (hieOptions (BM.elems commandMap)) captureFp
+    CTRL.run (getConfigFromNotification, dp) (hieHandlers rin) (hieOptions commandIds) captureFp
  where
   handlers  = [E.Handler ioExcept, E.Handler someExcept]
   finalProc = L.removeAllHandlers
   ioExcept (e :: E.IOException) = print e >> return 1
   someExcept (e :: E.SomeException) = print e >> return 1
-  getCommandMap = do
+  cmdPrefixer = do
     pid <- T.pack . show <$> getProcessID
-    let cmds = ["hare:demote", "applyrefact:applyOne", "hsimport:import", "package:add", "hie:fallbackCodeAction"]
-        newCmds = map (T.append pid . T.append ":") cmds
-    return $ BM.fromList (zip cmds newCmds)
+    return ((pid <> ":") <>)
 
 -- ---------------------------------------------------------------------
 
@@ -295,8 +299,8 @@ sendErrorLog msg = reactorSend' (`Core.sendErrorLogS` msg)
 -- | The single point that all events flow through, allowing management of state
 -- to stitch replies and requests together from the two asynchronous sides: lsp
 -- server and hie dispatcher
-reactor :: forall void. TChan ReactorInput -> BM.Bimap T.Text T.Text -> R void
-reactor inp commandMap = do
+reactor :: forall void. TChan ReactorInput -> R void
+reactor inp = do
   -- forever $ do
   let
     loop :: TrackingNumber -> R void
@@ -336,10 +340,15 @@ reactor inp commandMap = do
                    }
            }
           -}
+
+          -- TODO: Get all commands
+          prefix <- asks commandPrefixer
+          -- let pluginIds = map prefix (Map.keys (ipMap plugins))
+
           let
             options = J.object ["documentSelector" .= J.object [ "language" .= J.String "haskell"]]
             registrationsList =
-              [ J.Registration (commandMap BM.! "hare:demote") J.WorkspaceExecuteCommand (Just options)
+              [ J.Registration (prefix "hare:demote") J.WorkspaceExecuteCommand (Just options)
               ]
           let registrations = J.RegistrationParams (J.List registrationsList)
 
@@ -359,7 +368,7 @@ reactor inp commandMap = do
                       ++ "\nYou may want to use hie-wrapper. Check the README for more information"
             reactorSend $ NotShowMessage $ fmServerShowMessageNotification J.MtWarning msg
             reactorSend $ NotLogMessage $ fmServerLogMessageNotification J.MtWarning msg
-          
+
           -- Check cabal is installed
           hasCabal <- liftIO checkCabalInstall
           unless hasCabal $ do
@@ -523,7 +532,7 @@ reactor inp commandMap = do
 
         ReqCodeAction req -> do
           liftIO $ U.logs $ "reactor:got CodeActionRequest:" ++ show req
-          handleCodeActionReq tn commandMap req
+          handleCodeActionReq tn req
           -- TODO: make context specific commands for all sorts of things, such as refactorings          
 
         -- -------------------------------
@@ -531,12 +540,17 @@ reactor inp commandMap = do
         ReqExecuteCommand req -> do
           liftIO $ U.logs $ "reactor:got ExecuteCommandRequest:" ++ show req
           let params = req ^. J.params
-              command' = params ^. J.command
-              -- if this is a UUID then use the mapping for it
-              command = fromMaybe command' (BM.lookupR command' commandMap)
+              command = stripCmdPrefix (params ^. J.command)
+
+              -- | strips the PID prefix from the command id if it has one
+              stripCmdPrefix :: T.Text -> T.Text
+              stripCmdPrefix x
+                | T.count ":" x >= 2 = T.tail $ T.dropWhile (/= ':') x
+                | otherwise = x
+
               margs = params ^. J.arguments
 
-          liftIO $ U.logs $ "ExecuteCommand mapped command " ++ show command' ++ " to " ++ show command
+          liftIO $ U.logs $ "ExecuteCommand mapped command " ++ show (params ^. J.command) ++ " to " ++ show command
 
           --liftIO $ U.logs $ "reactor:ExecuteCommandRequest:margs=" ++ show margs
           let cmdparams = case margs of
@@ -571,10 +585,11 @@ reactor inp commandMap = do
                                 . J.ApplyWorkspaceEditParams
                   case mCmd of
                     -- If we have a command, execCmd will send the response
-                    Just (J.Command _ name mArgs) ->
-                      case mArgs of
-                        Just (J.List (x:_)) -> execCmd name x
-                        _ -> execCmd name J.Null
+                    Just (J.Command _ innerCmd mArgs) ->
+                      let innerCmd' = stripCmdPrefix innerCmd
+                      in case mArgs of
+                        Just (J.List (x:_)) -> execCmd innerCmd' x
+                        _ -> execCmd innerCmd' J.Null
 
                     -- Otherwise we need to send back a response oureslves
                     Nothing ->
@@ -819,7 +834,7 @@ syncOptions = J.TextDocumentSyncOptions
   }
 
 hieOptions :: [T.Text] -> Core.Options
-hieOptions commandUUIDs =
+hieOptions commandIds =
   def { Core.textDocumentSync       = Just syncOptions
       , Core.completionProvider     = Just (J.CompletionOptions (Just True) (Just ["."]))
       -- As of 2018-05-24, vscode needs the commands to be registered
@@ -828,7 +843,7 @@ hieOptions commandUUIDs =
       --
       -- Hopefully the end May 2018 vscode release will stabilise
       -- this, it is a major rework of the machinery anyway.
-      , Core.executeCommandProvider = Just (J.ExecuteCommandOptions (J.List commandUUIDs))
+      , Core.executeCommandProvider = Just (J.ExecuteCommandOptions (J.List commandIds))
       }
 
 

--- a/test/functional/CommandSpec.hs
+++ b/test/functional/CommandSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+module CommandSpec where
+
+import Control.Lens hiding (List)
+import Control.Monad.IO.Class
+import qualified Data.Text as T
+import Data.Char
+import Language.Haskell.LSP.Test
+import Language.Haskell.LSP.Types as LSP
+import Test.Hspec
+import TestUtils
+
+spec :: Spec
+spec = describe "commands" $ do
+  it "are prefixed" $ runSession hieCommand "test/testdata/" $ do
+    ResponseMessage _ _ (Just res) Nothing <- initializeResponse
+    let List cmds = res ^. LSP.capabilities . executeCommandProvider . _Just . commands
+        f x = (T.length (T.takeWhile isNumber x) >= 1) && (T.count ":" x >= 2)
+    liftIO $ do
+      cmds `shouldSatisfy` all f
+      cmds `shouldNotSatisfy` null
+
+  it "get de-prefixed" $ runSession hieCommand "test/testdata/" $ do
+    ResponseMessage _ _ _ (Just err) <- sendRequest
+            WorkspaceExecuteCommand
+            (ExecuteCommandParams "1234:package:add" (Just (List []))) :: Session ExecuteCommandResponse
+    let ResponseError _ msg _ = err
+    -- We expect an error message about the dud arguments, but should pickup "add" and "package"
+    liftIO $ msg `shouldSatisfy` T.isInfixOf "while parsing args for add in plugin package"

--- a/test/testdata/redundantImportTest/src/MultipleImports.hs
+++ b/test/testdata/redundantImportTest/src/MultipleImports.hs
@@ -1,0 +1,5 @@
+module MultipleImports where
+import Data.Foldable
+import Data.Maybe
+foo :: Int
+foo = fromJust (Just 3)


### PR DESCRIPTION
Does part of #701.
Both workspace edits and commands are now included in the `fallbackCodeAction` shim command.
Also gets rid of the command map which is now no longer needed, and automatically sends all plugin commands in the initialise request