### PR TITLE
Refactor command IDs to use CommandId type

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -44,17 +44,17 @@ import           Haskell.Ide.Engine.Plugin.Package
 
 -- | This will be read from a configuration, eventually
 plugins :: IdePlugins
-plugins = pluginDescToIdePlugins
-  [("applyrefact", applyRefactDescriptor)
-  ,("brittany"   , brittanyDescriptor)
-  ,("build"      , buildPluginDescriptor)
-  ,("eg2"        , example2Descriptor)
-  ,("ghcmod"     , ghcmodDescriptor)
-  ,("hare"       , hareDescriptor)
-  ,("base"       , baseDescriptor)
-  ,("hoogle"     , hoogleDescriptor)
-  ,("hsimport"   , hsimportDescriptor)
-  ,("package"    , packageDescriptor)
+plugins = mkIdePlugins
+  [ applyRefactDescriptor
+  , brittanyDescriptor
+  , buildPluginDescriptor
+  , example2Descriptor
+  , ghcmodDescriptor
+  , hareDescriptor
+  , baseDescriptor
+  , hoogleDescriptor
+  , hsimportDescriptor
+  , packageDescriptor
   ]
 
 -- ---------------------------------------------------------------------

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -86,10 +86,6 @@ library
                      , vector
                      , yaml >= 0.8.31
                      , yi-rope
-  if os(windows)
-    build-depends:     Win32
-  else
-    build-depends:     unix
   ghc-options:         -Wall -Wredundant-constraints
   if flag(pedantic)
      ghc-options:      -Werror

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -62,6 +62,7 @@ import           Data.Aeson
 import           Data.Dynamic (Dynamic)
 import           Data.IORef
 import qualified Data.Map as Map
+import           Data.Monoid ((<>))
 import qualified Data.Text as T
 import           Data.Typeable (TypeRep, Typeable)
 
@@ -155,7 +156,7 @@ noCodeActions _ _ _ _ = return $ IdeResponseOk []
 -- | a Description of the available commands and code action providers stored in IdeGhcM
 newtype IdePlugins = IdePlugins
   { ipMap :: Map.Map PluginId PluginDescriptor
-  } deriving (Generic)
+  }
 
 instance ToJSON IdePlugins where
   toJSON (IdePlugins m) = toJSON $ fmap (\x -> (commandId x, commandDesc x)) <$> fmap pluginCommands m

--- a/hie-plugin-api/Haskell/Ide/Engine/Process.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Process.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE CPP #-}
+module Haskell.Ide.Engine.Process where
+
+#ifdef mingw32_HOST_OS
+
+import qualified System.Win32.Process as P (getCurrentProcessId)
+getProcessID :: IO Int
+getProcessID = fromIntegral <$> P.getCurrentProcessId
+
+#else
+
+import qualified System.Posix.Process as P (getProcessID)
+getProcessID :: IO Int
+getProcessID = fromIntegral <$> P.getProcessID
+
+#endif

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -29,6 +29,7 @@ library
                        Haskell.Ide.Engine.PluginDescriptor
                        Haskell.Ide.Engine.PluginsIdeMonads
                        Haskell.Ide.Engine.PluginUtils
+                       Haskell.Ide.Engine.Process
   build-depends:       base >= 4.9 && < 5
                      , Diff
                      , aeson
@@ -48,6 +49,10 @@ library
                      , text
                      , transformers
                      , unordered-containers
+  if os(windows)
+    build-depends:     Win32
+  else
+    build-depends:     unix
   ghc-options:         -Wall
   if flag(pedantic)
      ghc-options:      -Werror

--- a/src/Haskell/Ide/Engine/Compat.hs
+++ b/src/Haskell/Ide/Engine/Compat.hs
@@ -21,20 +21,6 @@ import Data.List
 import System.FilePath
 #endif
 
