### PR TITLE
Improved suggestions for mispelled variables

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -251,11 +251,11 @@ test-suite func-test
                      , DiagnosticsSpec
                      , FormatSpec
                      , FunctionalCodeActionsSpec
+                     , FunctionalLiquidSpec
                      , FunctionalSpec
                      , HaReSpec
                      , HighlightSpec
                      , HoverSpec
-                     , LiquidSpec
                      , ReferencesSpec
                      , RenameSpec
                      , SymbolsSpec

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -475,7 +475,7 @@ codeActionProvider' supportsDocChanges _ docId _ _ context =
       | otherwise = substitutions
       where
         onlyErrorFuncs = null
-                       $ (map fsName subs) \\ ["undefined", "error", "errorWithoutStackTrace"]
+                       $ map fsName subs \\ ["undefined", "error", "errorWithoutStackTrace"]
         substitutions = map mkHoleAction subs
         suggestions = map mkHoleAction bindings
         mkHoleAction (FunctionSig name (TypeDef sig)) = codeAction
@@ -496,18 +496,19 @@ codeActionProvider' supportsDocChanges _ docId _ _ context =
 
 extractRenamableTerms :: T.Text -> [T.Text]
 extractRenamableTerms msg
-  | "not in scope:" `T.isInfixOf` head noBullets = go msg
+  -- Account for both "Variable not in scope" and "Not in scope"
+  | "ot in scope:" `T.isInfixOf` msg = extractSuggestions msg
   | otherwise = []
-
-  where noBullets = T.lines $ T.replace "• " "" msg
-        -- Extract everything in between ‘ ’
-        go t
-          | t == "" = []
-          | "‘" `T.isPrefixOf` t =
-            let rest = T.tail t
-                x = T.takeWhile (/= '’') rest
-              in x:go rest
-          | otherwise = go (T.dropWhile (/= '‘') t)
+  where
+    extractSuggestions = map getEnclosed
+                       . concatMap singleSuggestions
+                       . filter isKnownSymbol
+                       . T.lines
+    singleSuggestions = T.splitOn "), " -- Each suggestion is comma delimited
+    isKnownSymbol t = " (imported from" `T.isInfixOf` t  || " (line " `T.isInfixOf` t
+    getEnclosed = T.dropWhile (== '‘')
+                . T.dropWhileEnd (== '’')
+                . T.dropAround (\c -> c /= '‘' && c /= '’')
 
 extractRedundantImport :: T.Text -> Maybe T.Text
 extractRedundantImport msg =

--- a/test/functional/FunctionalLiquidSpec.hs
+++ b/test/functional/FunctionalLiquidSpec.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module LiquidSpec where
+module FunctionalLiquidSpec where
 
 import           Control.Lens hiding (List)
 import           Control.Monad.IO.Class

--- a/test/unit/CodeActionsSpec.hs
+++ b/test/unit/CodeActionsSpec.hs
@@ -39,11 +39,11 @@ spec = do
     it "doen't pick up irrelvant messages" $
       let msg = "The import of ‘Control.Exception’ is redundant\n      except perhaps to import instances from ‘Control.Exception’"
         in extractRenamableTerms msg `shouldBe` []
-      
+
     it "picks up variable not in scope with multiple suggestions" $
       let msg = "• Variable not in scope: uri\n• Perhaps you meant one of these:\n‘J.uri’ (imported from Language.Haskell.LSP.Types),\ndata constructor ‘J.Uri’ (imported from Language.Haskell.LSP.Types)"
         in extractRenamableTerms msg `shouldBe` ["J.uri", "J.Uri"]
-    
+
     it "picks up data constructors" $
       let msg = "• Data constructor not in scope:\n    MarkupContent :: J.MarkupKind -> Maybe T.Text -> t0\n• Perhaps you meant ‘J.MarkupContent’ (imported from Language.Haskell.LSP.Types)"
         in extractRenamableTerms msg `shouldBe` ["J.MarkupContent"]
@@ -51,10 +51,31 @@ spec = do
     it "returns nothing when there's no suggetsions" $
       let msg = "Variable not in scope:\n  fromJust\n    :: Maybe (Maybe (List CommandOrCodeAction)) -> Maybe (List a)"
         in extractRenamableTerms msg `shouldBe` []
+
     it "picks up variables not in scope on new line" $
       let msg = "• Variable not in scope:\n    forM_ :: [CodeAction] -> (s0 -> Expectation) -> IO a0\n• Perhaps you meant ‘iforM_’ (imported from Control.Lens)"
         in extractRenamableTerms msg `shouldBe` ["iforM_"]
-  
+
+    it "picks up qualified functions" $
+      let msg = "    Not in scope: ‘Foo.printResul’\n\
+                \    Perhaps you meant one of these:\n\
+                \      ‘Foo.printResult’ (imported from Mod.Bar.Foo),\n\
+                \      ‘Foo.formatResult’ (imported from Mod.Bar.Foo)\n\
+                \    Module ‘Mod.Bar.Foo’ does not export ‘printResul’"
+        in extractRenamableTerms msg `shouldBe` ["Foo.printResult", "Foo.formatResult"]
+
+    it "picks up local definitions" $
+      let msg = "• Variable not in scope: as :: f Foo\n\
+                \    • Perhaps you meant one of these:\n\
+                \        ‘ast’ (line 235)"
+        in extractRenamableTerms msg `shouldBe` ["ast"]
+
+    it "picks up definitions in same line" $
+      let msg = "• Variable not in scope: as :: f Foo\n\
+                \    • Perhaps you meant one of these:\n\
+                \        ‘ast’ (line 235), ‘abs’ (imported from Prelude)"
+        in extractRenamableTerms msg `shouldBe` ["ast", "abs"]
+
   describe "typed holes" $ do
     it "picks them up" $ do
       msg <- T.readFile "test/testdata/typedHoleDiag.txt"


### PR DESCRIPTION
This improves the code action for correcting typos, it now picks
suggestions consisting of qualified names and filters out things that
are not actuallly suggestions.

I took again the liberty of renaming a test module so that I could run the tests from ghci.