### PR TITLE
Running tests for MacOS in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_install:
 
 install:
   - git submodule update --init
-  - travis_retry stack --no-terminal --install-ghc $ARGS build --test
+  - travis_retry stack --no-terminal --install-ghc $ARGS build
 
 script:
   - stack --no-terminal $ARGS install

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,13 +25,11 @@ stages:
   - compile
   - test
 
-env:
-  - GHC_VER="8.4.3" ARGS="--stack-yaml=stack-8.4.3.yaml"
-
 jobs:
    include:
      - stage: setup
-       script:
+       env: ARGS="--stack-yaml=stack-8.4.3.yaml"
+       script: &setup
          - mkdir -p $HOME/.stack
          - mkdir -p ~/.local/bin
          - |
@@ -42,19 +40,80 @@ jobs:
            fi
          - travis_retry stack --no-terminal --install-ghc $ARGS setup
 
+     - stage: setup
+       env: ARGS="--stack-yaml=stack-8.4.3.yaml"
+       script: *setup
+
+     - stage: setup
+       env: ARGS="--stack-yaml=stack-8.2.2.yaml"
+       script: *setup
+
+     - stage: setup
+       env: ARGS="--stack-yaml=stack-8.2.1.yaml"
+       script: *setup
+
      - stage: dependencies
-       script:
+       env: ARGS="--stack-yaml=stack-8.4.3.yaml"
+       script: &dependencies
          - travis_retry stack --no-terminal --install-ghc $ARGS test --only-dependencies --no-run-tests
 
+     - stage: dependencies
+       env: ARGS="--stack-yaml=stack-8.4.2.yaml"
+       script: *dependencies
+
+     - stage: dependencies
+       env: ARGS="--stack-yaml=stack-8.2.2.yaml"
+       script: *dependencies
+
+     - stage: dependencies
+       env: ARGS="--stack-yaml=stack-8.2.1.yaml"
+       script: *dependencies
+
      - stage: compile
-       script: stack --no-terminal $ARGS build --test --no-run-tests
+       env: ARGS="--stack-yaml=stack-8.4.3.yaml"
+       script: &compile
+
+     - stage: compile
+       env: ARGS="--stack-yaml=stack-8.4.2.yaml"
+       script: *compile
+
+     - stage: compile
+       env: ARGS="--stack-yaml=stack-8.2.2.yaml"
+       script: *compile
+
+     - stage: compile
+       env: ARGS="--stack-yaml=stack-8.2.1.yaml"
+       script: *compile
 
      - stage: test
-       script:
+       env: ARGS="--stack-yaml=stack-8.4.3.yaml"
+       script: &functest
          - stack --no-terminal $ARGS exec hoogle generate
          - stack --no-terminal $ARGS test haskell-ide-engine:test:func-test
      -
-       script:
+       env: ARGS="--stack-yaml=stack-8.4.3.yaml"
+       script: &test
          - stack --no-terminal $ARGS test haskell-ide-engine:test:dispatcher-test
          - stack --no-terminal $ARGS test haskell-ide-engine:test:unit-test
          - stack --no-terminal $ARGS test haskell-ide-engine:test:wrapper-test
+
+     - stage: test
+       env: ARGS="--stack-yaml=stack-8.4.2.yaml"
+       script: *functest
+     -
+       env: ARGS="--stack-yaml=stack-8.4.2.yaml"
+       script: *test
+
+     - stage: test
+       env: ARGS="--stack-yaml=stack-8.2.2.yaml"
+       script: *functest
+     -
+       env: ARGS="--stack-yaml=stack-8.2.2.yaml"
+       script: *test
+
+     - stage: test
+       env: ARGS="--stack-yaml=stack-8.2.1.yaml"
+       script: *functest
+     -
+       env: ARGS="--stack-yaml=stack-8.2.1.yaml"
+       script: *test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler: gcc
 cache:
   directories:
   - $HOME/.stack
+  - $TRAVIS_BUILD_DIR/.stack-work
   timeout: 300
 
 matrix:
@@ -51,11 +52,10 @@ before_install:
 
 install:
   - git submodule update --init