-#ifdef mingw32_HOST_OS
-
-import qualified System.Win32.Process as P (getCurrentProcessId)
-getProcessID :: IO Int
-getProcessID = fromIntegral <$> P.getCurrentProcessId
-
-#else
-
-import qualified System.Posix.Process as P (getProcessID)
-getProcessID :: IO Int
-getProcessID = fromIntegral <$> P.getProcessID
-
-#endif
-
 #if MIN_VERSION_Cabal(2,2,0)
 #else  
 condBenchmarks :: Lens' GenericPackageDescription [(UnqualComponentName, CondTree ConfVar [Dependency] Benchmark)]

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -55,7 +55,7 @@ dispatcherP inChan plugins ghcModOptions env errorHandler callbackHandler caps =
   stateVarVar <- newEmptyMVar
   ideChan <- newTChanIO
   ghcChan <- newTChanIO
-  let startState = IdeState emptyModuleCache Map.empty plugins Map.empty Nothing
+  let startState = IdeState emptyModuleCache Map.empty plugins Map.empty Nothing Nothing
       runGhcDisp = runIdeGhcM ghcModOptions caps startState $ do
         stateVar <- lift $ lift $ lift ask
         liftIO $ putMVar stateVarVar stateVar

--- a/src/Haskell/Ide/Engine/LSP/Reactor.hs
+++ b/src/Haskell/Ide/Engine/LSP/Reactor.hs
@@ -13,7 +13,6 @@ where
 import           Control.Concurrent.STM
 import           Control.Monad.Reader
 import qualified Data.Set                      as S
-import qualified Data.Text                     as T
 import qualified Language.Haskell.LSP.Core     as Core
 import qualified Language.Haskell.LSP.Messages as J
 import qualified Language.Haskell.LSP.Types    as J
@@ -26,7 +25,6 @@ data REnv = REnv
   { dispatcherEnv   :: DispatcherEnv
   , reqChanIn       :: TChan (PluginRequest R)
   , lspFuncs        :: Core.LspFuncs Config
-  , commandPrefixer :: T.Text -> T.Text
   }
 
 -- | The monad used in the reactor
@@ -38,11 +36,10 @@ runReactor
   :: Core.LspFuncs Config
   -> DispatcherEnv
   -> TChan (PluginRequest R)
-  -> (T.Text -> T.Text)
   -> R a
   -> IO a
-runReactor lf de cin prefixer =
-  flip runReaderT (REnv de cin lf prefixer)
+runReactor lf de cin =
+  flip runReaderT (REnv de cin lf)
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -24,20 +24,25 @@ import           Data.Maybe (maybeToList)
 data FormatParams = FormatParams Int Uri (Maybe Range)
      deriving (Eq, Show, Generic, FromJSON, ToJSON)
 
-brittanyDescriptor :: PluginDescriptor
-brittanyDescriptor = PluginDescriptor
-  { pluginName     = "Brittany"
-  , pluginDesc     = "Brittany is a tool to format source code."
-  , pluginCommands = [ PluginCommand "format"
-                                     "Format a range of text or document"
-                                     cmd
-                     ]
-  , pluginCodeActionProvider = noCodeActions
-  }
+brittanyId :: PluginId
+brittanyId = "brittany"
+
+formatCmd :: PluginCommand
+formatCmd = PluginCommand (CommandId brittanyId "format")
+                          "Format a range of text or a document"
+                          cmd
  where
   cmd :: CommandFunc FormatParams [J.TextEdit]
   cmd =
     CmdSync $ \(FormatParams tabSize uri range) -> brittanyCmd tabSize uri range
+
+brittanyDescriptor :: PluginDescriptor
+brittanyDescriptor = PluginDescriptor
+  { pluginId       = brittanyId
+  , pluginDesc     = "Brittany is a tool to format source code."
+  , pluginCommands = [formatCmd]
+  , pluginCodeActionProvider = noCodeActions
+  }
 
 brittanyCmd :: Int -> Uri -> Maybe Range -> IdeGhcM (IdeResult [J.TextEdit])
 brittanyCmd tabSize uri range =

