### PR TITLE
diagnostic providers

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -38,6 +38,7 @@ import           Haskell.Ide.Engine.Plugin.GhcMod
 import           Haskell.Ide.Engine.Plugin.HaRe
 import           Haskell.Ide.Engine.Plugin.Hoogle
 import           Haskell.Ide.Engine.Plugin.HsImport
+import           Haskell.Ide.Engine.Plugin.Liquid
 import           Haskell.Ide.Engine.Plugin.Package
 
 -- ---------------------------------------------------------------------
@@ -46,14 +47,15 @@ import           Haskell.Ide.Engine.Plugin.Package
 plugins :: IdePlugins
 plugins = pluginDescToIdePlugins
   [("applyrefact", applyRefactDescriptor)
+  ,("base"       , baseDescriptor)
   ,("brittany"   , brittanyDescriptor)
   ,("build"      , buildPluginDescriptor)
   ,("eg2"        , example2Descriptor)
   ,("ghcmod"     , ghcmodDescriptor)
   ,("hare"       , hareDescriptor)
-  ,("base"       , baseDescriptor)
   ,("hoogle"     , hoogleDescriptor)
   ,("hsimport"   , hsimportDescriptor)
+  ,("liquid"     , liquidDescriptor)
   ,("package"    , packageDescriptor)
   ]
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -249,6 +249,7 @@ test-suite func-test
                      , CodeActionsSpec
                      , DeferredSpec
                      , DefinitionSpec
+                     , DiagnosticsSpec
                      , FormatSpec
                      , HighlightSpec
                      , HoverSpec

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -36,6 +36,7 @@ library
                        Haskell.Ide.Engine.Plugin.HieExtras
                        Haskell.Ide.Engine.Plugin.Hoogle
                        Haskell.Ide.Engine.Plugin.HsImport
+                       Haskell.Ide.Engine.Plugin.Liquid
                        Haskell.Ide.Engine.Plugin.Package
                        Haskell.Ide.Engine.Transport.JsonStdio
                        Haskell.Ide.Engine.Transport.LspStdio

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -110,8 +110,9 @@ type CodeActionProvider =  VersionedTextDocumentIdentifier
                         -> CodeActionContext
                         -> IdeM (IdeResponse [CodeAction])
 