-  - travis_retry stack --no-terminal --install-ghc $ARGS build --only-dependencies
-  - stack --no-terminal $ARGS install
+  - travis_retry stack --no-terminal --install-ghc $ARGS build --only-dependencies --test
 
 script:
-  - stack --no-terminal $ARGS test
+  - stack --no-terminal $ARGS install --test
 
 after_success:
 - mkdir -p ./releases/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,66 @@
+# Build starts faster without `sudo`
+sudo: false
+
+language: c
+compiler: gcc
+
+cache:
+  directories:
+  - $HOME/.stack
+  timeout: 300
+
+matrix:
+  include:
+    - env: GHC_VER="8.2.1" ARGS="--stack-yaml=stack-8.2.1.yaml"
+      os: osx
+      addons:
+        artifacts: {paths: [./releases]}
+    - env: GHC_VER="8.2.2" ARGS="--stack-yaml=stack-8.2.2.yaml"
+      os: osx
+      addons:
+        artifacts: {paths: [./releases]}
+    - env: GHC_VER="8.4.2" ARGS="--stack-yaml=stack-8.4.2.yaml"
+      os: osx
+      addons:
+        artifacts: {paths: [./releases]}
+    - env: GHC_VER="8.4.3" ARGS="--stack-yaml=stack-8.4.3.yaml"
+      os: osx
+      addons:
+        artifacts: {paths: [./releases]}
+
+before_install:
+  # Download and unpack the stack executable
+  - mkdir -p ~/.local/bin
+  - |
+    if [[ "${TRAVIS_OS_NAME}" = "osx" ]]
+    then
+      travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
+        | tar xz --strip-components=1 -C ~/.local/bin --include   '*/stack'
+    else
+      travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
+        | tar xz --strip-components=1 -C ~/.local/bin --wildcards '*/stack'
+    fi
+
+install:
+  - git submodule update --init
+  - travis_retry stack --no-terminal --install-ghc $ARGS build --only-dependencies
+
+script:
+  - stack --no-terminal $ARGS install
+
+after_success:
+- mkdir -p ./releases/
+- cp "$(which hie)" "./releases/"
+- cp "$(which hie-wrapper)" "./releases/"
+
+before_deploy:
+- mv ./releases/hie "./releases/hie-${GHC_VER}-macos"
+
+deploy:
+  provider: releases
+  api_key:
+    secure: jhNwLD87iJZBA4yCd3bXUz4bcAxzPVTR7PjW9okQxXu5LBOYfTbUFsYCqnpEaItk1ot8WKwAxOt6tXkU/KkmDwhYCkii1Mt1r9mEKzDkjp68WhRlRm/3iCjlUcophXavUwcKZDtZHpii2bn+hne2Y8Eo8zbMIb1l5kd+mDH6WqP9AAMcgKSaHa7ZIkoc2S2TJ04nU8OeEW7Ts6lfOc6NAuxC9V28sewDUdWoAl8DIydsXvZWEAJ245Ir06zvg7KmdDuGmqHnO+cR2XjaRCs5sSDypexhECH+u8pgMe8Bziiy8aI1FHvRB8nEh/LvS+urGj1eoDH6DQiH+MerUFqFknn1wTw5fW9m3IsMpufVdlIMgQb1cqrr0osHyH9ckL/O7gtu7Fr67LXXPVq5TiUkIcLE6ut+DbCMs9LjePrHKW1JiEkqBBYB+MKkkKrPh3cUOjzuOkgnrpFgvFaBASSabqvVQvoDhCb+CxZQrSH1N1Qqj9zMuy6WFsmDmN/Pb940H3J9/isF/zkrPwrYbm02ZVV3882IEWuNGlr3NUW1Ik9lXPlPlen9BtJebaxhVa/RkRdyWIjk5Wlv9iGwuT/dtxqfJvD1EXodnxKAfc6QJISRwqpRBMIVIvRHRWOdY42AqHy/0NWG4J0gsTcBuBB4z5iwi9/zG7n60zcYU4N+9pg=
+  file: "./releases/*"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,4 @@ jobs:
      - stage: test
        script:
          - stack --no-terminal $ARGS exec hoogle generate
