### PR TITLE
Only generate artifacts on tagged commit, publish to github

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,14 @@ cache:
 build_script:
 - cmd: stack --stack-yaml=stack-%GHCVER%.yaml install
 test: off
-artifacts:
-- path: .stack-work\install\**\bin\hie.exe
-- path: .stack-work\install\**\bin\hie-wrapper.exe
+deploy:
+  description: ''
+  provider: GitHub
+  auth_token:
+    secure: ae8337b11de3463a15224f6ff05f2a6081ff3098
+  artifacts:
+    - .stack-work\install\**\bin\hie.exe
+    - .stack-work\install\**\bin\hie-wrapper.exe
+  on:
+    branch: master
+    appveyor_repo_tag: true


### PR DESCRIPTION
Try to workaround around AppVeyor running out of artifact space, there doesn't seem to be an easy way to clear up old ones: https://help.appveyor.com/discussions/problems/10253-maximum-allowed-artifact-storage-size-of-1000-mb-will-be-exceeded