### PR TITLE
Store binary artifacts on CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,10 @@ defaults: &defaults
 
     - run:
         name: Build
-        command: stack -j 2 --stack-yaml=${STACK_FILE} build
+        command: stack -j 2 --stack-yaml=${STACK_FILE} install
 
     - store_artifacts:
-        path: ~/.stack/bin
+        path: ~/.local/bin
         destination: bin
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,10 @@ defaults: &defaults
     - store_artifacts:
         path: test-logs
 
+    - store_artifacts:
+        path: ~/.stack/bin
+        destination: bin
+
     - save_cache:
         key: stack-cache-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,10 @@ defaults: &defaults
         name: Build
         command: stack -j 2 --stack-yaml=${STACK_FILE} build
 
+    - store_artifacts:
+        path: ~/.stack/bin
+        destination: bin
+
     - run:
         name: Generate Hoogle database
         command: stack --stack-yaml=${STACK_FILE} exec hoogle generate
@@ -62,10 +66,6 @@ defaults: &defaults
 
     - store_artifacts:
         path: test-logs
-
-    - store_artifacts:
-        path: ~/.stack/bin
-        destination: bin
 
     - save_cache:
         key: stack-cache-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}


### PR DESCRIPTION
Useful for quickly grabbing a binary for testing lsp-test with, **not** for releasing/distributing