--- type DiagnosticProviderFunc = Uri -> IdeM (IdeResponse (Map.Map Uri (S.Set Diagnostic)))
-type DiagnosticProviderFunc = Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+-- type DiagnosticProviderFunc = DiagnosticTrigger -> Uri -> IdeM (IdeResponse (Map.Map Uri (S.Set Diagnostic)))
+type DiagnosticProviderFunc
+  = DiagnosticTrigger -> Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
 
 data DiagnosticProvider = DiagnosticProvider
      { dpTrigger :: S.Set DiagnosticTrigger -- AZ:should this be a NonEmptyList?

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -60,6 +60,7 @@ import           Data.Aeson
 import           Data.Dynamic (Dynamic)
 import           Data.IORef
 import qualified Data.Map as Map
+import qualified Data.Set as S
 import qualified Data.Text as T
 import           Data.Typeable (TypeRep, Typeable)
 
@@ -106,11 +107,15 @@ type CodeActionProvider =  VersionedTextDocumentIdentifier
                         -> CodeActionContext
                         -> IdeM (IdeResponse [CodeAction])
 
+type DiagnosticProvider = VersionedTextDocumentIdentifier
+                        -> IdeM (IdeResponse (Map.Map Uri (S.Set Diagnostic)))
+
 data PluginDescriptor =
-  PluginDescriptor { pluginName :: T.Text
-                   , pluginDesc :: T.Text
+  PluginDescriptor { pluginName     :: T.Text
+                   , pluginDesc     :: T.Text
                    , pluginCommands :: [PluginCommand]
                    , pluginCodeActionProvider :: CodeActionProvider
+                   , pluginDiagnosticProvider :: Maybe DiagnosticProvider
                    } deriving (Generic)
 
 instance Show PluginCommand where
@@ -119,13 +124,15 @@ instance Show PluginCommand where
 noCodeActions :: CodeActionProvider
 noCodeActions _ _ _ _ = return $ IdeResponseOk []
 
--- | a Description of the available commands and code action providers stored in IdeGhcM
+-- | a Description of the available commands stored in IdeGhcM
 newtype IdePlugins = IdePlugins
-  { ipMap :: Map.Map PluginId ([PluginCommand], CodeActionProvider)
+  { ipMap :: Map.Map PluginId PluginDescriptor
   } deriving (Generic)
 
+-- TODO:AZ this is a defective instance, do we actually need it?
+-- Perhaps rather make a separate type explicitly for this purpose.
 instance ToJSON IdePlugins where
-  toJSON (IdePlugins m) = toJSON $ fmap (\x -> (commandName x, commandDesc x)) <$> fmap fst m
+  toJSON (IdePlugins m) = toJSON $ fmap (\x -> (commandName x, commandDesc x)) <$> fmap pluginCommands m
 
 -- ---------------------------------------------------------------------
 

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -20,6 +20,9 @@ module Haskell.Ide.Engine.PluginsIdeMonads
   , PluginCommand(..)
   , CodeActionProvider
   , noCodeActions
+  , DiagnosticProvider(..)
+  , DiagnosticProviderFunc
+  , DiagnosticTrigger(..)
   , IdePlugins(..)
   -- * The IDE monad
   , IdeGhcM
@@ -107,8 +110,18 @@ type CodeActionProvider =  VersionedTextDocumentIdentifier
                         -> CodeActionContext
                         -> IdeM (IdeResponse [CodeAction])
 
-type DiagnosticProvider = VersionedTextDocumentIdentifier
-                        -> IdeM (IdeResponse (Map.Map Uri (S.Set Diagnostic)))
+-- type DiagnosticProviderFunc = Uri -> IdeM (IdeResponse (Map.Map Uri (S.Set Diagnostic)))
+type DiagnosticProviderFunc = Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+
+data DiagnosticProvider = DiagnosticProvider
+     { dpTrigger :: S.Set DiagnosticTrigger -- AZ:should this be a NonEmptyList?
+     , dpFunc    :: DiagnosticProviderFunc
+     }
+
+data DiagnosticTrigger = DiagnosticOnOpen
+                       | DiagnosticOnChange
+                       | DiagnosticOnSave
+                       deriving (Show,Ord,Eq)
 
 data PluginDescriptor =
   PluginDescriptor { pluginName     :: T.Text

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -41,7 +41,7 @@ handleCodeActionReq tn req = do
   let getProviders :: IdeM (IdeResponse [CodeActionProvider])
       getProviders = do
         IdePlugins m <- lift getPlugins
-        return $ IdeResponseOk $ map snd $ toList m
+        return $ IdeResponseOk $ map pluginCodeActionProvider $ toList m
 
       providersCb :: [CodeActionProvider] -> R ()
       providersCb providers =

--- a/src/Haskell/Ide/Engine/LSP/Config.hs
+++ b/src/Haskell/Ide/Engine/LSP/Config.hs
@@ -23,8 +23,8 @@ instance FromJSON Config where
   parseJSON = withObject "Config" $ \v -> do
     s <- v .: "languageServerHaskell"
     flip (withObject "Config.settings") s $ \o -> Config
-      <$> o .:? "hlintOn" .!= True
-      <*> o .: "maxNumberOfProblems"
+      <$> o .:? "hlintOn"             .!= True
+      <*> o .:? "maxNumberOfProblems" .!= 100
 
 -- 2017-10-09 23:22:00.710515298 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"languageServerHaskell":{"maxNumberOfProblems":100,"hlintOn":true}}}}
 -- 2017-10-09 23:22:00.710667381 [ThreadId 15] - reactor:got didChangeConfiguration notification:

--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -7,15 +7,16 @@ import           Data.Semigroup             hiding (option)
 import           Options.Applicative.Simple
 
 data GlobalOpts = GlobalOpts
-  { optDebugOn     :: Bool
-  , optLogFile     :: Maybe String
-  , optLsp         :: Bool
-  , optJson        :: Bool
-  , projectRoot    :: Maybe String
-  , optGhcModVomit :: Bool
-  , optEkg         :: Bool
-  , optEkgPort     :: Int
-  , optCaptureFile :: Maybe FilePath
+  { optDebugOn       :: Bool
+  , optLogFile       :: Maybe String
+  , optLsp           :: Bool
+  , optJson          :: Bool
+  , projectRoot      :: Maybe String
+  , optGhcModVomit   :: Bool
+  , optEkg           :: Bool
+  , optEkgPort       :: Int
+  , optCaptureFile   :: Maybe FilePath
+  , optExamplePlugin :: Bool
   } deriving (Show)
 
 globalOptsParser :: Parser GlobalOpts
@@ -61,3 +62,6 @@ globalOptsParser = GlobalOpts
       <> metavar "CAPTUREFILE"
       <> help "File to capture the session to"
        ))
