### PR TITLE
Fix completion when two imports have the same qualifier

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -185,7 +185,7 @@ instance ModuleCache CachedCompletions where
         getModCompls :: GhcMonad m => HscEnv -> m ([CompItem], QualCompls)
         getModCompls hscEnv = do
           (unquals, qualKVs) <- foldM (orgUnqualQual hscEnv) ([], []) allImportsInfo
-          return (unquals, Map.fromList qualKVs)
+          return (unquals, Map.fromListWith (++) qualKVs)
 
         orgUnqualQual hscEnv (prevUnquals, prevQualKVs) (isQual, modQual, modName, hasHiddsMembers) =
           let


### PR DESCRIPTION
Previously only the first import would have shown up when
entering the qualified completion, e.g. if you had

```haskell
import qualified A as Foo
import qualified B as Foo

Foo.bar
```

Only A's suggestions would show up.