--- a/src/Haskell/Ide/Engine/Plugin/Build.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Build.hs
@@ -120,33 +120,33 @@ buildPluginDescriptor = PluginDescriptor
 buildPluginDescriptor :: PluginDescriptor
 buildPluginDescriptor = PluginDescriptor
   {
-    pluginName = "Build plugin"
+    pluginId = "build"
   , pluginDesc = "A HIE plugin for building cabal/stack packages"
   , pluginCommands =
-      [ PluginCommand "prepare"
+      [ PluginCommand (CommandId "build" "prepare")
                       "Prepares helper executable. The project must be configured first"
                       prepareHelper
       -- , PluginCommand "isPrepared"
       --                    ("Checks whether cabal-helper is prepared to work with this project. "
       --                  <> "The project must be configured first")
       --                  isHelperPrepared
-      , PluginCommand "isConfigured"
+      , PluginCommand (CommandId "build" "isConfigured")
                        "Checks if project is configured"
                        isConfigured
-      , PluginCommand "configure"
+      , PluginCommand (CommandId "build" "configure")
                          ("Configures the project. "
                        <> "For stack project with multiple local packages - build it")
                        configure
-      , PluginCommand "listTargets"
+      , PluginCommand (CommandId "build" "listTargets")
                       "Given a directory with stack/cabal project lists all its targets"
                       listTargets
-      , PluginCommand "listFlags"
+      , PluginCommand (CommandId "build" "listFlags")
                       "Lists all flags that can be set when configuring a package"
                       listFlags
-      , PluginCommand "buildDirectory"
+      , PluginCommand (CommandId "build" "buildDirectory")
                       "Builds all targets that correspond to the specified directory"
                       buildDirectory
-      , PluginCommand "buildTarget"
+      , PluginCommand (CommandId "build" "buildTarget")
                       "Builds specified cabal or stack component"
                       buildTarget
       ]

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -14,11 +14,11 @@ import           Haskell.Ide.Engine.MonadTypes
 example2Descriptor :: PluginDescriptor
 example2Descriptor = PluginDescriptor
   {
-    pluginName = "Hello World"
+    pluginId = "helloWorld"
   , pluginDesc = "An example of writing an HIE plugin"
   , pluginCommands =
-      [ PluginCommand "sayHello" "say hello" sayHelloCmd
-      , PluginCommand "sayHelloTo ""say hello to the passed in param" sayHelloToCmd
+      [ PluginCommand (CommandId "helloWorld" "sayHello") "say hello" sayHelloCmd
+      , PluginCommand (CommandId "helloWorld" "sayHelloTo") "say hello to the passed in param" sayHelloToCmd
       ]
   , pluginCodeActionProvider = noCodeActions
   }

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -55,19 +55,22 @@ import           Outputable                        (renderWithStyle, mkUserStyle
 
 -- ---------------------------------------------------------------------
 
+ghcModId :: PluginId
+ghcModId = "ghcmod"
+
 ghcmodDescriptor :: PluginDescriptor
 ghcmodDescriptor = PluginDescriptor
   {
-    pluginName = "ghc-mod"
+    pluginId = ghcModId
   , pluginDesc = "ghc-mod is a backend program to enrich Haskell programming "
               <> "in editors. It strives to offer most of the features one has come to expect "
               <> "from modern IDEs in any editor."
   , pluginCommands =
-      [ PluginCommand "check" "check a file for GHC warnings and errors" checkCmd
-      , PluginCommand "lint" "Check files using `hlint'" lintCmd
-      , PluginCommand "info" "Look up an identifier in the context of FILE (like ghci's `:info')" infoCmd
-      , PluginCommand "type" "Get the type of the expression under (LINE,COL)" typeCmd
-      , PluginCommand "casesplit" "Generate a pattern match for a binding under (LINE,COL)" splitCaseCmd
+      [ PluginCommand (CommandId ghcModId "check") "check a file for GHC warnings and errors" checkCmd
+      , PluginCommand (CommandId ghcModId "lint") "Check files using `hlint'" lintCmd
+      , PluginCommand (CommandId ghcModId "info") "Look up an identifier in the context of FILE (like ghci's `:info')" infoCmd
+      , PluginCommand (CommandId ghcModId "type") "Get the type of the expression under (LINE,COL)" typeCmd
+      , PluginCommand (CommandId ghcModId "casesplit") "Generate a pattern match for a binding under (LINE,COL)" splitCaseCmd
       ]
   , pluginCodeActionProvider = codeActionProvider
   }

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -35,29 +35,32 @@ import           Language.Haskell.Refact.Utils.Monad          hiding (logm)
 
 -- ---------------------------------------------------------------------
 
+harePluginId :: PluginId
+harePluginId = "hare"
+
 hareDescriptor :: PluginDescriptor
 hareDescriptor = PluginDescriptor
-  { pluginName = "HaRe"
+  { pluginId = harePluginId
   , pluginDesc = "A Haskell 2010 refactoring tool. HaRe supports the full "
               <> "Haskell 2010 standard, through making use of the GHC API.  HaRe attempts to "
               <> "operate in a safe way, by first writing new files with proposed changes, and "
               <> "only swapping these with the originals when the change is accepted. "
   , pluginCommands =
-      [ PluginCommand "demote" "Move a definition one level down"
+      [ PluginCommand (CommandId harePluginId "demote") "Move a definition one level down"
           demoteCmd
-      , PluginCommand "dupdef" "Duplicate a definition"
+      , PluginCommand (CommandId harePluginId "dupdef") "Duplicate a definition"
           dupdefCmd
-      , PluginCommand "iftocase" "Converts an if statement to a case statement"
+      , PluginCommand (CommandId harePluginId "iftocase") "Converts an if statement to a case statement"
           iftocaseCmd
-      , PluginCommand "liftonelevel" "Move a definition one level up from where it is now"
+      , PluginCommand (CommandId harePluginId "liftonelevel") "Move a definition one level up from where it is now"
           liftonelevelCmd
-      , PluginCommand "lifttotoplevel" "Move a definition to the top level from where it is now"
+      , PluginCommand (CommandId harePluginId "lifttotoplevel") "Move a definition to the top level from where it is now"
           lifttotoplevelCmd
-      , PluginCommand "rename" "rename a variable or type"
+      , PluginCommand (CommandId harePluginId "rename") "rename a variable or type"
           renameCmd
-      , PluginCommand "deletedef" "Delete a definition"
+      , PluginCommand (CommandId harePluginId "deletedef") "Delete a definition"
           deleteDefCmd
-      , PluginCommand "genapplicative" "Generalise a monadic function to use applicative"
+      , PluginCommand (CommandId harePluginId "genapplicative") "Generalise a monadic function to use applicative"
           genApplicativeCommand
       ]
   , pluginCodeActionProvider = noCodeActions

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -20,17 +20,20 @@ import           Text.HTML.TagSoup.Tree
 
 -- ---------------------------------------------------------------------
 
+hoogleId :: PluginId
+hoogleId = "hoogle"
+
 hoogleDescriptor :: PluginDescriptor
 hoogleDescriptor = PluginDescriptor
   {
-    pluginName = "hoogle"
+    pluginId = hoogleId
   , pluginDesc =
          "Hoogle is a Haskell API search engine, which allows you to search "
       <> "many standard Haskell libraries by either function name, or by approximate "
       <> "type signature. "
   , pluginCommands =
-      [ PluginCommand "info" "Look up the documentation for an identifier in the hoogle database" infoCmd
-      , PluginCommand "lookup" "Search the hoogle database with a string" lookupCmd
+      [ PluginCommand (CommandId hoogleId "info") "Look up the documentation for an identifier in the hoogle database" infoCmd
+      , PluginCommand (CommandId hoogleId "lookup") "Search the hoogle database with a string" lookupCmd
       ]
   , pluginCodeActionProvider = noCodeActions
   }

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -32,6 +32,7 @@ import qualified Data.Text                             as T
 import           GHC.Generics
 import           Haskell.Ide.Engine.Dispatcher
 import           Haskell.Ide.Engine.PluginDescriptor
+import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Types
 import qualified Language.Haskell.LSP.Types            as J
 import           Language.Haskell.LSP.Types.Capabilities
@@ -111,7 +112,7 @@ run dispatcherProc cin = flip E.catches handlers $ do
       forever $ do
         req <- getNextReq
         let preq = GReq 0 (context req) Nothing (Just $ J.IdInt rid) (liftIO . callback)
-              $ runPluginCommand (plugin req) (command req) (arg req)
+              $ runPluginCommand (CommandId (plugin req) (command req)) (arg req)
             rid = reqId req
             callback = sendResponse rid . dynToJSON
         atomically $ writeTChan cin preq

--- a/test/unit/ApplyRefactPluginSpec.hs
+++ b/test/unit/ApplyRefactPluginSpec.hs
@@ -27,7 +27,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: IdePlugins
-testPlugins = pluginDescToIdePlugins [("applyrefact",applyRefactDescriptor)]
+testPlugins = mkIdePlugins [applyRefactDescriptor]
 
 -- ---------------------------------------------------------------------
 
@@ -47,7 +47,7 @@ applyRefactSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton applyRefactPath textEdits)
             Nothing
-      testCommand testPlugins act "applyrefact" "applyOne" arg res
+      testCommand testPlugins act (commandId applyOneCmd) arg res
 
     -- ---------------------------------
 
@@ -60,9 +60,11 @@ applyRefactSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton applyRefactPath textEdits)
             Nothing            
-      testCommand testPlugins act "applyrefact" "applyAll" arg res
+      testCommand testPlugins act (commandId applyAllCmd) arg res
 
     -- ---------------------------------
+
+    let lintCmdId = commandId lintCmd
 
     it "returns hints as diagnostics" $ do
 
@@ -85,7 +87,7 @@ applyRefactSpec = do
                             "Redundant bracket\nFound:\n  (x + 1)\nWhy not:\n  x + 1\n"
                             Nothing
                ]}
-      testCommand testPlugins act "applyrefact" "lint" arg res
+      testCommand testPlugins act lintCmdId arg res
 
     -- ---------------------------------
 
@@ -105,7 +107,7 @@ applyRefactSpec = do
                            , _source = Just "hlint"
                            , _message = "Parse error: :~:\n  import           Data.Type.Equality            ((:~:) (..), (:~~:) (..))\n  \n> data instance Sing (z :: (a :~: b)) where\n      SRefl :: Sing Refl\n\n"
                            , _relatedInformation = Nothing }]}
-      testCommand testPlugins act "applyrefact" "lint" arg res
+      testCommand testPlugins act lintCmdId arg res
 
     -- ---------------------------------
 

--- a/test/unit/BrittanySpec.hs
+++ b/test/unit/BrittanySpec.hs
@@ -17,7 +17,7 @@ spec :: Spec
 spec = describe "brittany plugin" brittanySpec
 
 testPlugins :: IdePlugins
-testPlugins = pluginDescToIdePlugins [("brittany", brittanyDescriptor)]
+testPlugins = mkIdePlugins [brittanyDescriptor]
 
 brittanySpec :: Spec
 brittanySpec = describe "brittany plugin commands" $ do
@@ -25,6 +25,8 @@ brittanySpec = describe "brittany plugin commands" $ do
     "./test/testdata/BrittanyLF.hs"
   crlfFile <- runIO $ filePathToUri <$> makeAbsolute
     "./test/testdata/BrittanyCRLF.hs"
+
+  let formatCmdId = commandId formatCmd
 
   it "formats a document with LF endings" $ do
     let
@@ -39,7 +41,7 @@ brittanySpec = describe "brittany plugin commands" $ do
             , _newText = "foo :: Int -> String -> IO ()\nfoo x y = do\n    print x\n    return 42\n"
             }
         ]