+  <*> switch
+       ( long "example"
+       <> help "Enable Example2 plugin. Useful for developers only")

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -98,6 +98,7 @@ lintCmd :: CommandFunc Uri PublishDiagnosticsParams
 lintCmd = CmdSync $ \uri -> do
   lintCmd' uri
 
+-- AZ:TODO: Why is this in IdeGhcM?
 lintCmd' :: Uri -> IdeGhcM (IdeResult PublishDiagnosticsParams)
 lintCmd' uri = pluginGetFile "lintCmd: " uri $ \fp -> do
       res <- GM.withMappedFile fp $ \file' -> liftIO $ runExceptT $ runLintCmd file' []

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -43,6 +43,7 @@ applyRefactDescriptor = PluginDescriptor
       , PluginCommand "lint" "Run hlint on the file to generate hints" lintCmd
       ]
   , pluginCodeActionProvider = codeActionProvider
+  , pluginDiagnosticProvider = Nothing
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Base.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Base.hs
@@ -42,6 +42,7 @@ baseDescriptor = PluginDescriptor
       , PluginCommand "commandDetail" "list parameters required for a given command" commandDetailCmd
       ]
   , pluginCodeActionProvider = noCodeActions
+  , pluginDiagnosticProvider = Nothing
   }
 
 -- ---------------------------------------------------------------------
@@ -62,7 +63,7 @@ commandsCmd = CmdSync $ \p -> do
       , ideMessage = "Can't find plugin:" <> p
       , ideInfo = toJSON p
       }
-    Just pl -> return $ IdeResultOk $ map commandName $ fst pl
+    Just pl -> return $ IdeResultOk $ map commandName $ pluginCommands pl
 
 commandDetailCmd :: CommandFunc (T.Text, T.Text) T.Text
 commandDetailCmd = CmdSync $ \(p,command) -> do
@@ -73,7 +74,7 @@ commandDetailCmd = CmdSync $ \(p,command) -> do
       , ideMessage = "Can't find plugin:" <> p
       , ideInfo = toJSON p
       }
-    Just pl -> case find (\cmd -> command == commandName cmd) (fst pl) of
+    Just pl -> case find (\cmd -> command == commandName cmd) (pluginCommands pl) of
       Nothing -> return $ IdeResultFail $ IdeError
         { ideCode = UnknownCommand
         , ideMessage = "Can't find command:" <> command

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -33,6 +33,7 @@ brittanyDescriptor = PluginDescriptor
                                      cmd
                      ]
   , pluginCodeActionProvider = noCodeActions
+  , pluginDiagnosticProvider = Nothing
   }
  where
   cmd :: CommandFunc FormatParams [J.TextEdit]

--- a/src/Haskell/Ide/Engine/Plugin/Build.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Build.hs
@@ -151,6 +151,7 @@ buildPluginDescriptor = PluginDescriptor
                       buildTarget
       ]
   , pluginCodeActionProvider = noCodeActions
+  , pluginDiagnosticProvider = Nothing
   }
 
 data OperationMode = StackMode | CabalMode

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -6,8 +6,10 @@ import           Control.Monad.IO.Class
 #if __GLASGOW_HASKELL__ < 804
 import           Data.Monoid
 #endif
+import qualified Data.Map                      as Map
+import qualified Data.Set                      as S
 import qualified Data.Text                     as T
-import           Haskell.Ide.Engine.MonadTypes
+import           Haskell.Ide.Engine.MonadTypes hiding (_range)
 
 -- ---------------------------------------------------------------------
 
@@ -21,7 +23,7 @@ example2Descriptor = PluginDescriptor
       , PluginCommand "sayHelloTo ""say hello to the passed in param" sayHelloToCmd
       ]
   , pluginCodeActionProvider = noCodeActions
