### PR TITLE
Liquid plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/build
   docker:
-    - image: quay.io/haskell_works/stack-build-icu
+    - image: alanz/haskell-hie-ci
   steps:
     - checkout
     - run:

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -50,16 +50,16 @@ plugins includeExamples = pluginDescToIdePlugins allPlugins
                    else basePlugins
     basePlugins =
       [applyRefactDescriptor "applyrefact"
-      ,baseDescriptor "base"
-      ,brittanyDescriptor "brittany"
+      ,baseDescriptor        "base"
+      ,brittanyDescriptor    "brittany"
       ,buildPluginDescriptor "build"
-      ,ghcmodDescriptor "ghcmod"
-      ,hareDescriptor "hare"
-      ,hoogleDescriptor "hoogle"
-      ,hsimportDescriptor "hsimport"
-      ,liquidDescriptor "liquid"
-      ,packageDescriptor "package"
-      ,haddockDescriptor "haddock"
+      ,ghcmodDescriptor      "ghcmod"
+      ,hareDescriptor        "hare"
+      ,hoogleDescriptor      "hoogle"
+      ,hsimportDescriptor    "hsimport"
+      ,liquidDescriptor      "liquid"
+      ,packageDescriptor     "package"
+      ,haddockDescriptor     "haddock"
       ]
     examplePlugins =
       [example2Descriptor "eg2"

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -255,6 +255,7 @@ test-suite func-test
                      , HaReSpec
                      , HighlightSpec
                      , HoverSpec
+                     , LiquidSpec
                      , ReferencesSpec
                      , RenameSpec
                      , SymbolsSpec

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -262,6 +262,8 @@ test-suite func-test
                      , Utils
 
                      , TestUtils
+  -- This cannot currently be handled by hie (cabal-helper)
+  -- build-tool-depends:  haskell-ide-engine:hie
   build-depends:       aeson
                      , base
                      , containers

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -258,6 +258,7 @@ test-suite func-test
                      , ReferencesSpec
                      , RenameSpec
                      , SymbolsSpec
+                     , Utils
 
                      , TestUtils
   build-depends:       aeson

--- a/hie-plugin-api/Haskell/Ide/Engine/Monad.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Monad.hs
@@ -17,4 +17,3 @@ runIdeGhcM ghcModOptions caps s0 f = do
     case eres of
         Left err  -> liftIO $ throwIO err
         Right res -> return res
-

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -184,7 +184,7 @@ diffText' supports (f,fText) f2Text withDeletions  =
 
     isDeletion (Deletion _ _) = True
     isDeletion _ = False
-    
+
     r = map diffOperationToTextEdit diffOps
     diff = J.List r
     h = H.singleton f diff

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -154,13 +154,13 @@ instance ToJSON IdePlugins where
 type IdeGhcM = GM.GhcModT IdeM
 
 instance MonadMTState IdeState IdeGhcM where
-  readMTS = lift $ lift $ lift readMTS
+  readMTS     = lift $ lift $ lift readMTS
   modifyMTS f = lift $ lift $ lift $ modifyMTS f
 
 type IdeM = ReaderT ClientCapabilities (MultiThreadState IdeState)
 
 instance MonadMTState IdeState IdeM where
-  readMTS = lift readMTS
+  readMTS   = lift readMTS
   modifyMTS = lift . modifyMTS
 
 class (Monad m) => LiftsToGhc m where

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -156,7 +156,7 @@ type CodeActionProvider =  PluginId
 
 -- type DiagnosticProviderFunc = DiagnosticTrigger -> Uri -> IdeM (IdeResponse (Map.Map Uri (S.Set Diagnostic)))
 type DiagnosticProviderFunc
-  = DiagnosticTrigger -> Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+  = DiagnosticTrigger -> Uri -> IdeM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
 
 data DiagnosticProvider = DiagnosticProvider
      { dpTrigger :: S.Set DiagnosticTrigger -- AZ:should this be a NonEmptyList?

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -155,7 +155,9 @@ type CodeActionProvider =  PluginId
                         -> IdeM (IdeResult [CodeAction])
 
 type DiagnosticProviderFunc
-  = DiagnosticTrigger -> Uri -> IdeDeferM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+  = DiagnosticTrigger -> Uri
+  -> (Map.Map Uri (S.Set Diagnostic) -> IO ())
+  -> IdeDeferM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
 
 data DiagnosticProvider = DiagnosticProvider
      { dpTrigger :: S.Set DiagnosticTrigger -- AZ:should this be a NonEmptyList?

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -154,9 +154,8 @@ type CodeActionProvider =  PluginId
                         -> CodeActionContext
                         -> IdeM (IdeResult [CodeAction])
 
--- type DiagnosticProviderFunc = DiagnosticTrigger -> Uri -> IdeM (IdeResponse (Map.Map Uri (S.Set Diagnostic)))
 type DiagnosticProviderFunc
-  = DiagnosticTrigger -> Uri -> IdeM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+  = DiagnosticTrigger -> Uri -> IdeDeferM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
 
 data DiagnosticProvider = DiagnosticProvider
      { dpTrigger :: S.Set DiagnosticTrigger -- AZ:should this be a NonEmptyList?

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -26,7 +26,9 @@ module Haskell.Ide.Engine.PluginsIdeMonads
   , PluginCommand(..)
   , CodeActionProvider
   , DiagnosticProvider(..)
-  , DiagnosticProviderFunc
+  , DiagnosticProviderFunc(..)
+  , DiagnosticProviderFuncSync
+  , DiagnosticProviderFuncAsync
   , DiagnosticTrigger(..)
   , HoverProvider
   , SymbolProvider
@@ -154,10 +156,19 @@ type CodeActionProvider =  PluginId
                         -> CodeActionContext
                         -> IdeM (IdeResult [CodeAction])
 
-type DiagnosticProviderFunc
+type DiagnosticProviderFuncSync
+  = DiagnosticTrigger -> Uri
+  -> IdeDeferM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+
+type DiagnosticProviderFuncAsync
   = DiagnosticTrigger -> Uri
   -> (Map.Map Uri (S.Set Diagnostic) -> IO ())
-  -> IdeDeferM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+  -> IdeDeferM (IdeResult ())
+
+data DiagnosticProviderFunc
+  = DiagnosticProviderSync  DiagnosticProviderFuncSync
+  | DiagnosticProviderAsync DiagnosticProviderFuncAsync
+
 
 data DiagnosticProvider = DiagnosticProvider
      { dpTrigger :: S.Set DiagnosticTrigger -- AZ:should this be a NonEmptyList?

--- a/src/Haskell/Ide/Engine/Dispatcher.hs
+++ b/src/Haskell/Ide/Engine/Dispatcher.hs
@@ -83,7 +83,8 @@ mainDispatcher inChan ghcChan ideChan = forever $ do
 ideDispatcher :: forall void m. TVar IdeState -> J.ClientCapabilities
               -> DispatcherEnv -> ErrorHandler -> CallbackHandler m
               -> TChan (IdeRequest m) -> IO void
-ideDispatcher stateVar caps env errorHandler callbackHandler pin = 
+ideDispatcher stateVar caps env errorHandler callbackHandler pin =
+  -- TODO: AZ run a single ReaderT, with a composite R.
   flip runReaderT stateVar $ flip runReaderT caps $ forever $ do
     debugm "ideDispatcher: top of loop"
     (IdeRequest tn lid callback action) <- liftIO $ atomically $ readTChan pin
@@ -104,7 +105,7 @@ ideDispatcher stateVar caps env errorHandler callbackHandler pin =
           case muc of
             Just uc -> cacheCb uc
             Nothing -> lift $ modifyMTState $ \s ->
-              let oldQueue = requestQueue s 
+              let oldQueue = requestQueue s
                   -- add to existing queue if possible
                   update Nothing = [cacheCb]
                   update (Just x) = cacheCb : x

--- a/src/Haskell/Ide/Engine/LSP/Config.hs
+++ b/src/Haskell/Ide/Engine/LSP/Config.hs
@@ -1,9 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Haskell.Ide.Engine.LSP.Config where
 
-import Data.Aeson
+import           Data.Aeson
+import qualified Data.Map  as Map
 import qualified Data.Text as T
-import Language.Haskell.LSP.Types
+import           Haskell.Ide.Engine.PluginsIdeMonads
+import           Language.Haskell.LSP.Types
+
+-- ---------------------------------------------------------------------
 
 -- | Callback from haskell-lsp core to convert the generic message to the
 -- specific one for hie
@@ -13,10 +17,13 @@ getConfigFromNotification (NotificationMessage _ _ (DidChangeConfigurationParams
     Success c -> Right c
     Error err -> Left $ T.pack err
 
+-- ---------------------------------------------------------------------
+
 data Config =
   Config
     { hlintOn             :: Bool
     , maxNumberOfProblems :: Int
+    , liquidOn            :: Bool
     } deriving (Show)
 
 instance FromJSON Config where
@@ -25,6 +32,7 @@ instance FromJSON Config where
     flip (withObject "Config.settings") s $ \o -> Config
       <$> o .:? "hlintOn"             .!= True
       <*> o .:? "maxNumberOfProblems" .!= 100
+      <*> o .:? "liquidOn"            .!= False
 
 -- 2017-10-09 23:22:00.710515298 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"languageServerHaskell":{"maxNumberOfProblems":100,"hlintOn":true}}}}
 -- 2017-10-09 23:22:00.710667381 [ThreadId 15] - reactor:got didChangeConfiguration notification:
@@ -34,3 +42,20 @@ instance FromJSON Config where
 --   , _params = DidChangeConfigurationParams
 --                 {_settings = Object (fromList [("languageServerHaskell",Object (fromList [("hlintOn",Bool True)
 --                                                                                          ,("maxNumberOfProblems",Number 100.0)]))])}}
+
+instance ToJSON Config where
+  toJSON (Config h m l) = object [ "languageServerHaskell" .= r ]
+    where
+      r = object [ "hlintOn"             .= h
+                 , "maxNumberOfProblems" .= m
+                 , "liquidOn"            .= l
+                 ]
+
+-- ---------------------------------------------------------------------
+
+-- | For the diagnostic providers in the config, return a map of
+-- current enabled state, indexed by the plugin id.
+getDiagnosticProvidersConfig :: Config -> Map.Map PluginId Bool
+getDiagnosticProvidersConfig c = Map.fromList [("applyrefact",hlintOn c)
+                                              ,("liquid",     liquidOn c)
+                                              ]

--- a/src/Haskell/Ide/Engine/LSP/Config.hs
+++ b/src/Haskell/Ide/Engine/LSP/Config.hs
@@ -24,7 +24,7 @@ data Config =
     { hlintOn             :: Bool
     , maxNumberOfProblems :: Int
     , liquidOn            :: Bool
-    } deriving (Show)
+    } deriving (Show,Eq)
 
 instance FromJSON Config where
   parseJSON = withObject "Config" $ \v -> do

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -24,7 +24,8 @@ example2Descriptor plId = PluginDescriptor
       , PluginCommand "sayHelloTo ""say hello to the passed in param" sayHelloToCmd
       ]
   , pluginCodeActionProvider = Nothing
-  , pluginDiagnosticProvider = Just (DiagnosticProvider (S.singleton DiagnosticOnSave) diagnosticProvider)
+  , pluginDiagnosticProvider
+      = Just (DiagnosticProvider (S.singleton DiagnosticOnSave) (DiagnosticProviderSync diagnosticProvider))
   , pluginHoverProvider = Nothing
   , pluginSymbolProvider = Nothing
   }
