### PR TITLE
Spring day (in the south). Update resolvers.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ defaults: &defaults
 
     - restore_cache:
         keys:
-          - stack-cache-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
-          - stack-cache-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
-          - stack-cache-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
-          - stack-work-dirs-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+          - stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
+          - stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+          - stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+          - stack-work-dirs-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
 
     - run:
         name: Stack setup
@@ -52,7 +52,7 @@ defaults: &defaults
         command: stack --stack-yaml=${STACK_FILE} exec hoogle generate
 
     - save_cache:
-        key: stack-cache-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+        key: stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
         paths:
           - ~/.stack
           - ~/.cache
@@ -66,19 +66,19 @@ defaults: &defaults
         path: test-logs
 
     - save_cache:
-        key: stack-cache-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+        key: stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
         paths:
           - ~/.stack
           - ~/.cache
 
     - save_cache:
-        key: stack-cache-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
+        key: stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
         paths:
           - ~/.stack
           - ~/.cache
 
     - save_cache:
-        key: stack-work-dirs-05-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+        key: stack-work-dirs-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
         paths:
           - ~/build/.stack-work
           - ~/build/hie-plugin-api/.stack-work

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.2
+resolver: lts-12.8
 packages:
 - .
 - hie-plugin-api

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-07-26 # GHC 8.4.3
+resolver: nightly-2018-09-01 # GHC 8.4.3
 packages:
 - .
 - hie-plugin-api
@@ -10,8 +10,9 @@ extra-deps:
 - ./submodules/haskell-lsp
 - ./submodules/haskell-lsp/haskell-lsp-types
 - aeson-1.3.1.1
-- apply-refact-0.5.0.0
+# - apply-refact-0.5.0.0
 - base-compat-0.9.3
+- base-orphans-0.7
 - brittany-0.11.0.0
 - cabal-helper-0.8.1.0@rev:0
 - cabal-plan-0.3.0.0
@@ -21,7 +22,9 @@ extra-deps:
 - ghc-exactprint-0.5.6.1
 - haddock-api-2.20.0
 - hsimport-0.8.6
+- monad-memo-0.4.1
 - lsp-test-0.2.1.0
+- semigroupoids-5.2.2
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32


### PR DESCRIPTION
I had to blow away the precompiled caches in `~/.stack`, else
`haddock-library` fails to compile, with a dependency version mismatch.