-    testCommand testPlugins act "brittany" "format" arg res
+    testCommand testPlugins act formatCmdId arg res
 
   it "formats a document with CRLF endings" $ do
     let
@@ -54,7 +56,7 @@ brittanySpec = describe "brittany plugin commands" $ do
             , _newText = "foo :: Int -> String -> IO ()\nfoo x y = do\n    print x\n    return 42\n"
             }
         ]
-    testCommand testPlugins act "brittany" "format" arg res
+    testCommand testPlugins act formatCmdId arg res
 
   it "formats a range with LF endings" $ do
     let r   = Range (Position 1 0) (Position 2 22)
@@ -69,7 +71,7 @@ brittanySpec = describe "brittany plugin commands" $ do
               , _newText = "foo x y = do\n    print x\n    return 42\n"
               }
           ]
-    testCommand testPlugins act "brittany" "format" arg res
+    testCommand testPlugins act formatCmdId arg res
 
   it "formats a range with CRLF endings" $ do
     let r   = Range (Position 1 0) (Position 2 22)
@@ -84,4 +86,4 @@ brittanySpec = describe "brittany plugin commands" $ do
               , _newText = "foo x y = do\n    print x\n    return 42\n"
               }
           ]
-    testCommand testPlugins act "brittany" "format" arg res
+    testCommand testPlugins act formatCmdId arg res