@@ -49,8 +50,8 @@ sayHelloTo n = return $ "hello " <> n <> " from ExamplePlugin2"
 
 -- ---------------------------------------------------------------------
 
-diagnosticProvider :: DiagnosticProviderFunc
-diagnosticProvider trigger uri _cb = do
+diagnosticProvider :: DiagnosticProviderFuncSync
+diagnosticProvider trigger uri = do
   liftIO $ logm "Example2.diagnosticProvider called"
   let diag = Diagnostic
               { _range = Range (Position 0 0) (Position 1 0)

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -49,8 +49,8 @@ sayHelloTo n = return $ "hello " <> n <> " from ExamplePlugin2"
 
 -- ---------------------------------------------------------------------
 
-diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeDeferM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
-diagnosticProvider trigger uri = do
+diagnosticProvider :: DiagnosticProviderFunc
+diagnosticProvider trigger uri _cb = do
   liftIO $ logm "Example2.diagnosticProvider called"
   let diag = Diagnostic
               { _range = Range (Position 0 0) (Position 1 0)

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -49,7 +49,7 @@ sayHelloTo n = return $ "hello " <> n <> " from ExamplePlugin2"
 
 -- ---------------------------------------------------------------------
 
-diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeDeferM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
 diagnosticProvider trigger uri = do
   liftIO $ logm "Example2.diagnosticProvider called"
   let diag = Diagnostic

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -49,7 +49,7 @@ sayHelloTo n = return $ "hello " <> n <> " from ExamplePlugin2"
 
 -- ---------------------------------------------------------------------
 
-diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
 diagnosticProvider trigger uri = do
   liftIO $ logm "Example2.diagnosticProvider called"
   let diag = Diagnostic

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -98,15 +98,6 @@ diagnosticProvider _trigger uri = do
     Just es -> return $ IdeResultOk m
       where
         m = Map.fromList [(uri,S.fromList (map liquidErrorToDiagnostic es))]
-  -- let diag = Diagnostic
-  --             { _range = Range (Position 5 0) (Position 7 0)
-  --             , _severity = Nothing
-  --             , _code = Nothing
-  --             , _source = Just "eg2"
-  --             , _message = "Liquid plugin diagnostic, vim annot in " <> T.pack (vimAnnotFile uri)
-  --             , _relatedInformation = Nothing
-  --             }
-  -- return $ IdeResultOk $ Map.fromList [(uri,S.singleton diag)]
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -42,11 +42,11 @@ liquidDescriptor plId = PluginDescriptor
       , PluginCommand "sayHelloTo" "say hello to the passed in param" sayHelloToCmd
       ]
   , pluginCodeActionProvider = Nothing
-  , pluginDiagnosticProvider= Just (DiagnosticProvider
+  , pluginDiagnosticProvider = Just (DiagnosticProvider
                                     (S.singleton DiagnosticOnSave)
                                     (DiagnosticProviderAsync diagnosticProvider))
   , pluginHoverProvider      = Just hoverProvider
-  , pluginSymbolProvider = Nothing
+  , pluginSymbolProvider     = Nothing
   }
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -129,7 +129,7 @@ runLiquidHaskell fp = do
         (\_ -> mapM_ (setEnv "GHC_PACKAGE_PATH") mpp)
         (\_ -> readCreateProcessWithExitCode cp "")
       logm $ "runLiquidHaskell:v=" ++ show (ec,o,e)
-      return [cmd,show ec,o,e]
+      return [show ec,o,e]
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -20,11 +20,11 @@ import           GHC.Generics
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes hiding (_range)
 import           Haskell.Ide.Engine.PluginUtils
-import qualified Language.Haskell.LSP.Types as J
+import qualified Language.Haskell.LSP.Types    as J
 import           System.Directory
+import           System.Environment
 import           System.FilePath
 import           System.Process
-import           System.Environment
 import           Text.Parsec
 import           Text.Parsec.Text
 
@@ -40,7 +40,9 @@ liquidDescriptor plId = PluginDescriptor
       , PluginCommand "sayHelloTo" "say hello to the passed in param" sayHelloToCmd
       ]
   , pluginCodeActionProvider = Nothing