-         - stack --no-terminal $ARGS test haskell-ide-engine:test:func-test
-     -
-       script: stack --no-terminal $ARGS test haskell-ide-engine:test:unit-test
-     -
-       script: stack --no-terminal $ARGS test haskell-ide-engine:test:dispatcher-test
-     -
-       script: stack --no-terminal $ARGS test haskell-ide-engine:test:wrapper-test
+         - stack --no-terminal $ARGS test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,13 @@ cache:
   - $HOME/.stack
   - $HOME/.local/bin
   - $TRAVIS_BUILD_DIR/.stack-work
+  - $TRAVIS_BUILD_DIR/submodules/HaRe/.stack-work
+  - $TRAVIS_BUILD_DIR/submodules/ghc-mod/.stack-work
+  - $TRAVIS_BUILD_DIR/submodules/ghc-mod/core/.stack-work
+  - $TRAVIS_BUILD_DIR/submodules/haskell-lsp/.stack-work
+  - $TRAVIS_BUILD_DIR/submodules/haskell-lsp/haskell-lsp-types/.stack-work
+  - $TRAVIS_BUILD_DIR/submodules/cabal-helper/.stack-work
+  - $TRAVIS_BUILD_DIR/hie-plugin-api/.stack-work
   timeout: 600
 
 stages:
@@ -43,7 +50,9 @@ jobs:
        script: stack --no-terminal $ARGS build --test --no-run-tests
 
      - stage: test
-       script: stack --no-terminal $ARGS test haskell-ide-engine:test:func-test
+       script:
+         - stack --no-terminal $ARGS exec hoogle generate
+         - stack --no-terminal $ARGS test haskell-ide-engine:test:func-test
      -
        script: stack --no-terminal $ARGS test haskell-ide-engine:test:unit-test
      -

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ install:
 
 script:
   - stack --no-terminal $ARGS install
+  - stack --no-terminal $ARGS test
 
 after_success:
 - mkdir -p ./releases/

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
          - stack $ARGS build lens
 
      - stage: setup
-       env: ARGS="--stack-yaml=stack-8.4.3.yaml"
+       env: ARGS="--stack-yaml=stack-8.4.2.yaml"
        script: *setup
 
      - stage: setup
@@ -74,6 +74,7 @@ jobs:
      - stage: compile
        env: ARGS="--stack-yaml=stack-8.4.3.yaml"
        script: &compile
+         - stack --no-terminal $ARGS build --test --no-run-tests
 
      - stage: compile
        env: ARGS="--stack-yaml=stack-8.4.2.yaml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,4 +52,9 @@ jobs:
      - stage: test
        script:
          - stack --no-terminal $ARGS exec hoogle generate
-         - stack --no-terminal $ARGS test
+         - stack --no-terminal $ARGS test haskell-ide-engine:test:func-test
+     -
+       script:
+         - stack --no-terminal $ARGS test haskell-ide-engine:test:dispatcher-test
+         - stack --no-terminal $ARGS test haskell-ide-engine:test:unit-test
+         - stack --no-terminal $ARGS test haskell-ide-engine:test:wrapper-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,21 +102,12 @@ jobs:
 
      - stage: test
        env: ARGS="--stack-yaml=stack-8.4.2.yaml"
-       script: *functest
-     -
-       env: ARGS="--stack-yaml=stack-8.4.2.yaml"
        script: *test
 
      - stage: test
        env: ARGS="--stack-yaml=stack-8.2.2.yaml"
-       script: *functest
-     -
-       env: ARGS="--stack-yaml=stack-8.2.2.yaml"
        script: *test
 
      - stage: test
-       env: ARGS="--stack-yaml=stack-8.2.1.yaml"
-       script: *functest
-     -
        env: ARGS="--stack-yaml=stack-8.2.1.yaml"
        script: *test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,24 +11,32 @@ cache:
 
 matrix:
   include:
-    - env: GHC_VER="8.2.1" ARGS="--stack-yaml=stack-8.2.1.yaml"
+    - env: GHC_VER="8.2.1" STACK_CACHE="https://www.dropbox.com/s/ay5q7f1crjy1juq/stack-8.2.1.tar.bz?dl=1" ARGS="--stack-yaml=stack-8.2.1.yaml"
       os: osx
       addons:
         artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.2.2" ARGS="--stack-yaml=stack-8.2.2.yaml"
+    - env: GHC_VER="8.2.2" STACK_CACHE="https://www.dropbox.com/s/m0ibz81zerr0c2f/stack-8.2.2.tar.bz?dl=1" ARGS="--stack-yaml=stack-8.2.2.yaml"
       os: osx
       addons:
         artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.4.2" ARGS="--stack-yaml=stack-8.4.2.yaml"
+    - env: GHC_VER="8.4.2" STACK_CACHE="https://www.dropbox.com/s/zo316nei0cfom77/stack-8.4.2.tar.bz?dl=1" ARGS="--stack-yaml=stack-8.4.2.yaml"
       os: osx
       addons:
         artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.4.3" ARGS="--stack-yaml=stack-8.4.3.yaml"
+    - env: GHC_VER="8.4.3" STACK_CACHE="https://www.dropbox.com/s/xkf7c3ltx9jz0c9/stack-8.4.3.tar.bz?dl=1" ARGS="--stack-yaml=stack-8.4.3.yaml"
       os: osx
       addons:
         artifacts: {paths: [./releases]}
 
 before_install:
+  # Seeding the cache with some pre-compile packages
+  - |
+    if [[ ! -f "${HOME}/.stack/indices/Hackage/00-index.tar.gz" ]]
+    then
+      mkdir -p $HOME/.stack
+      travis_retry curl -sSL $STACK_CACHE \
+        | tar xj --strip-components=1 -C $HOME/.stack
+    fi
   # Download and unpack the stack executable
   - mkdir -p ~/.local/bin
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,19 +11,19 @@ cache:
 
 matrix:
   include:
-    - env: GHC_VER="8.2.1" STACK_CACHE="https://www.dropbox.com/s/ay5q7f1crjy1juq/stack-8.2.1.tar.bz?dl=1" ARGS="--stack-yaml=stack-8.2.1.yaml"
+    - env: GHC_VER="8.2.1" STACK_CACHE="https://www.dropbox.com/s/51ois4onz5cpuak/stack-8.2.1.tar.bz2?dl=1" ARGS="--stack-yaml=stack-8.2.1.yaml"
       os: osx
       addons:
         artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.2.2" STACK_CACHE="https://www.dropbox.com/s/m0ibz81zerr0c2f/stack-8.2.2.tar.bz?dl=1" ARGS="--stack-yaml=stack-8.2.2.yaml"
+    - env: GHC_VER="8.2.2" STACK_CACHE="https://www.dropbox.com/s/2bvw2qaec8oe08b/stack-8.2.2.tar.bz2?dl=1" ARGS="--stack-yaml=stack-8.2.2.yaml"
       os: osx
       addons:
         artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.4.2" STACK_CACHE="https://www.dropbox.com/s/zo316nei0cfom77/stack-8.4.2.tar.bz?dl=1" ARGS="--stack-yaml=stack-8.4.2.yaml"
+    - env: GHC_VER="8.4.2" STACK_CACHE="https://www.dropbox.com/s/ph5x48keq7tk165/stack-8.4.2.tar.bz2?dl=1" ARGS="--stack-yaml=stack-8.4.2.yaml"
       os: osx
       addons:
         artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.4.3" STACK_CACHE="https://www.dropbox.com/s/xkf7c3ltx9jz0c9/stack-8.4.3.tar.bz?dl=1" ARGS="--stack-yaml=stack-8.4.3.yaml"
+    - env: GHC_VER="8.4.3" STACK_CACHE="https://www.dropbox.com/s/r7522f5l79zynoe/stack-8.4.3.tar.bz2?dl=1" ARGS="--stack-yaml=stack-8.4.3.yaml"
       os: osx
       addons:
         artifacts: {paths: [./releases]}