--- a/test/unit/ExtensibleStateSpec.hs
+++ b/test/unit/ExtensibleStateSpec.hs
@@ -22,8 +22,8 @@ extensibleStateSpec =
   describe "stores and retrieves in the state" $
     it "stores the first one" $ do
       r <- runIGM testPlugins $ do
-          r1 <- makeRequest "test" "cmd1" ()
-          r2 <- makeRequest "test" "cmd2" ()
+          r1 <- makeRequest (CommandId "test" "cmd1") ()
+          r2 <- makeRequest (CommandId "test" "cmd2") ()
           return (r1,r2)
       fmap fromDynJSON (fst r) `shouldBe` IdeResultOk (Just "result:put foo" :: Maybe T.Text)
       fmap fromDynJSON (snd r) `shouldBe` IdeResultOk (Just "result:got:\"foo\"" :: Maybe T.Text)
@@ -31,16 +31,16 @@ extensibleStateSpec =
 -- ---------------------------------------------------------------------
 
 testPlugins :: IdePlugins
-testPlugins = pluginDescToIdePlugins [("test",testDescriptor)]
+testPlugins = mkIdePlugins [testDescriptor]
 
 testDescriptor :: PluginDescriptor
 testDescriptor = PluginDescriptor
   {
-    pluginName = "testDescriptor"
+    pluginId = "test"
   , pluginDesc = "PluginDescriptor for testing Dispatcher"
   , pluginCommands = [
-        PluginCommand "cmd1" "description" cmd1
-      , PluginCommand "cmd2" "description" cmd2
+        PluginCommand (CommandId "test" "cmd1") "description" cmd1
+      , PluginCommand (CommandId "test" "cmd2") "description" cmd2
       ]
   , pluginCodeActionProvider = noCodeActions
   }

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -33,7 +33,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: IdePlugins
-testPlugins = pluginDescToIdePlugins [("ghcmod",ghcmodDescriptor)]
+testPlugins = mkIdePlugins [ghcmodDescriptor]
 
 -- ---------------------------------------------------------------------
 