-  , pluginDiagnosticProvider = Just (DiagnosticProvider (S.singleton DiagnosticOnSave) diagnosticProvider)
+  , pluginDiagnosticProvider= Just (DiagnosticProvider
+                                    (S.singleton DiagnosticOnSave)
+                                    diagnosticProvider)
   , pluginHoverProvider      = Just hoverProvider
   , pluginSymbolProvider = Nothing
   }

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -97,19 +97,20 @@ instance ToJSON   LiquidError
 
 -- ---------------------------------------------------------------------
 
-diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
-diagnosticProvider trigger uri = do
-  me <- liftIO $ readJsonAnnot uri
-  case me of
-    Nothing -> return $ IdeResultOk Map.empty
-    Just es -> do
-      case trigger of
-        DiagnosticOnSave -> do
-          return ()
-        _ -> return ()
-      return $ IdeResultOk m
-      where
-        m = Map.fromList [(uri,S.fromList (map liquidErrorToDiagnostic es))]
+diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+diagnosticProvider trigger uri = pluginGetFile "Liquid.diagnosticProvider:" uri $ \file ->
+  withCachedModuleAndData file (IdeResultOk Map.empty) $ \_cm () -> do
+    me <- liftIO $ readJsonAnnot uri
+    case me of
+      Nothing -> return $ IdeResultOk Map.empty
+      Just es -> do
+        case trigger of
+          DiagnosticOnSave -> do
+            return ()
+          _ -> return ()
+        return $ IdeResultOk m
+        where
+          m = Map.fromList [(uri,S.fromList (map liquidErrorToDiagnostic es))]
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -32,8 +32,8 @@ liquidDescriptor = PluginDescriptor
     pluginName = "Liquid Haskell"
   , pluginDesc = "Integration with Liquid Haskell"
   , pluginCommands =