-  , pluginDiagnosticProvider = Nothing
+  , pluginDiagnosticProvider = Just (DiagnosticProvider (S.singleton DiagnosticOnSave) diagnosticProvider)
   }
 
 -- ---------------------------------------------------------------------
@@ -41,3 +43,17 @@ sayHello = "hello from ExamplePlugin2"
 
 sayHelloTo :: T.Text -> IO T.Text
 sayHelloTo n = return $ "hello " <> n <> " from ExamplePlugin2"
+
+-- ---------------------------------------------------------------------
+
+diagnosticProvider :: Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+diagnosticProvider uri = do
+  let diag = Diagnostic
+              { _range = Range (Position 0 0) (Position 1 0)
+              , _severity = Nothing
+              , _code = Nothing
+              , _source = Just "eg2"
+              , _message = "Example plugin diagnostic"
+              , _relatedInformation = Nothing
+              }
+  return $ IdeResultOk $ Map.fromList [(uri,S.singleton diag)]

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -46,14 +46,14 @@ sayHelloTo n = return $ "hello " <> n <> " from ExamplePlugin2"
 
 -- ---------------------------------------------------------------------
 
-diagnosticProvider :: Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
-diagnosticProvider uri = do
+diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+diagnosticProvider trigger uri = do
   let diag = Diagnostic
               { _range = Range (Position 0 0) (Position 1 0)
               , _severity = Nothing
               , _code = Nothing
               , _source = Just "eg2"
-              , _message = "Example plugin diagnostic"
+              , _message = "Example plugin diagnostic, triggered by" <> T.pack (show trigger)
               , _relatedInformation = Nothing
               }
   return $ IdeResultOk $ Map.fromList [(uri,S.singleton diag)]

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -70,6 +70,7 @@ ghcmodDescriptor = PluginDescriptor
       , PluginCommand "casesplit" "Generate a pattern match for a binding under (LINE,COL)" splitCaseCmd
       ]
   , pluginCodeActionProvider = codeActionProvider
+  , pluginDiagnosticProvider = Nothing
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -61,6 +61,7 @@ hareDescriptor = PluginDescriptor
           genApplicativeCommand
       ]
   , pluginCodeActionProvider = noCodeActions
+  , pluginDiagnosticProvider = Nothing
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -33,6 +33,7 @@ hoogleDescriptor = PluginDescriptor
       , PluginCommand "lookup" "Search the hoogle database with a string" lookupCmd
       ]
   , pluginCodeActionProvider = noCodeActions
+  , pluginDiagnosticProvider = Nothing
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -29,6 +29,7 @@ hsimportDescriptor = PluginDescriptor
   , pluginDesc = "A tool for extending the import list of a Haskell source file."
   , pluginCommands = [PluginCommand "import" "Import a module" importCmd]
   , pluginCodeActionProvider = codeActionProvider
+  , pluginDiagnosticProvider = Nothing
   }
 
 data ImportParams = ImportParams

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
-module Haskell.Ide.Engine.Plugin.Example2 where
+module Haskell.Ide.Engine.Plugin.Liquid where
 
 import           Control.Monad.IO.Class
 #if __GLASGOW_HASKELL__ < 804
@@ -11,11 +11,11 @@ import           Haskell.Ide.Engine.MonadTypes
 
 -- ---------------------------------------------------------------------
 