@@ -54,7 +54,7 @@ ghcmodSpec =
                             "Variable not in scope: x"
                             Nothing
 
-      testCommand testPlugins act "ghcmod" "check" arg res
+      testCommand testPlugins act (CommandId "ghcmod" "check") arg res
 
     -- ---------------------------------
 
@@ -68,7 +68,7 @@ ghcmodSpec =
 #else
           res = IdeResultOk (T.pack fp <> ":6:9: Warning: Redundant do\NULFound:\NUL  do return (3 + x)\NULWhy not:\NUL  return (3 + x)\n")
 #endif
-      testCommand testPlugins act "ghcmod" "lint" arg res
+      testCommand testPlugins act (CommandId "ghcmod" "lint") arg res
 
     -- ---------------------------------
 
@@ -79,7 +79,7 @@ ghcmodSpec =
           arg = IP uri "main"
           res = IdeResultOk "main :: IO () \t-- Defined at HaReRename.hs:2:1\n"
       -- ghc-mod tries to load the test file in the context of the hie project if we do not cd first.
-      testCommand testPlugins act "ghcmod" "info" arg res
+      testCommand testPlugins act (CommandId "ghcmod" "info") arg res
 
     -- ---------------------------------
 
@@ -95,7 +95,7 @@ ghcmodSpec =
             ,(Range (toPos (5,9)) (toPos (5,14)), "Int")
             ,(Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
             ]
