### PR TITLE
Fix circle ci work dir caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,9 @@ defaults: &defaults
 
     - restore_cache:
         keys:
-          - stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
-          - stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
-          - stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
-          - stack-work-dirs-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+          - stack-cache-07-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
+          - stack-cache-07-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+          - stack-cache-07-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
 
     - run:
         name: Stack setup
@@ -52,10 +51,12 @@ defaults: &defaults
         command: stack --stack-yaml=${STACK_FILE} exec hoogle generate
 
     - save_cache:
-        key: stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
+        key: stack-cache-07-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "resolver.txt" }}
         paths:
           - ~/.stack
           - ~/.cache
+          - ~/build/.stack-work
+          - ~/build/hie-plugin-api/.stack-work
 
     - run:
         name: Test
@@ -66,20 +67,18 @@ defaults: &defaults
         path: test-logs
 
     - save_cache:
-        key: stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
+        key: stack-cache-07-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
         paths:
           - ~/.stack
           - ~/.cache
+          - ~/build/.stack-work
+          - ~/build/hie-plugin-api/.stack-work
 
     - save_cache:
-        key: stack-cache-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
+        key: stack-cache-07-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}-{{ checksum "all-cabal.txt" }}
         paths:
           - ~/.stack
           - ~/.cache
-
-    - save_cache:
-        key: stack-work-dirs-06-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "stack-build.txt" }}
-        paths:
           - ~/build/.stack-work
           - ~/build/hie-plugin-api/.stack-work
 


### PR DESCRIPTION
The cache keys are cascading fallbacks, so .stack/.cache/.stack-work should all be cached at once