-example2Descriptor :: PluginDescriptor
-example2Descriptor = PluginDescriptor
+liquidDescriptor :: PluginDescriptor
+liquidDescriptor = PluginDescriptor
   {
-    pluginName = "Hello World"
-  , pluginDesc = "An example of writing an HIE plugin"
+    pluginName = "Liquid Haskell"
+  , pluginDesc = "Integration with Liquid Haskell"
   , pluginCommands =
       [ PluginCommand "sayHello" "say hello" sayHelloCmd
       , PluginCommand "sayHelloTo ""say hello to the passed in param" sayHelloToCmd

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -55,6 +55,7 @@ packageDescriptor = PluginDescriptor
   , pluginDesc     = "Tools for editing .cabal and package.yaml files."
   , pluginCommands = [PluginCommand "add" "Add a packge" addCmd]
   , pluginCodeActionProvider = codeActionProvider
+  , pluginDiagnosticProvider = Nothing
   }
 
 data AddParams = AddParams
@@ -76,7 +77,7 @@ addCmd = CmdSync $ \(AddParams rootDir modulePath pkg) -> do
     CabalPackage relFp -> do
       absFp <- liftIO $ canonicalizePath relFp
       let relModulePath = makeRelative (takeDirectory absFp) modulePath
-      
+
       liftToGhc $ editCabalPackage absFp relModulePath (T.unpack pkg) fileMap
     HpackPackage relFp -> do
       absFp <- liftIO $ canonicalizePath relFp
@@ -233,7 +234,7 @@ codeActionProvider docId mRootDir _ context = do
       pkgs = mapMaybe getAddablePackages diags
 
   res <- mapM (bimapM return Hoogle.searchPackages) pkgs
-  let actions = mapMaybe (uncurry mkAddPackageAction) (concatPkgs res)  
+  let actions = mapMaybe (uncurry mkAddPackageAction) (concatPkgs res)
 
   return $ IdeResponseOk actions
 
@@ -248,7 +249,7 @@ codeActionProvider docId mRootDir _ context = do
            cmdParams = J.List [toJSON (AddParams rootDir docFp pkgName)]
        in Just (J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd))
      _ -> Nothing
-    
+
     getAddablePackages :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
     getAddablePackages diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractModuleName msg
     getAddablePackages _ = Nothing
@@ -259,4 +260,3 @@ extractModuleName msg
   | otherwise = Nothing
   where line = T.replace "\n" "" msg
         nameAndQuotes = T.dropWhileEnd (/= '’') $ T.dropWhile (/= '‘') line
-

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -131,7 +131,7 @@ run dispatcherProc cin _origDir plugins captureFp = flip E.catches handlers $ do
         _ <- forkIO $ race_ (dispatcherProc dEnv errorHandler callbackHandler caps) reactorFunc
         return Nothing
 
-      commandIds = Map.foldlWithKey cmdFolder [] (fst <$> ipMap plugins)
+      commandIds = Map.foldlWithKey cmdFolder [] (pluginCommands <$> ipMap plugins)
       cmdFolder :: [T.Text] -> T.Text -> [PluginCommand] -> [T.Text]
       cmdFolder acc plugin cmds = acc ++ map prefix cmdIds
         where cmdIds = map (\cmd -> plugin <> ":" <> commandName cmd) cmds

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -825,7 +825,7 @@ requestDiagnostics trigger tn file mVer = do
             Nothing -> Nothing
             Just v -> Just (file,v)
         let reql = GReq tn (Just file) fv Nothing callbackl
-                     $ ds file
+                     $ ds trigger file
             callbackl pd = do
               let diags = Map.toList $ S.toList <$> pd
               case diags of

--- a/src/Haskell/Ide/Engine/Types.hs
+++ b/src/Haskell/Ide/Engine/Types.hs
@@ -9,7 +9,7 @@ import qualified Language.Haskell.LSP.Types as J
 
 -- ---------------------------------------------------------------------
 