-      [ PluginCommand "sayHello" "say hello" sayHelloCmd
-      , PluginCommand "sayHelloTo ""say hello to the passed in param" sayHelloToCmd
+      [ PluginCommand "sayHello"   "say hello"                        sayHelloCmd
+      , PluginCommand "sayHelloTo" "say hello to the passed in param" sayHelloToCmd
       ]
   , pluginCodeActionProvider = Nothing
   , pluginDiagnosticProvider = Just (DiagnosticProvider (S.singleton DiagnosticOnSave) diagnosticProvider)
@@ -92,13 +92,23 @@ instance ToJSON   LiquidError
 -- ---------------------------------------------------------------------
 
 diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeGhcM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
-diagnosticProvider _trigger uri = do
+diagnosticProvider trigger uri = do
   me <- liftIO $ readJsonAnnot uri
   case me of
     Nothing -> return $ IdeResultOk Map.empty
-    Just es -> return $ IdeResultOk m
+    Just es -> do
+      case trigger of
+        DiagnosticOnSave -> do
+          return ()
+        _ -> return ()
+      return $ IdeResultOk m
       where
         m = Map.fromList [(uri,S.fromList (map liquidErrorToDiagnostic es))]
+
+-- ---------------------------------------------------------------------
+
+runLiquidHaskell = do
+  return []
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -97,7 +97,9 @@ instance ToJSON   LiquidError
 
 -- ---------------------------------------------------------------------
 
-diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+-- diagnosticProvider :: DiagnosticTrigger -> Uri -> IdeM (IdeResult (Map.Map Uri (S.Set Diagnostic)))
+
+diagnosticProvider :: DiagnosticProviderFunc
 diagnosticProvider trigger uri = pluginGetFile "Liquid.diagnosticProvider:" uri $ \file ->
   withCachedModuleAndData file (IdeResultOk Map.empty) $ \_cm () -> do
     me <- liftIO $ readJsonAnnot uri

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -756,8 +756,13 @@ requestDiagnostics trigger tn file mVer = do
           --   Nothing -> Nothing
           --   Just v -> Just (file,v)
         let fakeId = J.IdString "fake,remove" -- TODO:AZ: IReq should take a Maybe LspId
-        let reql = IReq tn fakeId callbackl
-                     $ ds trigger file callbackl
+        let reql = case ds of
+              DiagnosticProviderSync dps ->
+                IReq tn fakeId callbackl
+                     $ dps trigger file
+              DiagnosticProviderAsync dpa ->
+                IReq tn fakeId pure
+                     $ dpa trigger file callbackl
             -- This callback is used in R for the dispatcher normally,
             -- but also in IO if the plugin chooses to spawn an
             -- external process that returns diagnostics when it

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -503,6 +503,7 @@ reactor inp = do
                   cached <- isCached fp
                   -- Hover requests need to be instant so don't wait
                   -- for cached module to be loaded
+                  -- TODO:AZ: what if a plugin hoverprovider does not need the cached module?
                   if cached
                     then sequence <$> mapM (\hp -> hp doc pos) hps
                     else return (IdeResponseOk [])

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -750,10 +750,12 @@ requestDiagnostics trigger tn file mVer = do
             publishDiagnostics maxToSend fileUri Nothing (Map.fromList [(Just pid,SL.toSortedList ds')])
 
           sendEmpty = publishDiagnostics maxToSend file Nothing (Map.fromList [(Just pid,SL.toSortedList [])])
-          fv = case mVer of
-            Nothing -> Nothing
-            Just v -> Just (file,v)
-        let reql = GReq tn (Just file) fv Nothing callbackl
+          -- fv = case mVer of
+          --   Nothing -> Nothing
+          --   Just v -> Just (file,v)
+        -- let reql = GReq tn (Just file) fv Nothing callbackl
+        let fakeId = J.IdString "fake,remove" -- TODO:AZ: IReq should take a Maybe LspId
+        let reql = IReq tn fakeId callbackl
                      $ ds trigger file
             callbackl pd = do
               let diags = Map.toList $ S.toList <$> pd

--- a/src/Haskell/Ide/Engine/Types.hs
+++ b/src/Haskell/Ide/Engine/Types.hs
@@ -26,7 +26,8 @@ pattern GReq :: TrackingNumber
              -> PluginRequest m
 pattern GReq a b c d e f = Right (GhcRequest   a b c d e f)
 
-pattern IReq :: TrackingNumber -> J.LspId -> RequestCallback m a -> IdeM (IdeResult a) -> Either (IdeRequest m) b
+pattern IReq :: TrackingNumber -> J.LspId
+             -> RequestCallback m a -> IdeM (IdeResult a) -> PluginRequest m
 pattern IReq a b c d   = Left  (IdeRequest a b c d)
 
 type PluginRequest m = Either (IdeRequest m) (GhcRequest m)

--- a/test/functional/CommandSpec.hs
+++ b/test/functional/CommandSpec.hs
@@ -9,10 +9,11 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types as LSP
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = describe "commands" $ do
-  it "are prefixed" $ runSession hieCommand fullCaps "test/testdata/" $ do
+  it "are prefixed" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/" $ do
     ResponseMessage _ _ (Just res) Nothing <- initializeResponse
     let List cmds = res ^. LSP.capabilities . executeCommandProvider . _Just . commands
         f x = (T.length (T.takeWhile isNumber x) >= 1) && (T.count ":" x >= 2)
@@ -20,10 +21,11 @@ spec = describe "commands" $ do
       cmds `shouldSatisfy` all f
       cmds `shouldNotSatisfy` null
 
-  it "get de-prefixed" $ runSession hieCommand fullCaps "test/testdata/" $ do
+  it "get de-prefixed" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/" $ do
     ResponseMessage _ _ _ (Just err) <- request
             WorkspaceExecuteCommand
             (ExecuteCommandParams "1234:package:add" (Just (List []))) :: Session ExecuteCommandResponse
     let ResponseError _ msg _ = err
     -- We expect an error message about the dud arguments, but should pickup "add" and "package"
     liftIO $ msg `shouldSatisfy` T.isInfixOf "while parsing args for add in plugin package"
+

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -9,10 +9,11 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = describe "completions" $ do
-  it "works" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+  it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
@@ -27,7 +28,7 @@ spec = describe "completions" $ do
       item ^. detail `shouldBe` Just "String -> IO ()\nPrelude"
   --TODO: Replay session
 
-  it "completes imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+  it "completes imports" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
@@ -41,7 +42,7 @@ spec = describe "completions" $ do
       item ^. detail `shouldBe` Just "Data.Maybe"
       item ^. kind `shouldBe` Just CiModule
 
-  it "completes qualified imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+  it "completes qualified imports" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 

--- a/test/functional/DeferredSpec.hs
+++ b/test/functional/DeferredSpec.hs
@@ -17,11 +17,12 @@ import Test.Hspec
 import System.Directory
 import System.FilePath
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = do
   describe "deferred responses" $ do
-    it "do not affect hover requests" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "do not affect hover requests" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "FuncTest.hs" "haskell"
 
       id1 <- sendRequest TextDocumentHover (TextDocumentPositionParams doc (Position 4 2))
@@ -91,13 +92,13 @@ spec = do
                      }
                    ]
 
-    it "instantly respond to failed modules with no cache" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "instantly respond to failed modules with no cache" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "FuncTestFail.hs" "haskell"
 
       symbols <- request TextDocumentDocumentSymbol (DocumentSymbolParams doc) :: Session DocumentSymbolsResponse
       liftIO $ symbols ^. result `shouldBe` Just (DSDocumentSymbols mempty)
 
-    it "returns hints as diagnostics" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "returns hints as diagnostics" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       _ <- openDoc "FuncTest.hs" "haskell"
 
       cwd <- liftIO getCurrentDirectory
@@ -135,7 +136,7 @@ spec = do
 
   describe "multi-server setup" $
     it "doesn't have clashing commands on two servers" $ do
-      let getCommands = runSession hieCommand fullCaps "test/testdata" $ do
+      let getCommands = runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
               rsp <- initializeResponse
               let uuids = rsp ^? result . _Just . capabilities . executeCommandProvider . _Just . commands
               return $ fromJust uuids
@@ -147,8 +148,8 @@ spec = do
 
   describe "multiple main modules" $
     it "Can load one file at a time, when more than one Main module exists"
-                                  -- $ runSession hieCommand fullCaps "test/testdata" $ do
-                                  $ runSession hieCommandVomit fullCaps "test/testdata" $ do
+                                  -- $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+                                  $ runSessionWithConfig noLogConfig hieCommandVomit fullCaps "test/testdata" $ do
       _doc <- openDoc "ApplyRefact2.hs" "haskell"
       _diagsRspHlint <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification
       diagsRspGhc   <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification

--- a/test/functional/DefinitionSpec.hs
+++ b/test/functional/DefinitionSpec.hs
@@ -7,40 +7,41 @@ import Language.Haskell.LSP.Types
 import System.Directory
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = describe "definitions" $ do
-  it "goto's symbols" $ runSession hieCommand fullCaps "test/testdata" $ do
+  it "goto's symbols" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "References.hs" "haskell"
     defs <- getDefinitions doc (Position 7 8)
     let expRange = Range (Position 4 0) (Position 4 3)
     liftIO $ defs `shouldBe` [Location (doc ^. uri) expRange]
 
-  it "goto's imported modules" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
+  it "goto's imported modules" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/definition" $ do
     doc <- openDoc "Foo.hs" "haskell"
     defs <- getDefinitions doc (Position 2 8)
     liftIO $ do
       fp <- canonicalizePath "test/testdata/definition/Bar.hs"
       defs `shouldBe` [Location (filePathToUri fp) zeroRange]
 
-  it "goto's exported modules" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
+  it "goto's exported modules" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/definition" $ do
     doc <- openDoc "Foo.hs" "haskell"
     defs <- getDefinitions doc (Position 0 15)
     liftIO $ do
       fp <- canonicalizePath "test/testdata/definition/Bar.hs"
       defs `shouldBe` [Location (filePathToUri fp) zeroRange]
 
-  it "goto's imported modules that are loaded" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
+  it "goto's imported modules that are loaded" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/definition" $ do
     doc <- openDoc "Foo.hs" "haskell"
     _ <- openDoc "Bar.hs" "haskell"
     defs <- getDefinitions doc (Position 2 8)
     liftIO $ do
       fp <- canonicalizePath "test/testdata/definition/Bar.hs"
       defs `shouldBe` [Location (filePathToUri fp) zeroRange]
-  
+
   it "goto's imported modules that are loaded, and then closed" $
-    runSession hieCommand fullCaps "test/testdata/definition" $ do
-      doc <- openDoc "Foo.hs" "haskell" 
+    runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/definition" $ do
+      doc <- openDoc "Foo.hs" "haskell"
       otherDoc <- openDoc "Bar.hs" "haskell"
       closeDoc otherDoc
       defs <- getDefinitions doc (Position 2 8)

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -4,14 +4,12 @@ module DiagnosticsSpec where
 
 import Control.Lens hiding (List)
 import Control.Monad.IO.Class
-import Data.Default
 import qualified Data.Text as T
-import qualified Language.Haskell.LSP.Test as Test
 import Language.Haskell.LSP.Test hiding (message)
 import Language.Haskell.LSP.Types as LSP hiding (contents, error )
-import qualified Language.Haskell.LSP.Types.Capabilities as C
 import Test.Hspec
 import TestUtils
+import Utils
 
 -- ---------------------------------------------------------------------
 
@@ -55,20 +53,9 @@ spec = describe "diagnostics providers" $ do
 
   describe "typed hole errors" $
     it "is deferred" $
-      runSession hieCommand fullCaps "test/testdata" $ do
+      runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
         _ <- openDoc "TypedHoles.hs" "haskell"
         [diag] <- waitForDiagnosticsSource "ghcmod"
         liftIO $ diag ^. severity `shouldBe` Just DsWarning
 
-
 -- ---------------------------------------------------------------------
-
-noLogConfig :: SessionConfig
-noLogConfig = Test.defaultConfig { logMessages = False }
-
-codeActionSupportCaps :: C.ClientCapabilities
-codeActionSupportCaps = def { C._textDocument = Just textDocumentCaps }
-  where
-    textDocumentCaps = def { C._codeAction = Just codeActionCaps }
-    codeActionCaps = C.CodeActionClientCapabilities (Just True) (Just literalSupport)
-    literalSupport = C.CodeActionLiteralSupport def

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -17,7 +17,8 @@ spec :: Spec
 spec = describe "diagnostics providers" $ do
   describe "diagnostics triggers" $ do
     it "runs diagnostics on save" $
-      runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      -- runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
         doc <- openDoc "ApplyRefact2.hs" "haskell"
 
         diags@(reduceDiag:_) <- waitForDiagnostics
@@ -31,14 +32,21 @@ spec = describe "diagnostics providers" $ do
           reduceDiag ^. code `shouldBe` Just "Eta reduce"
           reduceDiag ^. source `shouldBe` Just "hlint"
 
+        -- diags2a <- waitForDiagnostics
+        -- -- liftIO $ show diags2a `shouldBe` ""
+        -- liftIO $ length diags2a `shouldBe` 2
+
+        diags2eg@(eg2:_) <- waitForDiagnostics
+        liftIO $ show diags2eg `shouldBe` ""
+        liftIO $ length diags2eg `shouldBe` 3
+        liftIO $ eg2 ^. source `shouldBe` Just "eg2"
+
         -- docItem <- getDocItem file languageId
         sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
         diags2hlint <- waitForDiagnostics
         -- liftIO $ show diags2hlint `shouldBe` ""
-        -- liftIO $ length diags2hlint `shouldBe` 2
         liftIO $ length diags2hlint `shouldBe` 3
         diags2liquid <- waitForDiagnostics
-        -- liftIO $ length diags2liquid `shouldBe` 2
         liftIO $ length diags2liquid `shouldBe` 3
         -- liftIO $ show diags2 `shouldBe` ""
         diags3@(d:_) <- waitForDiagnostics

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -2,14 +2,15 @@
 
 module DiagnosticsSpec where
 
-import Control.Lens hiding (List)
-import Control.Monad.IO.Class
+import           Control.Lens hiding (List)
+import           Control.Monad.IO.Class
 import qualified Data.Text as T
-import Language.Haskell.LSP.Test hiding (message)
-import Language.Haskell.LSP.Types as LSP hiding (contents, error )
-import Test.Hspec
-import TestUtils
-import Utils
+import           Haskell.Ide.Engine.MonadFunctions
+import           Language.Haskell.LSP.Test hiding (message)
+import           Language.Haskell.LSP.Types as LSP hiding (contents, error )
+import           Test.Hspec
+import           TestUtils
+import           Utils
 
 -- ---------------------------------------------------------------------
 
@@ -17,8 +18,9 @@ spec :: Spec
 spec = describe "diagnostics providers" $ do
   describe "diagnostics triggers" $ do
     it "runs diagnostics on save" $
-      -- runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
-      runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      -- runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+        logm $ "starting DiagnosticSpec.runs diagnostic on save"
         doc <- openDoc "ApplyRefact2.hs" "haskell"
 
         diags@(reduceDiag:_) <- waitForDiagnostics
@@ -32,23 +34,18 @@ spec = describe "diagnostics providers" $ do
           reduceDiag ^. code `shouldBe` Just "Eta reduce"
           reduceDiag ^. source `shouldBe` Just "hlint"
 
-        -- diags2a <- waitForDiagnostics
-        -- -- liftIO $ show diags2a `shouldBe` ""
-        -- liftIO $ length diags2a `shouldBe` 2
-
-        diags2eg@(eg2:_) <- waitForDiagnostics
-        liftIO $ show diags2eg `shouldBe` ""
-        liftIO $ length diags2eg `shouldBe` 3
-        liftIO $ eg2 ^. source `shouldBe` Just "eg2"
+        diags2a <- waitForDiagnostics
+        -- liftIO $ show diags2a `shouldBe` ""
+        liftIO $ length diags2a `shouldBe` 2
 
         -- docItem <- getDocItem file languageId
         sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
-        diags2hlint <- waitForDiagnostics
-        -- liftIO $ show diags2hlint `shouldBe` ""
-        liftIO $ length diags2hlint `shouldBe` 3
-        diags2liquid <- waitForDiagnostics
-        liftIO $ length diags2liquid `shouldBe` 3
-        -- liftIO $ show diags2 `shouldBe` ""
+        -- diags2hlint <- waitForDiagnostics
+        -- -- liftIO $ show diags2hlint `shouldBe` ""
+        -- liftIO $ length diags2hlint `shouldBe` 3
+        -- diags2liquid <- waitForDiagnostics
+        -- liftIO $ length diags2liquid `shouldBe` 3
+        -- -- liftIO $ show diags2 `shouldBe` ""
         diags3@(d:_) <- waitForDiagnostics
         -- liftIO $ show diags3 `shouldBe` ""
         liftIO $ do

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -36,9 +36,12 @@ spec = describe "diagnostics providers" $ do
         -- docItem <- getDocItem file languageId
         sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
         diags2hlint <- waitForDiagnostics
-        liftIO $ length diags2hlint `shouldBe` 2
+        -- liftIO $ show diags2hlint `shouldBe` ""
+        -- liftIO $ length diags2hlint `shouldBe` 2
+        liftIO $ length diags2hlint `shouldBe` 3
         diags2liquid <- waitForDiagnostics
-        liftIO $ length diags2liquid `shouldBe` 2
+        -- liftIO $ length diags2liquid `shouldBe` 2
+        liftIO $ length diags2liquid `shouldBe` 3
         -- liftIO $ show diags2 `shouldBe` ""
         diags3@(d:_) <- waitForDiagnostics
         -- liftIO $ show diags3 `shouldBe` ""
@@ -49,6 +52,7 @@ spec = describe "diagnostics providers" $ do
           d ^. code `shouldBe` Nothing
           d ^. source `shouldBe` Just "eg2"
           d ^. message `shouldBe` (T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave")
+
   describe "typed hole errors" $
     it "is deferred" $
       runSession hieCommand fullCaps "test/testdata" $ do

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -19,7 +19,7 @@ spec :: Spec
 spec = describe "diagnostics providers" $ do
   describe "diagnostics triggers" $ do
     it "runs diagnostics on save" $
-      runSessionWithConfig codeActionSupportConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
         doc <- openDoc "ApplyRefact2.hs" "haskell"
 
         diags@(reduceDiag:_) <- waitForDiagnostics
@@ -63,8 +63,8 @@ spec = describe "diagnostics providers" $ do
 
 -- ---------------------------------------------------------------------
 
-codeActionSupportConfig :: SessionConfig
-codeActionSupportConfig = Test.defaultConfig
+noLogConfig :: SessionConfig
+noLogConfig = Test.defaultConfig { logMessages = False }
 
 codeActionSupportCaps :: C.ClientCapabilities
 codeActionSupportCaps = def { C._textDocument = Just textDocumentCaps }

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -7,25 +7,26 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = do
   describe "format document" $ do
-    it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Format.hs" "haskell"
       formatDoc doc (FormattingOptions 2 True)
       documentContents doc >>= liftIO . (`shouldBe` formattedDocTabSize2)
-    it "works with custom tab size" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "works with custom tab size" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Format.hs" "haskell"
       formatDoc doc (FormattingOptions 5 True)
       documentContents doc >>= liftIO . (`shouldBe` formattedDocTabSize5)
 
   describe "format range" $ do
-    it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Format.hs" "haskell"
       formatRange doc (FormattingOptions 2 True) (Range (Position 1 0) (Position 3 10))
       documentContents doc >>= liftIO . (`shouldBe` formattedRangeTabSize2)
-    it "works with custom tab size" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "works with custom tab size" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Format.hs" "haskell"
       formatRange doc (FormattingOptions 5 True) (Range (Position 4 0) (Position 7 19))
       documentContents doc >>= liftIO . (`shouldBe` formattedRangeTabSize5)

--- a/test/functional/HaReSpec.hs
+++ b/test/functional/HaReSpec.hs
@@ -9,6 +9,7 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types hiding (error, context)
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = describe "HaRe" $
@@ -59,9 +60,9 @@ getCANamed named = head . mapMaybe test
         test _ = Nothing
 
 execCodeAction :: String -> Range -> T.Text -> T.Text -> IO ()
-execCodeAction fp r n expected = runSession hieCommand fullCaps "test/testdata" $ do
+execCodeAction fp r n expected = runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
   doc <- openDoc fp "haskell"
-  
+
   -- Code actions aren't deferred - need to wait for compilation
   _ <- count 2 waitForDiagnostics
 

--- a/test/functional/HighlightSpec.hs
+++ b/test/functional/HighlightSpec.hs
@@ -7,10 +7,11 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = describe "highlight" $
-  it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
+  it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "Highlight.hs" "haskell"
     _ <- skipManyTill loggingNotification $ count 2 noDiagnostics
     highlights <- getHighlights doc (Position 2 2)

--- a/test/functional/HoverSpec.hs
+++ b/test/functional/HoverSpec.hs
@@ -9,10 +9,11 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = describe "hover" $
-  it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
+  it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "Hover.hs" "haskell"
     _ <- skipManyTill loggingNotification $ count 2 noDiagnostics
     Just hover <- getHover doc (Position 1 19)

--- a/test/functional/LiquidSpec.hs
+++ b/test/functional/LiquidSpec.hs
@@ -19,14 +19,14 @@ import           Utils
 spec :: Spec
 spec = describe "liquid haskell diagnostics" $ do
     it "runs diagnostics on save, no liquid" $
-      -- runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
-      runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      -- runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
         doc <- openDoc "liquid/Evens.hs" "haskell"
 
         diags@(reduceDiag:_) <- waitForDiagnostics
 
         -- liftIO $ show diags `shouldBe` ""
-        liftIO $ putStrLn "a"
+        -- liftIO $ putStrLn "a"
 
         liftIO $ do
           length diags `shouldBe` 2
@@ -35,23 +35,23 @@ spec = describe "liquid haskell diagnostics" $ do
           reduceDiag ^. code `shouldBe` Just "Use negate"
           reduceDiag ^. source `shouldBe` Just "hlint"
 
-        liftIO $ putStrLn "b"
+        -- liftIO $ putStrLn "b"
 
         diags2hlint <- waitForDiagnostics
-        liftIO $ putStrLn "c"
+        -- liftIO $ putStrLn "c"
         -- liftIO $ show diags2hlint `shouldBe` ""
         liftIO $ length diags2hlint `shouldBe` 2
 
         -- docItem <- getDocItem file languageId
         sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
 
-        diags2liquid <- waitForDiagnostics
-        liftIO $ putStrLn "d"
-        liftIO $ length diags2liquid `shouldBe` 3
-        -- liftIO $ show diags2liquid `shouldBe` ""
+        -- diags2liquid <- waitForDiagnostics
+        -- liftIO $ putStrLn "d"
+        -- liftIO $ length diags2liquid `shouldBe` 3
+        -- -- liftIO $ show diags2liquid `shouldBe` ""
 
         diags3@(d:_) <- waitForDiagnostics
-        liftIO $ putStrLn "e"
+        -- liftIO $ putStrLn "e"
         -- liftIO $ show diags3 `shouldBe` ""
         liftIO $ do
           length diags3 `shouldBe` 3

--- a/test/functional/LiquidSpec.hs
+++ b/test/functional/LiquidSpec.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module LiquidSpec where
+
+import           Control.Lens hiding (List)
+import           Control.Monad.IO.Class
+import           Data.Aeson
+import qualified Data.Text as T
+import           Language.Haskell.LSP.Test hiding (message)
+-- import           Language.Haskell.LSP       as LSP
+import           Language.Haskell.LSP.Types as LSP hiding (contents, error )
+import           Haskell.Ide.Engine.LSP.Config
+import           Test.Hspec
+import           TestUtils
+import           Utils
+
+-- ---------------------------------------------------------------------
+
+spec :: Spec
+spec = describe "liquid haskell diagnostics" $ do
+    it "runs diagnostics on save, no liquid" $
+      -- runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+        doc <- openDoc "liquid/Evens.hs" "haskell"
+
+        diags@(reduceDiag:_) <- waitForDiagnostics
+
+        -- liftIO $ show diags `shouldBe` ""
+        liftIO $ putStrLn "a"
+
+        liftIO $ do
+          length diags `shouldBe` 2
+          reduceDiag ^. range `shouldBe` Range (Position 5 18) (Position 5 22)
+          reduceDiag ^. severity `shouldBe` Just DsHint
+          reduceDiag ^. code `shouldBe` Just "Use negate"
+          reduceDiag ^. source `shouldBe` Just "hlint"
+
+        liftIO $ putStrLn "b"
+
+        diags2hlint <- waitForDiagnostics
+        liftIO $ putStrLn "c"
+        -- liftIO $ show diags2hlint `shouldBe` ""
+        liftIO $ length diags2hlint `shouldBe` 2
+
+        -- docItem <- getDocItem file languageId
+        sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
+
+        diags2liquid <- waitForDiagnostics
+        liftIO $ putStrLn "d"
+        liftIO $ length diags2liquid `shouldBe` 3
+        -- liftIO $ show diags2liquid `shouldBe` ""
+
+        diags3@(d:_) <- waitForDiagnostics
+        liftIO $ putStrLn "e"
+        -- liftIO $ show diags3 `shouldBe` ""
+        liftIO $ do
+          length diags3 `shouldBe` 3
+          d ^. range `shouldBe` Range (Position 0 0) (Position 1 0)
+          d ^. severity `shouldBe` Nothing
+          d ^. code `shouldBe` Nothing
+          d ^. source `shouldBe` Just "eg2"
+          d ^. message `shouldBe` (T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave")
+
+    -- ---------------------------------
+
+    it "runs diagnostics on save, with liquid haskell" $
+      runSessionWithConfig noLogConfig hieCommand codeActionSupportCaps "test/testdata" $ do
+      -- runSessionWithConfig logConfig hieCommand codeActionSupportCaps "test/testdata" $ do
+        doc <- openDoc "liquid/Evens.hs" "haskell"
+
+        diags@(reduceDiag:_) <- waitForDiagnostics
+
+        -- liftIO $ show diags `shouldBe` ""
+
+        liftIO $ do
+          length diags `shouldBe` 2
+          reduceDiag ^. range `shouldBe` Range (Position 5 18) (Position 5 22)
+          reduceDiag ^. severity `shouldBe` Just DsHint
+          reduceDiag ^. code `shouldBe` Just "Use negate"
+          reduceDiag ^. source `shouldBe` Just "hlint"
+
+        -- Enable liquid haskell plugin
+        let config =
+             Config
+               { hlintOn             = False
+               , maxNumberOfProblems = 50
+               , liquidOn            = True
+               }
+        sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+        -- docItem <- getDocItem file languageId
+        sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
+        diags2hlint <- waitForDiagnostics
+        -- liftIO $ show diags2hlint `shouldBe` ""
+
+        -- We turned hlint diagnostics off
+        liftIO $ length diags2hlint `shouldBe` 0
+        diags2liquid <- waitForDiagnostics
+        liftIO $ length diags2liquid `shouldBe` 0
+        -- liftIO $ show diags2liquid `shouldBe` ""
+        diags3@(d:_) <- waitForDiagnostics
+        -- liftIO $ show diags3 `shouldBe` ""
+        liftIO $ do
+          length diags3 `shouldBe` 1
+          d ^. range `shouldBe` Range (Position 8 0) (Position 8 7)
+          d ^. severity `shouldBe` Just DsError
+          d ^. code `shouldBe` Nothing
+          d ^. source `shouldBe` Just "liquid"
+          d ^. message `shouldBe` (T.pack "Error: Liquid Type Mismatch\n  Inferred type\n    VV : {v : Int | v == (7 : int)}\n \n  not a subtype of Required type\n    VV : {VV : Int | VV mod 2 == 0}\n \n  In Context")
+
+
+-- ---------------------------------------------------------------------

--- a/test/functional/Main.hs
+++ b/test/functional/Main.hs
@@ -7,4 +7,5 @@ import TestUtils
 main :: IO ()
 main = do
   setupStackFiles
-  withFileLogging "functional.log" $ hspec FunctionalSpec.spec
+  -- withFileLogging "functional.log" $ hspec FunctionalSpec.spec
+  withFileLogging logFilePath $ hspec FunctionalSpec.spec

--- a/test/functional/ReferencesSpec.hs
+++ b/test/functional/ReferencesSpec.hs
@@ -1,15 +1,16 @@
 module ReferencesSpec where
 
+import Control.Lens
+import Control.Monad.IO.Class
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
-import Control.Monad.IO.Class
-import Control.Lens
+import Utils
 
 spec :: Spec
 spec = describe "references" $
-  it "works with definitions" $ runSession hieCommand fullCaps "test/testdata" $ do
+  it "works with definitions" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "References.hs" "haskell"
     let pos = Position 2 7 -- foo = bar <--
     refs <- getReferences doc pos True
@@ -22,7 +23,7 @@ spec = describe "references" $
       , mkRange 2 6 2 9
       ]
   -- TODO: Respect withDeclaration parameter
-  -- it "works without definitions" $ runSession hieCommand fullCaps "test/testdata" $ do
+  -- it "works without definitions" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
   --   doc <- openDoc "References.hs" "haskell"
   --   let pos = Position 2 7 -- foo = bar <--
   --   refs <- getReferences doc pos False

--- a/test/functional/RenameSpec.hs
+++ b/test/functional/RenameSpec.hs
@@ -6,10 +6,11 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = describe "rename" $
-  it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
+  it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "Rename.hs" "haskell"
     rename doc (Position 3 1) "baz" -- foo :: Int -> Int
     documentContents doc >>= liftIO . flip shouldBe expected

--- a/test/functional/SymbolsSpec.hs
+++ b/test/functional/SymbolsSpec.hs
@@ -7,6 +7,7 @@ import Language.Haskell.LSP.Test as Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
+import Utils
 
 spec :: Spec
 spec = describe "document symbols" $ do
@@ -28,7 +29,7 @@ spec = describe "document symbols" $ do
       bR  = Range (Position 9 14) (Position 9 22)
 
   describe "3.10 hierarchical document symbols" $ do
-    it "provides nested data types and constructors" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "provides nested data types and constructors" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Symbols.hs" "haskell"
       Left symbs <- getDocumentSymbols doc
 
@@ -38,7 +39,7 @@ spec = describe "document symbols" $ do
 
       liftIO $ symbs `shouldContain` [myData]
 
-    it "provides nested where functions" $ runSession hieCommand fullCaps "test/testdata" $ do
+    it "provides nested where functions" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Symbols.hs" "haskell"
       Left symbs <- getDocumentSymbols doc
 
@@ -52,7 +53,7 @@ spec = describe "document symbols" $ do
     -- TODO: Test module, imports
 
   describe "pre 3.10 symbol information" $ do
-    it "provides nested data types and constructors" $ runSession hieCommand oldCaps "test/testdata" $ do
+    it "provides nested data types and constructors" $ runSessionWithConfig noLogConfig hieCommand oldCaps "test/testdata" $ do
       doc@(TextDocumentIdentifier testUri) <- openDoc "Symbols.hs" "haskell"
       Right symbs <- getDocumentSymbols doc
 
@@ -62,7 +63,7 @@ spec = describe "document symbols" $ do
 
       liftIO $ symbs `shouldContain` [myData, a, b]
 
-    it "provides nested where functions" $ runSession hieCommand oldCaps "test/testdata" $ do
+    it "provides nested where functions" $ runSessionWithConfig noLogConfig hieCommand oldCaps "test/testdata" $ do
       doc@(TextDocumentIdentifier testUri) <- openDoc "Symbols.hs" "haskell"
       Right symbs <- getDocumentSymbols doc
 

--- a/test/functional/Utils.hs
+++ b/test/functional/Utils.hs
@@ -1,0 +1,18 @@
+module Utils where
+
+import           Data.Default
+import qualified Language.Haskell.LSP.Test as Test
+import           Language.Haskell.LSP.Test hiding (message)
+import qualified Language.Haskell.LSP.Types.Capabilities as C
+
+-- ---------------------------------------------------------------------
+
+noLogConfig :: SessionConfig
+noLogConfig = Test.defaultConfig { logMessages = False }
+
+codeActionSupportCaps :: C.ClientCapabilities
+codeActionSupportCaps = def { C._textDocument = Just textDocumentCaps }
+  where
+    textDocumentCaps = def { C._codeAction = Just codeActionCaps }
+    codeActionCaps = C.CodeActionClientCapabilities (Just True) (Just literalSupport)
+    literalSupport = C.CodeActionLiteralSupport def

--- a/test/functional/Utils.hs
+++ b/test/functional/Utils.hs
@@ -10,6 +10,9 @@ import qualified Language.Haskell.LSP.Types.Capabilities as C
 noLogConfig :: SessionConfig
 noLogConfig = Test.defaultConfig { logMessages = False }
 
+logConfig :: SessionConfig
+logConfig = Test.defaultConfig { logMessages = True }
+
 codeActionSupportCaps :: C.ClientCapabilities
 codeActionSupportCaps = def { C._textDocument = Just textDocumentCaps }
   where

--- a/test/unit/JsonSpec.hs
+++ b/test/unit/JsonSpec.hs
@@ -10,6 +10,7 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Plugin.ApplyRefact
 import           Haskell.Ide.Engine.Plugin.GhcMod
 import           Haskell.Ide.Engine.Plugin.HaRe
+import           Haskell.Ide.Engine.LSP.Config
 
 import           Data.Aeson
 import           Test.Hspec
@@ -42,6 +43,7 @@ jsonSpec = do
   -- Plugin Api types
     prop "IdeErrorCode"      (propertyJsonRoundtrip :: IdeErrorCode -> Bool)
     prop "IdeError"          (propertyJsonRoundtrip :: IdeError -> Bool)
+    prop "Config"            (propertyJsonRoundtrip :: Config -> Bool)
 
 -- ---------------------------------------------------------------------
 

--- a/test/unit/JsonSpec.hs
+++ b/test/unit/JsonSpec.hs
@@ -99,3 +99,6 @@ instance Arbitrary Position where
     Positive l <- arbitrary
     Positive c <- arbitrary
     return $ Position l c
+
+instance Arbitrary Config where
+  arbitrary = Config <$> arbitrary <*> arbitrary <*> arbitrary

--- a/test/unit/LiquidSpec.hs
+++ b/test/unit/LiquidSpec.hs
@@ -113,7 +113,7 @@ spec = do
         -- uri = filePathToUri fp
       r <- runLiquidHaskell fp
       r `shouldBe`
-         ["unset GHC_PACKAGE_PATH;/home/alanz/.cabal/bin/liquid --json \"/home/alanz/mysrc/github/alanz/haskell-ide-engine/test/testdata/liquid/Evens.hs\""
+         ["/home/alanz/.cabal/bin/liquid --json \"/home/alanz/mysrc/github/alanz/haskell-ide-engine/test/testdata/liquid/Evens.hs\""
          ,"ExitFailure 1"
          ,"RESULT\n[{\"start\":{\"line\":9,\"column\":1},\"stop\":{\"line\":9,\"column\":8},\"message\":\"Error: Liquid Type Mismatch\\n  Inferred type\\n    VV : {v : Int | v == (7 : int)}\\n \\n  not a subtype of Required type\\n    VV : {VV : Int | VV mod 2 == 0}\\n \\n  In Context\"}]\n"
          ,""]

--- a/test/unit/LiquidSpec.hs
+++ b/test/unit/LiquidSpec.hs
@@ -8,6 +8,7 @@ import           Data.Monoid ((<>))
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Plugin.Liquid
 import           System.Directory
+import           System.Exit
 import           System.FilePath
 import           Test.Hspec
 
@@ -113,8 +114,9 @@ spec = do
         -- uri = filePathToUri fp
       r <- runLiquidHaskell fp
       r `shouldBe`
-         ["ExitFailure 1"
-         ,"RESULT\n[{\"start\":{\"line\":9,\"column\":1},\"stop\":{\"line\":9,\"column\":8},\"message\":\"Error: Liquid Type Mismatch\\n  Inferred type\\n    VV : {v : Int | v == (7 : int)}\\n \\n  not a subtype of Required type\\n    VV : {VV : Int | VV mod 2 == 0}\\n \\n  In Context\"}]\n"
-         ,""]
+         Just
+           (ExitFailure 1,
+           ["RESULT\n[{\"start\":{\"line\":9,\"column\":1},\"stop\":{\"line\":9,\"column\":8},\"message\":\"Error: Liquid Type Mismatch\\n  Inferred type\\n    VV : {v : Int | v == (7 : int)}\\n \\n  not a subtype of Required type\\n    VV : {VV : Int | VV mod 2 == 0}\\n \\n  In Context\"}]\n"
+           ,""])
 
     -- ---------------------------------

--- a/test/unit/LiquidSpec.hs
+++ b/test/unit/LiquidSpec.hs
@@ -29,6 +29,8 @@ spec = do
       vimFile  `shouldBe` (cwd </> "test/testdata/liquid/.liquid/Evens.hs.vim.annot")
       jsonFile `shouldBe` (cwd </> "test/testdata/liquid/.liquid/Evens.hs.json")
 
+    -- ---------------------------------
+
     it "reads errors from json file" $ do
       let
         uri = filePathToUri $ cwd </> "test/testdata/liquid/Evens.hs"
@@ -46,21 +48,29 @@ spec = do
              }
          ]
 
+    -- ---------------------------------
+
     it "gracefully manages missing json file" $ do
       let
         uri = filePathToUri $ cwd </> "test/testdata/Rename.hs"
       n <- readJsonAnnot uri
       n `shouldBe` Nothing
 
+    -- ---------------------------------
+
     it "parses a vim annotation" $ do
       parseType "6:1-6:10::Main.weAreEven :: \"[{v : GHC.Types.Int | v mod 2 == 0}]\""
         `shouldBe`
           [LE (LP 6 1) (LP 6 10) "[{v : GHC.Types.Int | v mod 2 == 0}]"]
+    -- ---------------------------------
+
     it "parses multiple vim annotations" $ do
       parseType "1:1-1:1::Main.$trModule :: \"GHC.Types.Module\"\n6:1-6:10::Main.weAreEven :: \"[{v : GHC.Types.Int | v mod 2 == 0}]\""
         `shouldBe`
           [LE (LP 1 1) (LP 1 1) "GHC.Types.Module"
           ,LE (LP 6 1) (LP 6 10) "[{v : GHC.Types.Int | v mod 2 == 0}]"]
+
+    -- ---------------------------------
 
     it "reads types from vim.annot file" $ do
       let
@@ -74,6 +84,8 @@ spec = do
           ,LE (LP 6 1) (LP 6 10) "[{v : GHC.Types.Int | v mod 2 == 0}]"]
       length ts `shouldBe` 38
 
+    -- ---------------------------------
+
     it "reads types from vim.annot file 2" $ do
       let
         uri = filePathToUri $ cwd </> "test/testdata/liquid/Evens.hs"
@@ -84,8 +96,25 @@ spec = do
           ,LE (LP 6 1) (LP 6 10) "[{v : GHC.Types.Int | v mod 2 == 0}]"]
       length ts `shouldBe` 38
 
