### PR TITLE
Specify cabal-helper revision

### DIFF
--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -24,7 +24,7 @@ packages:
 extra-deps:
 - brittany-0.11.0.0
 - butcher-1.3.1.1
-- cabal-helper-0.8.1.0
+- cabal-helper-0.8.1.0@rev:0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
 - czipwith-1.0.1.0

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -24,7 +24,7 @@ packages:
 extra-deps:
 - brittany-0.11.0.0
 - butcher-1.3.1.1
-- cabal-helper-0.8.1.0
+- cabal-helper-0.8.1.0@rev:0
 - cabal-plan-0.3.0.0
 - conduit-parse-0.2.1.0
 - constrained-dynamic-0.1.0.0

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -24,7 +24,7 @@ packages:
 extra-deps:
 - base-compat-0.9.3
 - brittany-0.11.0.0
-- cabal-helper-0.8.1.0
+- cabal-helper-0.8.1.0@rev:0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.20.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -23,7 +23,7 @@ packages:
 
 extra-deps:
 - base-compat-0.9.3
-- cabal-helper-0.8.1.0
+- cabal-helper-0.8.1.0@rev:0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.20.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,7 +26,7 @@ extra-deps:
 - apply-refact-0.5.0.0
 - base-compat-0.9.3
 - brittany-0.11.0.0
-- cabal-helper-0.8.1.0
+- cabal-helper-0.8.1.0@rev:0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
 - ekg-0.4.0.15


### PR DESCRIPTION
Recently a new revision of cabal-helper-0.8.1.0 was uploaded to Hackage, but due to [this issue](https://github.com/haskell/haskell-ide-engine/issues/784#issuecomment-416075778) it causes hie to fail when building via stack. This specifies the first revision to circumvent this until it is fixed
Fixes #784, superseeds #788 