-      testCommand testPlugins act "ghcmod" "type" arg res
+      testCommand testPlugins act (CommandId "ghcmod" "type") arg res
 
     it "runs the type command with an absolute path from another folder, correct params" $ do
       fp <- makeAbsolute "./test/testdata/HaReRename.hs"
@@ -114,7 +114,7 @@ ghcmodSpec =
               ,(Range (toPos (5,9)) (toPos (5,14)), "Int")
               ,(Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
               ]
-        testCommand testPlugins act "ghcmod" "type" arg res
+        testCommand testPlugins act (CommandId "ghcmod" "type") arg res
 
     -- ---------------------------------
 
@@ -130,7 +130,7 @@ ghcmodSpec =
                                 $ List [TextEdit (Range (Position 4 0) (Position 4 10))
                                           "foo Nothing = ()\nfoo (Just x) = ()"])
             Nothing
-      testCommand testPlugins act "ghcmod" "casesplit" arg res
+      testCommand testPlugins act (CommandId "ghcmod" "casesplit") arg res
 
     it "runs the casesplit command with an absolute path from another folder, correct params" $ do
       fp <- makeAbsolute "./test/testdata/GhcModCaseSplit.hs"
@@ -149,4 +149,4 @@ ghcmodSpec =
                                   $ List [TextEdit (Range (Position 4 0) (Position 4 10))
                                             "foo Nothing = ()\nfoo (Just x) = ()"])
               Nothing
-        testCommand testPlugins act "ghcmod" "casesplit" arg res
+        testCommand testPlugins act (CommandId "ghcmod" "casesplit") arg res

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -34,7 +34,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: IdePlugins
-testPlugins = pluginDescToIdePlugins [("hare",hareDescriptor)]
+testPlugins = mkIdePlugins [hareDescriptor]
 
 dispatchRequestPGoto :: IdeGhcM a -> IO a
 dispatchRequestPGoto =
@@ -58,7 +58,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "rename" arg res
+      testCommand testPlugins act (CommandId "hare" "rename") arg res
 
     -- ---------------------------------
 
@@ -69,7 +69,7 @@ hareSpec = do
           res = IdeResultFail
                   IdeError { ideCode = PluginError
                            , ideMessage = "rename: \"Invalid cursor position!\"", ideInfo = Null}
-      testCommand testPlugins act "hare" "rename" arg res
+      testCommand testPlugins act (CommandId "hare" "rename") arg res
 
     -- ---------------------------------
 
@@ -81,7 +81,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "demote" arg res
+      testCommand testPlugins act (CommandId "hare" "demote") arg res
 
     -- ---------------------------------
 
@@ -93,7 +93,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "dupdef" arg res
+      testCommand testPlugins act (CommandId "hare" "dupdef") arg res
 
     -- ---------------------------------
 
@@ -108,7 +108,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "iftocase" arg res
+      testCommand testPlugins act (CommandId "hare" "iftocase") arg res
 
     -- ---------------------------------
 
@@ -122,7 +122,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "liftonelevel" arg res
+      testCommand testPlugins act (CommandId "hare" "liftonelevel") arg res
 
     -- ---------------------------------
 