+    -- ---------------------------------
+
     it "gracefully manages missing vim.annot file" $ do
       let
         uri = filePathToUri $ cwd </> "test/testdata/Rename.hs"
       n <- readVimAnnot uri
       n `shouldBe` Nothing
+
+    -- ---------------------------------
+
+    it "runs the liquid haskell exe" $ do
+      let
+        fp = cwd </> "test/testdata/liquid/Evens.hs"
+        -- fp = "/home/alanz/tmp/haskell-proc-play/Evens.hs"
+        -- uri = filePathToUri fp
+      r <- runLiquidHaskell fp
+      r `shouldBe`
+         ["unset GHC_PACKAGE_PATH;/home/alanz/.cabal/bin/liquid --json \"/home/alanz/mysrc/github/alanz/haskell-ide-engine/test/testdata/liquid/Evens.hs\""
+         ,"ExitFailure 1"
+         ,"RESULT\n[{\"start\":{\"line\":9,\"column\":1},\"stop\":{\"line\":9,\"column\":8},\"message\":\"Error: Liquid Type Mismatch\\n  Inferred type\\n    VV : {v : Int | v == (7 : int)}\\n \\n  not a subtype of Required type\\n    VV : {VV : Int | VV mod 2 == 0}\\n \\n  In Context\"}]\n"
+         ,""]
+    -- ---------------------------------