@@ -31,7 +31,7 @@ matrix:
 before_install:
   # Seeding the cache with some pre-compile packages
   - |
-    if [[ ! -f "${HOME}/.stack/indices/Hackage/00-index.tar.gz" ]]
+    if [[ ! -f "${HOME}/.stack/indices/Hackage/00-index.tar" ]]
     then
       mkdir -p $HOME/.stack
       travis_retry curl -sSL $STACK_CACHE \

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
   - $TRAVIS_BUILD_DIR/submodules/haskell-lsp/haskell-lsp-types/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/cabal-helper/.stack-work
   - $TRAVIS_BUILD_DIR/hie-plugin-api/.stack-work
-  timeout: 600
+  timeout: 800
 
 stages:
   - setup
@@ -39,6 +39,8 @@ jobs:
                | tar xz --strip-components=1 -C ~/.local/bin --include   '*/stack'
            fi
          - travis_retry stack --no-terminal --install-ghc $ARGS setup
+         # Build a bing package to offload the next stage from doing too much work
+         - stack $ARGS build lens
 
      - stage: setup
        env: ARGS="--stack-yaml=stack-8.4.3.yaml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,10 @@ before_install:
 install:
   - git submodule update --init
   - travis_retry stack --no-terminal --install-ghc $ARGS build --only-dependencies
+  - stack --no-terminal $ARGS install
 
 script:
-  - stack --no-terminal $ARGS install
+  - stack --no-terminal $ARGS test
 
 after_success:
 - mkdir -p ./releases/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,74 +3,50 @@ sudo: false
 
 language: c
 compiler: gcc
+os: osx
 
 cache:
   directories:
   - $HOME/.stack
+  - $HOME/.local/bin
   - $TRAVIS_BUILD_DIR/.stack-work
-  timeout: 300
+  timeout: 600
 
-matrix:
-  include:
-    - env: GHC_VER="8.2.1" STACK_CACHE="https://www.dropbox.com/s/51ois4onz5cpuak/stack-8.2.1.tar.bz2?dl=1" ARGS="--stack-yaml=stack-8.2.1.yaml"
-      os: osx
-      addons:
-        artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.2.2" STACK_CACHE="https://www.dropbox.com/s/2bvw2qaec8oe08b/stack-8.2.2.tar.bz2?dl=1" ARGS="--stack-yaml=stack-8.2.2.yaml"
-      os: osx
-      addons:
-        artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.4.2" STACK_CACHE="https://www.dropbox.com/s/ph5x48keq7tk165/stack-8.4.2.tar.bz2?dl=1" ARGS="--stack-yaml=stack-8.4.2.yaml"
-      os: osx
-      addons:
-        artifacts: {paths: [./releases]}
-    - env: GHC_VER="8.4.3" STACK_CACHE="https://www.dropbox.com/s/r7522f5l79zynoe/stack-8.4.3.tar.bz2?dl=1" ARGS="--stack-yaml=stack-8.4.3.yaml"
-      os: osx
-      addons:
-        artifacts: {paths: [./releases]}
+stages:
+  - setup
+  - dependencies
+  - compile
+  - test
 
-before_install:
-  # Seeding the cache with some pre-compile packages
-  - |
-    if [[ ! -f "${HOME}/.stack/indices/Hackage/00-index.tar" ]]
-    then
-      mkdir -p $HOME/.stack
-      travis_retry curl -sSL $STACK_CACHE \
-        | tar xj --strip-components=1 -C $HOME/.stack
-    fi
-  # Download and unpack the stack executable
-  - mkdir -p ~/.local/bin
-  - |
-    if [[ "${TRAVIS_OS_NAME}" = "osx" ]]
-    then
-      travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
-        | tar xz --strip-components=1 -C ~/.local/bin --include   '*/stack'
-    else
-      travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
-        | tar xz --strip-components=1 -C ~/.local/bin --wildcards '*/stack'
-    fi
+env:
+  - GHC_VER="8.4.3" ARGS="--stack-yaml=stack-8.4.3.yaml"
 