@@ -138,7 +138,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "lifttotoplevel" arg res
+      testCommand testPlugins act (CommandId "hare" "lifttotoplevel") arg res
 
     -- ---------------------------------
 
@@ -150,7 +150,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "deletedef" arg res
+      testCommand testPlugins act (CommandId "hare" "deletedef") arg res
 
     -- ---------------------------------
 
@@ -163,7 +163,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "genapplicative" arg res
+      testCommand testPlugins act (CommandId "hare" "genapplicative") arg res
 
     -- ---------------------------------
 

--- a/test/unit/HooglePluginSpec.hs
+++ b/test/unit/HooglePluginSpec.hs
@@ -24,7 +24,7 @@ spec = do
 -- ---------------------------------------------------------------------
 
 testPlugins :: IdePlugins
-testPlugins = pluginDescToIdePlugins [("hoogle",hoogleDescriptor)]
+testPlugins = mkIdePlugins [hoogleDescriptor]
 
 dispatchRequestP :: IdeGhcM a -> IO a
 dispatchRequestP = runIGM testPlugins

--- a/test/utils/TestUtils.hs
+++ b/test/utils/TestUtils.hs
@@ -54,23 +54,23 @@ cdAndDo path fn = do
           $ const fn
 
 
-testCommand :: (ToJSON a, Typeable b, ToJSON b, Show b, Eq b) => IdePlugins -> IdeGhcM (IdeResult b) -> PluginId -> CommandName -> a -> IdeResult b -> IO ()
-testCommand testPlugins act plugin cmd arg res = do
+testCommand :: (ToJSON a, Typeable b, ToJSON b, Show b, Eq b) => IdePlugins -> IdeGhcM (IdeResult b) -> CommandId -> a -> IdeResult b -> IO ()
+testCommand testPlugins act cmdId arg res = do
   (newApiRes, oldApiRes) <- runIGM testPlugins $ do
     new <- act
-    old <- makeRequest plugin cmd arg
+    old <- makeRequest cmdId arg
     return (new, old)
   newApiRes `shouldBe` res
   fmap fromDynJSON oldApiRes `shouldBe` fmap Just res
 
-runSingleReq :: ToJSON a => IdePlugins -> PluginId -> CommandName -> a -> IO (IdeResult DynamicJSON)
-runSingleReq testPlugins plugin com arg = runIGM testPlugins (makeRequest plugin com arg)
+runSingleReq :: ToJSON a => IdePlugins -> CommandId -> a -> IO (IdeResult DynamicJSON)
+runSingleReq testPlugins cmdId arg = runIGM testPlugins (makeRequest cmdId arg)
 
-makeRequest :: ToJSON a => PluginId -> CommandName -> a -> IdeGhcM (IdeResult DynamicJSON)
-makeRequest plugin com arg = runPluginCommand plugin com (toJSON arg)
+makeRequest :: ToJSON a => CommandId -> a -> IdeGhcM (IdeResult DynamicJSON)
+makeRequest cmdId arg = runPluginCommand cmdId (toJSON arg)
 
 runIGM :: IdePlugins -> IdeGhcM a -> IO a
-runIGM testPlugins = runIdeGhcM testOptions def (IdeState emptyModuleCache Map.empty testPlugins Map.empty Nothing)
+runIGM testPlugins = runIdeGhcM testOptions def (IdeState emptyModuleCache Map.empty testPlugins Map.empty Nothing Nothing)
 
 withFileLogging :: FilePath -> IO a -> IO a
 withFileLogging logFile f = do


### PR DESCRIPTION
- Code actions should now be created by `mkLSPCommand`, which will take care of wrapping the command IDs
- `PluginName` is now `PluginId`, and is used to build the `IdePlugins` map (Should we still keep the name for human readability/the JSON transport?)
- `CommandName` is now `CommandId`, which contains the `PluginId` inside it. The plan is that these can now be declared at the top level and referenced from other places. The same goes for `PluginCommands`