--- a/test/unit/LiquidSpec.hs
+++ b/test/unit/LiquidSpec.hs
@@ -113,8 +113,8 @@ spec = do
         -- uri = filePathToUri fp
       r <- runLiquidHaskell fp
       r `shouldBe`
-         ["/home/alanz/.cabal/bin/liquid --json \"/home/alanz/mysrc/github/alanz/haskell-ide-engine/test/testdata/liquid/Evens.hs\""
-         ,"ExitFailure 1"
+         ["ExitFailure 1"
          ,"RESULT\n[{\"start\":{\"line\":9,\"column\":1},\"stop\":{\"line\":9,\"column\":8},\"message\":\"Error: Liquid Type Mismatch\\n  Inferred type\\n    VV : {v : Int | v == (7 : int)}\\n \\n  not a subtype of Required type\\n    VV : {VV : Int | VV mod 2 == 0}\\n \\n  In Context\"}]\n"
          ,""]
+
     -- ---------------------------------

--- a/test/utils/TestUtils.hs
+++ b/test/utils/TestUtils.hs
@@ -10,6 +10,7 @@ module TestUtils
   , makeRequest
   , runIGM
   , ghc84
+  , logFilePath
   , hieCommand
   , hieCommandVomit
   , hieCommandExamplePlugin
@@ -132,6 +133,9 @@ stackYaml =
   "stack-8.0.2.yaml"
 #endif
 
+logFilePath :: String
+logFilePath = "functional-hie-" ++ stackYaml ++ ".log"
+
 -- | The command to execute the version of hie for the current compiler.
 -- Make sure to disable the STACK_EXE and GHC_PACKAGE_PATH environment
 -- variables or else it messes up -- ghc-mod.
@@ -139,7 +143,7 @@ stackYaml =
 -- run with `stack test`
 hieCommand :: String
 hieCommand = "stack exec --no-stack-exe --no-ghc-package-path --stack-yaml=" ++ stackYaml ++
-             " hie -- -d -l test-logs/functional-hie-" ++ stackYaml ++ ".log"
+             " hie -- -d -l test-logs/" ++ logFilePath
 
 hieCommandVomit :: String
 hieCommandVomit = hieCommand ++ " --vomit"


### PR DESCRIPTION
Add a plugin for liquid haskell.

This is disabled by default, and has to be enabled via a config setting (similar to `hlintOn`)

The `diagnostic provider` interface has changed, to include the concept of an async provider, which can run an external process, and then send results when it finishes, without blocking the dispatcher.