-install:
-  - git submodule update --init
-  - travis_retry stack --no-terminal --install-ghc $ARGS build
+jobs:
+   include:
+     - stage: setup
+       script:
+         - mkdir -p $HOME/.stack
+         - mkdir -p ~/.local/bin
+         - |
+           if [[ ! -f "${HOME}/.local/bin/stack" ]]
+           then
+             travis_retry curl -sSL https://www.stackage.org/stack/${TRAVIS_OS_NAME}-x86_64 \
+               | tar xz --strip-components=1 -C ~/.local/bin --include   '*/stack'
+           fi
+         - travis_retry stack --no-terminal --install-ghc $ARGS setup
 
-script:
-  - stack --no-terminal $ARGS install
-  - stack --no-terminal $ARGS test
+     - stage: dependencies
+       script:
+         - travis_retry stack --no-terminal --install-ghc $ARGS test --only-dependencies --no-run-tests
 
-after_success:
-- mkdir -p ./releases/
-- cp "$(which hie)" "./releases/"
-- cp "$(which hie-wrapper)" "./releases/"
+     - stage: compile
+       script: stack --no-terminal $ARGS build --test --no-run-tests
 
-before_deploy:
-- mv ./releases/hie "./releases/hie-${GHC_VER}-macos"
-
-deploy:
-  provider: releases
-  api_key:
-    secure: jhNwLD87iJZBA4yCd3bXUz4bcAxzPVTR7PjW9okQxXu5LBOYfTbUFsYCqnpEaItk1ot8WKwAxOt6tXkU/KkmDwhYCkii1Mt1r9mEKzDkjp68WhRlRm/3iCjlUcophXavUwcKZDtZHpii2bn+hne2Y8Eo8zbMIb1l5kd+mDH6WqP9AAMcgKSaHa7ZIkoc2S2TJ04nU8OeEW7Ts6lfOc6NAuxC9V28sewDUdWoAl8DIydsXvZWEAJ245Ir06zvg7KmdDuGmqHnO+cR2XjaRCs5sSDypexhECH+u8pgMe8Bziiy8aI1FHvRB8nEh/LvS+urGj1eoDH6DQiH+MerUFqFknn1wTw5fW9m3IsMpufVdlIMgQb1cqrr0osHyH9ckL/O7gtu7Fr67LXXPVq5TiUkIcLE6ut+DbCMs9LjePrHKW1JiEkqBBYB+MKkkKrPh3cUOjzuOkgnrpFgvFaBASSabqvVQvoDhCb+CxZQrSH1N1Qqj9zMuy6WFsmDmN/Pb940H3J9/isF/zkrPwrYbm02ZVV3882IEWuNGlr3NUW1Ik9lXPlPlen9BtJebaxhVa/RkRdyWIjk5Wlv9iGwuT/dtxqfJvD1EXodnxKAfc6QJISRwqpRBMIVIvRHRWOdY42AqHy/0NWG4J0gsTcBuBB4z5iwi9/zG7n60zcYU4N+9pg=
-  file: "./releases/*"
-  skip_cleanup: true
-  on:
-    tags: true
+     - stage: test
+       script: stack --no-terminal $ARGS test haskell-ide-engine:test:func-test
+     -
+       script: stack --no-terminal $ARGS test haskell-ide-engine:test:unit-test
+     -
+       script: stack --no-terminal $ARGS test haskell-ide-engine:test:dispatcher-test
+     -
+       script: stack --no-terminal $ARGS test haskell-ide-engine:test:wrapper-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,10 @@ before_install:
 
 install:
   - git submodule update --init
-  - travis_retry stack --no-terminal --install-ghc $ARGS build --only-dependencies --test
+  - travis_retry stack --no-terminal --install-ghc $ARGS build --test
 
 script:
-  - stack --no-terminal $ARGS install --test
+  - stack --no-terminal $ARGS install
 
 after_success:
 - mkdir -p ./releases/


### PR DESCRIPTION
Compiles and runs tests for the 4 versions of GHC we currently support.

Currently the `func-tests` suite is disabled for GHC < 8.4.3 as there seems to be a bug in the suite that needs to investigated further.