--- | A callback from a request. 
+-- | A callback from a request.
 type RequestCallback m a = a -> m ()
 
 -- | Used to track a request through the system, for logging

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module DiagnosticsSpec where
+
+-- import Control.Applicative.Combinators
+import Control.Lens hiding (List)
+-- import Control.Monad
+import Control.Monad.IO.Class
+import Data.Default
+-- import Data.Maybe
+import qualified Data.Text as T
+import qualified Language.Haskell.LSP.Test as Test
+import Language.Haskell.LSP.Test hiding (message)
+import Language.Haskell.LSP.Types as LSP hiding (contents, error )
+-- import qualified Language.Haskell.LSP.Types as LSP
+import qualified Language.Haskell.LSP.Types.Capabilities as C
+import Test.Hspec
+import TestUtils
+
+-- ---------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "diagnostics providers" $ do
+  describe "diagnostics triggers" $ do
+    it "runs diagnostics on save" $
+      runSessionWithConfig codeActionSupportConfig hieCommand "test/testdata" $ do
+        doc <- openDoc "ApplyRefact2.hs" "haskell"
+
+        diags@(reduceDiag:_) <- waitForDiagnostics
+
+        -- liftIO $ show diags `shouldBe` ""
+
+        liftIO $ do
+          length diags `shouldBe` 2
+          reduceDiag ^. range `shouldBe` Range (Position 1 0) (Position 1 12)
+          reduceDiag ^. severity `shouldBe` Just DsInfo
+          reduceDiag ^. code `shouldBe` Just "Eta reduce"
+          reduceDiag ^. source `shouldBe` Just "hlint"
+
+        -- docItem <- getDocItem file languageId
+        sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
+        diags2 <- waitForDiagnostics
+        liftIO $ length diags2 `shouldBe` 2
+        -- liftIO $ show diags2 `shouldBe` ""
+        diags3@(d:_) <- waitForDiagnostics
+        -- liftIO $ show diags3 `shouldBe` ""
+        liftIO $ do
+          length diags3 `shouldBe` 3
+          d ^. range `shouldBe` Range (Position 0 0) (Position 1 0)
+          d ^. severity `shouldBe` Nothing
+          d ^. code `shouldBe` Nothing
+          d ^. source `shouldBe` Just "eg2"
+          d ^. message `shouldBe` (T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave")
+
+
+-- ---------------------------------------------------------------------
+
+codeActionSupportConfig :: SessionConfig
+codeActionSupportConfig = def { Test.capabilities = codeActionSupportCaps }
+
+codeActionSupportCaps :: C.ClientCapabilities
+codeActionSupportCaps = def { C._textDocument = Just textDocumentCaps }
+  where
+    textDocumentCaps = def { C._codeAction = Just codeActionCaps }
+    codeActionCaps = C.CodeActionClientCapabilities (Just True) (Just literalSupport)
+    literalSupport = C.CodeActionLiteralSupport def

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -2,17 +2,13 @@
 
 module DiagnosticsSpec where
 
--- import Control.Applicative.Combinators
 import Control.Lens hiding (List)
--- import Control.Monad
 import Control.Monad.IO.Class
 import Data.Default
--- import Data.Maybe
 import qualified Data.Text as T
 import qualified Language.Haskell.LSP.Test as Test
 import Language.Haskell.LSP.Test hiding (message)
 import Language.Haskell.LSP.Types as LSP hiding (contents, error )
--- import qualified Language.Haskell.LSP.Types as LSP
 import qualified Language.Haskell.LSP.Types.Capabilities as C
 import Test.Hspec
 import TestUtils
@@ -23,7 +19,7 @@ spec :: Spec
 spec = describe "diagnostics providers" $ do
   describe "diagnostics triggers" $ do
     it "runs diagnostics on save" $
-      runSessionWithConfig codeActionSupportConfig hieCommand "test/testdata" $ do
+      runSessionWithConfig codeActionSupportConfig hieCommandExamplePlugin "test/testdata" $ do
         doc <- openDoc "ApplyRefact2.hs" "haskell"
 
         diags@(reduceDiag:_) <- waitForDiagnostics

--- a/test/unit/ExtensibleStateSpec.hs
+++ b/test/unit/ExtensibleStateSpec.hs
@@ -43,6 +43,7 @@ testDescriptor = PluginDescriptor
       , PluginCommand "cmd2" "description" cmd2
       ]
   , pluginCodeActionProvider = noCodeActions
+  , pluginDiagnosticProvider = Nothing
   }
 
 -- ---------------------------------------------------------------------

--- a/test/utils/TestUtils.hs
+++ b/test/utils/TestUtils.hs
@@ -11,6 +11,7 @@ module TestUtils
   , runIGM
   , hieCommand
   , hieCommandVomit
+  , hieCommandExamplePlugin
   ) where
 
 import           Control.Exception
@@ -134,6 +135,9 @@ hieCommand = "stack exec --no-stack-exe --no-ghc-package-path --stack-yaml=" ++ 
 
 hieCommandVomit :: String
 hieCommandVomit = hieCommand ++ " --vomit"
+
+hieCommandExamplePlugin :: String
+hieCommandExamplePlugin = hieCommand ++ " --example"
 
 -- |Choose a resolver based on the current compiler, otherwise HaRe/ghc-mod will
 -- not be able to load the files


### PR DESCRIPTION
Adds the ability for a given plugin to generate diagnostics.

These can be triggered from any set of `DidOpen`, `DidChange` or `DidSave` notifications.

Still need to add a config option to enable the example plugin, else normal users will get spammed with junk.
