### PR TITLE
Revert the upgrade of cabal-helper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install zlib
+          command: apt-get update && apt-get install -y zlib1g-dev
+      - run:
           name: Sync submodules
           command: git submodule sync --recursive
       - run:
@@ -129,7 +132,7 @@ jobs:
           command: git submodule update --recursive --init
       - restore-cache:
           keys:
-            - cabal-02
+            - cabal-01
       - run:
           name: Update
           command: cabal new-update
@@ -140,7 +143,7 @@ jobs:
           name: Build
           command: cabal new-build -j2
       - save_cache:
-          key: cabal-02
+          key: cabal-01
           paths:
             - ~/.cabal
 

--- a/cabal.project
+++ b/cabal.project
@@ -3,6 +3,7 @@ packages:
          ./hie-plugin-api/
 
          ./submodules/HaRe
+         ./submodules/cabal-helper/
          ./submodules/ghc-mod/
          ./submodules/ghc-mod/core/
          ./submodules/haskell-lsp/

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -53,7 +53,7 @@ library
                      , brittany
                      , bytestring
                      , Cabal
-                     , cabal-helper >= 0.8.1.0
+                     , cabal-helper >= 0.8.0.4
                      , containers
                      , data-default
                      , directory

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -8,6 +8,10 @@ packages:
   extra-dep: true
 
 - location:
+    ./submodules/cabal-helper
+  extra-dep: true
+
+- location:
     ./submodules/ghc-mod
   extra-dep: true
   subdirs:
@@ -24,7 +28,6 @@ packages:
 extra-deps:
 - brittany-0.11.0.0
 - butcher-1.3.1.1
-- cabal-helper-0.8.1.0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
 - czipwith-1.0.1.0
@@ -34,10 +37,10 @@ extra-deps:
 - lsp-test-0.2.1.0
 - hlint-2.0.11
 # - hlint-2.1.8
-- hsimport-0.8.6
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 - yaml-0.8.32
+- hsimport-0.8.6
 
 flags:
   haskell-ide-engine:

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,10 +1,14 @@
-resolver: lts-11.18 # lts-11.x is the last one for GHC 8.2.2
+resolver: lts-11.22 # lts-11.x is the last one for GHC 8.2.2
 packages:
 - .
 - hie-plugin-api
 
 - location:
     ./submodules/HaRe
+  extra-dep: true
+
+- location:
+    ./submodules/cabal-helper
   extra-dep: true
 
 - location:
@@ -24,9 +28,7 @@ packages:
 extra-deps:
 - brittany-0.11.0.0
 - butcher-1.3.1.1
-- cabal-helper-0.8.1.0
 - cabal-plan-0.3.0.0
-- conduit-parse-0.2.1.0
 - constrained-dynamic-0.1.0.0
 - czipwith-1.0.1.0
 - haddock-api-2.18.1
@@ -35,6 +37,7 @@ extra-deps:
 - lsp-test-0.2.1.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
+- conduit-parse-0.2.1.0
 
 flags:
   haskell-ide-engine:

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -8,6 +8,10 @@ packages:
   extra-dep: true
 
 - location:
+    ./submodules/cabal-helper
+  extra-dep: true
+
+- location:
     ./submodules/ghc-mod
   extra-dep: true
   subdirs:
@@ -24,7 +28,6 @@ packages:
 extra-deps:
 - base-compat-0.9.3
 - brittany-0.11.0.0
-- cabal-helper-0.8.1.0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.20.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -8,6 +8,10 @@ packages:
   extra-dep: true
 
 - location:
+    ./submodules/cabal-helper
+  extra-dep: true
+
+- location:
     ./submodules/ghc-mod
   extra-dep: true
   subdirs:
@@ -22,8 +26,8 @@ packages:
     - haskell-lsp-types
 
 extra-deps:
+- apply-refact-0.5.0.0
 - base-compat-0.9.3
-- cabal-helper-0.8.1.0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.20.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,6 +8,10 @@ packages:
   extra-dep: true
 
 - location:
+    ./submodules/cabal-helper
+  extra-dep: true
+
+- location:
     ./submodules/ghc-mod
   extra-dep: true
   subdirs:
@@ -26,13 +30,13 @@ extra-deps:
 - apply-refact-0.5.0.0
 - base-compat-0.9.3
 - brittany-0.11.0.0
-- cabal-helper-0.8.1.0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
 - ekg-0.4.0.15
 - ekg-json-0.1.0.6
 - ghc-exactprint-0.5.6.1
 - haddock-api-2.20.0
+- haddock-library-1.6.0
 - hsimport-0.8.6
 - lsp-test-0.2.1.0
 - syz-0.2.0.0


### PR DESCRIPTION
Could not find other way but to refer the commit that introduced this change

This reverts commit 4a54b7528fe3f046ac74090070c9a1c3ea033525.

Fixes #784 