### PR TITLE
Update to haskell-lsp-0.7.0.0, lsp-test-0.3.0.0

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -270,7 +270,7 @@ test-suite func-test
                      , data-default
                      , directory
                      , filepath
-                     , lsp-test >= 0.2.1
+                     , lsp-test >= 0.3.0
                      , haskell-ide-engine
                      -- , hie-test-utils
                      , hie-plugin-api

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -18,7 +18,7 @@ extra-deps:
 - ghc-exactprint-0.5.6.1
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- lsp-test-0.2.1.0
+- lsp-test-0.3.0.0
 - hlint-2.0.11
 # - hlint-2.1.8
 - hsimport-0.8.6

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -19,7 +19,7 @@ extra-deps:
 - haddock-api-2.18.1
 - haddock-library-1.4.4
 - hsimport-0.8.6
-- lsp-test-0.2.1.0
+- lsp-test-0.3.0.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -18,7 +18,7 @@ extra-deps:
 - haddock-library-1.6.0
 - hlint-2.1.8
 - hsimport-0.8.6
-- lsp-test-0.2.1.0
+- lsp-test-0.3.0.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - haddock-api-2.20.0
 - haddock-library-1.6.0
 - hsimport-0.8.6
-- lsp-test-0.2.1.0
+- lsp-test-0.3.0.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
 - haddock-api-2.20.0
 - hsimport-0.8.6
 - monad-memo-0.4.1
-- lsp-test-0.2.1.0
+- lsp-test-0.3.0.0
 - semigroupoids-5.2.2
 - syz-0.2.0.0
 - temporary-1.2.1.1

--- a/test/functional/CommandSpec.hs
+++ b/test/functional/CommandSpec.hs
@@ -13,7 +13,7 @@ import Utils
 
 spec :: Spec
 spec = describe "commands" $ do
-  it "are prefixed" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/" $ do
+  it "are prefixed" $ runSession hieCommand fullCaps "test/testdata/" $ do
     ResponseMessage _ _ (Just res) Nothing <- initializeResponse
     let List cmds = res ^. LSP.capabilities . executeCommandProvider . _Just . commands
         f x = (T.length (T.takeWhile isNumber x) >= 1) && (T.count ":" x >= 2)
@@ -21,7 +21,7 @@ spec = describe "commands" $ do
       cmds `shouldSatisfy` all f
       cmds `shouldNotSatisfy` null
 
-  it "get de-prefixed" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/" $ do
+  it "get de-prefixed" $ runSession hieCommand fullCaps "test/testdata/" $ do
     ResponseMessage _ _ _ (Just err) <- request
             WorkspaceExecuteCommand
             (ExecuteCommandParams "1234:package:add" (Just (List []))) :: Session ExecuteCommandResponse

--- a/test/functional/CommandSpec.hs
+++ b/test/functional/CommandSpec.hs
@@ -9,7 +9,6 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types as LSP
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "commands" $ do

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -9,7 +9,6 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types hiding (applyEdit)
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "completions" $ do

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -13,7 +13,7 @@ import Utils
 
 spec :: Spec
 spec = describe "completions" $ do
-  it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/completion" $ do
+  it "works" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
@@ -28,7 +28,7 @@ spec = describe "completions" $ do
       item ^. detail `shouldBe` Just "String -> IO ()\nPrelude"
   --TODO: Replay session
 
-  it "completes imports" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/completion" $ do
+  it "completes imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
@@ -42,7 +42,7 @@ spec = describe "completions" $ do
       item ^. detail `shouldBe` Just "Data.Maybe"
       item ^. kind `shouldBe` Just CiModule
 
-  it "completes qualified imports" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/completion" $ do
+  it "completes qualified imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -6,7 +6,7 @@ import Control.Monad.IO.Class
 import Control.Lens
 import Language.Haskell.LSP.Test
 -- import Language.Haskell.LSP.Test.Replay
-import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types hiding (applyEdit)
 import Test.Hspec
 import TestUtils
 import Utils

--- a/test/functional/DeferredSpec.hs
+++ b/test/functional/DeferredSpec.hs
@@ -22,7 +22,7 @@ import Utils
 spec :: Spec
 spec = do
   describe "deferred responses" $ do
-    it "do not affect hover requests" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "do not affect hover requests" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "FuncTest.hs" "haskell"
 
       id1 <- sendRequest TextDocumentHover (TextDocumentPositionParams doc (Position 4 2))
@@ -92,13 +92,13 @@ spec = do
                      }
                    ]
 
-    it "instantly respond to failed modules with no cache" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "instantly respond to failed modules with no cache" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "FuncTestFail.hs" "haskell"
 
       symbols <- request TextDocumentDocumentSymbol (DocumentSymbolParams doc) :: Session DocumentSymbolsResponse
       liftIO $ symbols ^. result `shouldBe` Just (DSDocumentSymbols mempty)
 
-    it "returns hints as diagnostics" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "returns hints as diagnostics" $ runSession hieCommand fullCaps "test/testdata" $ do
       _ <- openDoc "FuncTest.hs" "haskell"
 
       cwd <- liftIO getCurrentDirectory
@@ -136,7 +136,7 @@ spec = do
 
   describe "multi-server setup" $
     it "doesn't have clashing commands on two servers" $ do
-      let getCommands = runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+      let getCommands = runSession hieCommand fullCaps "test/testdata" $ do
               rsp <- initializeResponse
               let uuids = rsp ^? result . _Just . capabilities . executeCommandProvider . _Just . commands
               return $ fromJust uuids
@@ -148,8 +148,8 @@ spec = do
 
   describe "multiple main modules" $
     it "Can load one file at a time, when more than one Main module exists"
-                                  -- $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
-                                  $ runSessionWithConfig noLogConfig hieCommandVomit fullCaps "test/testdata" $ do
+                                  -- $ runSession hieCommand fullCaps "test/testdata" $ do
+                                  $ runSession hieCommandVomit fullCaps "test/testdata" $ do
       _doc <- openDoc "ApplyRefact2.hs" "haskell"
       _diagsRspHlint <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification
       diagsRspGhc   <- skipManyTill anyNotification message :: Session PublishDiagnosticsNotification

--- a/test/functional/DeferredSpec.hs
+++ b/test/functional/DeferredSpec.hs
@@ -17,7 +17,6 @@ import Test.Hspec
 import System.Directory
 import System.FilePath
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = do

--- a/test/functional/DefinitionSpec.hs
+++ b/test/functional/DefinitionSpec.hs
@@ -7,7 +7,6 @@ import Language.Haskell.LSP.Types
 import System.Directory
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "definitions" $ do

--- a/test/functional/DefinitionSpec.hs
+++ b/test/functional/DefinitionSpec.hs
@@ -11,27 +11,27 @@ import Utils
 
 spec :: Spec
 spec = describe "definitions" $ do
-  it "goto's symbols" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+  it "goto's symbols" $ runSession hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "References.hs" "haskell"
     defs <- getDefinitions doc (Position 7 8)
     let expRange = Range (Position 4 0) (Position 4 3)
     liftIO $ defs `shouldBe` [Location (doc ^. uri) expRange]
 
-  it "goto's imported modules" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/definition" $ do
+  it "goto's imported modules" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
     doc <- openDoc "Foo.hs" "haskell"
     defs <- getDefinitions doc (Position 2 8)
     liftIO $ do
       fp <- canonicalizePath "test/testdata/definition/Bar.hs"
       defs `shouldBe` [Location (filePathToUri fp) zeroRange]
 
-  it "goto's exported modules" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/definition" $ do
+  it "goto's exported modules" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
     doc <- openDoc "Foo.hs" "haskell"
     defs <- getDefinitions doc (Position 0 15)
     liftIO $ do
       fp <- canonicalizePath "test/testdata/definition/Bar.hs"
       defs `shouldBe` [Location (filePathToUri fp) zeroRange]
 
-  it "goto's imported modules that are loaded" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/definition" $ do
+  it "goto's imported modules that are loaded" $ runSession hieCommand fullCaps "test/testdata/definition" $ do
     doc <- openDoc "Foo.hs" "haskell"
     _ <- openDoc "Bar.hs" "haskell"
     defs <- getDefinitions doc (Position 2 8)
@@ -40,7 +40,7 @@ spec = describe "definitions" $ do
       defs `shouldBe` [Location (filePathToUri fp) zeroRange]
 
   it "goto's imported modules that are loaded, and then closed" $
-    runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/definition" $ do
+    runSession hieCommand fullCaps "test/testdata/definition" $ do
       doc <- openDoc "Foo.hs" "haskell"
       otherDoc <- openDoc "Bar.hs" "haskell"
       closeDoc otherDoc

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -18,7 +18,7 @@ spec :: Spec
 spec = describe "diagnostics providers" $ do
   describe "diagnostics triggers" $ do
     it "runs diagnostics on save" $
-      runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      runSession hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
       -- runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
         logm $ "starting DiagnosticSpec.runs diagnostic on save"
         doc <- openDoc "ApplyRefact2.hs" "haskell"
@@ -58,7 +58,7 @@ spec = describe "diagnostics providers" $ do
 
   describe "typed hole errors" $
     it "is deferred" $
-      runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+      runSession hieCommand fullCaps "test/testdata" $ do
         _ <- openDoc "TypedHoles.hs" "haskell"
         [diag] <- waitForDiagnosticsSource "ghcmod"
         liftIO $ diag ^. severity `shouldBe` Just DsWarning

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -7,7 +7,6 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = do

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -12,21 +12,21 @@ import Utils
 spec :: Spec
 spec = do
   describe "format document" $ do
-    it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Format.hs" "haskell"
       formatDoc doc (FormattingOptions 2 True)
       documentContents doc >>= liftIO . (`shouldBe` formattedDocTabSize2)
-    it "works with custom tab size" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "works with custom tab size" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Format.hs" "haskell"
       formatDoc doc (FormattingOptions 5 True)
       documentContents doc >>= liftIO . (`shouldBe` formattedDocTabSize5)
 
   describe "format range" $ do
-    it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Format.hs" "haskell"
       formatRange doc (FormattingOptions 2 True) (Range (Position 1 0) (Position 3 10))
       documentContents doc >>= liftIO . (`shouldBe` formattedRangeTabSize2)
-    it "works with custom tab size" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "works with custom tab size" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Format.hs" "haskell"
       formatRange doc (FormattingOptions 5 True) (Range (Position 4 0) (Position 7 19))
       documentContents doc >>= liftIO . (`shouldBe` formattedRangeTabSize5)

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -23,7 +23,7 @@ import           Utils
 spec :: Spec
 spec = describe "code actions" $ do
   describe "hlint suggestions" $ do
-    it "provides 3.8 code actions" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "provides 3.8 code actions" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "ApplyRefact2.hs" "haskell"
 
       diags@(reduceDiag:_) <- waitForDiagnostics
@@ -47,7 +47,7 @@ spec = describe "code actions" $ do
 
       noDiagnostics
 
-    it "falls back to pre 3.8 code actions" $ runSessionWithConfig noLogConfig hieCommand noLiteralCaps "test/testdata" $ do
+    it "falls back to pre 3.8 code actions" $ runSession hieCommand noLiteralCaps "test/testdata" $ do
       doc <- openDoc "ApplyRefact2.hs" "haskell"
 
       _ <- waitForDiagnostics
@@ -65,7 +65,7 @@ spec = describe "code actions" $ do
       noDiagnostics
 
   describe "rename suggestions" $ do
-    it "works" $ runSessionWithConfig noLogConfig hieCommand noLiteralCaps "test/testdata" $ do
+    it "works" $ runSession hieCommand noLiteralCaps "test/testdata" $ do
       doc <- openDoc "CodeActionRename.hs" "haskell"
 
       _ <- waitForDiagnosticsSource "ghcmod"
@@ -76,7 +76,7 @@ spec = describe "code actions" $ do
       x:_ <- T.lines <$> documentContents doc
       liftIO $ x `shouldBe` "main = putStrLn \"hello\""
     it "doesn't give both documentChanges and changes" $
-      runSessionWithConfig noLogConfig hieCommand noLiteralCaps "test/testdata" $ do
+      runSession hieCommand noLiteralCaps "test/testdata" $ do
         doc <- openDoc "CodeActionRename.hs" "haskell"
 
         _ <- waitForDiagnosticsSource "ghcmod"
@@ -94,7 +94,7 @@ spec = describe "code actions" $ do
         liftIO $ x `shouldBe` "foo = putStrLn \"world\""
 
   it "provides import suggestions and 3.8 code action kinds" $
-    runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "CodeActionImport.hs" "haskell"
 
       -- ignore the first empty hlint diagnostic publish
@@ -122,7 +122,7 @@ spec = describe "code actions" $ do
 
 
   describe "add package suggestions" $ do
-    it "adds to .cabal files" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/addPackageTest/cabal" $ do
+    it "adds to .cabal files" $ runSession hieCommand fullCaps "test/testdata/addPackageTest/cabal" $ do
       doc <- openDoc "AddPackage.hs" "haskell"
 
       -- ignore the first empty hlint diagnostic publish
@@ -143,7 +143,7 @@ spec = describe "code actions" $ do
       liftIO $ T.lines contents `shouldSatisfy` \x -> any (\l -> "text -any" `T.isSuffixOf` (x !! l)) [15, 16]
 
     it "adds to hpack package.yaml files" $
-      runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/addPackageTest/hpack" $ do
+      runSession hieCommand fullCaps "test/testdata/addPackageTest/hpack" $ do
         doc <- openDoc "app/Asdf.hs" "haskell"
 
         -- ignore the first empty hlint diagnostic publish
@@ -170,7 +170,7 @@ spec = describe "code actions" $ do
 
   describe "redundant import code actions" $ do
     it "remove solitary redundant imports" $
-      runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata/redundantImportTest/" $ do
+      runSession hieCommand fullCaps "test/testdata/redundantImportTest/" $ do
         doc <- openDoc "src/CodeActionRedundant.hs" "haskell"
 
         -- ignore the first empty hlint diagnostic publish
@@ -196,7 +196,7 @@ spec = describe "code actions" $ do
         -- the server
         contents <- documentContents doc
         liftIO $ contents `shouldBe` "main :: IO ()\nmain = putStrLn \"hello\""
-    it "doesn't touch other imports" $ runSessionWithConfig noLogConfig hieCommand noLiteralCaps "test/testdata/redundantImportTest/" $ do
+    it "doesn't touch other imports" $ runSession hieCommand noLiteralCaps "test/testdata/redundantImportTest/" $ do
       doc <- openDoc "src/MultipleImports.hs" "haskell"
 
       _ <- count 2 waitForDiagnostics
@@ -215,7 +215,7 @@ spec = describe "code actions" $ do
 
   describe "typed hole code actions" $ do
       it "works" $
-        runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+        runSession hieCommand fullCaps "test/testdata" $ do
           doc <- openDoc "TypedHoles.hs" "haskell"
           _ <- waitForDiagnosticsSource "ghcmod"
           cas <- map (\(CACodeAction x)-> x) <$> getAllCodeActions doc
@@ -245,7 +245,7 @@ spec = describe "code actions" $ do
             \foo x = " <> suggestion
 
       it "shows more suggestions" $
-        runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+        runSession hieCommand fullCaps "test/testdata" $ do
           doc <- openDoc "TypedHoles2.hs" "haskell"
           _ <- waitForDiagnosticsSource "ghcmod"
           cas <- map (\(CACodeAction x)-> x) <$> getAllCodeActions doc

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -14,7 +14,7 @@ import           Data.Monoid ((<>))
 import qualified Data.Text as T
 import           Language.Haskell.LSP.Test as Test
 import qualified Language.Haskell.LSP.Types as LSP
-import           Language.Haskell.LSP.Types as LSP hiding (contents, error, message)
+import           Language.Haskell.LSP.Types as LSP hiding (contents, error, message, executeCommand)
 import qualified Language.Haskell.LSP.Types.Capabilities as C
 import           Test.Hspec
 import           TestUtils

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -18,7 +18,6 @@ import           Language.Haskell.LSP.Types as LSP hiding (contents, error, mess
 import qualified Language.Haskell.LSP.Types.Capabilities as C
 import           Test.Hspec
 import           TestUtils
-import           Utils
 
 spec :: Spec
 spec = describe "code actions" $ do

--- a/test/functional/HaReSpec.hs
+++ b/test/functional/HaReSpec.hs
@@ -60,7 +60,7 @@ getCANamed named = head . mapMaybe test
         test _ = Nothing
 
 execCodeAction :: String -> Range -> T.Text -> T.Text -> IO ()
-execCodeAction fp r n expected = runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+execCodeAction fp r n expected = runSession hieCommand fullCaps "test/testdata" $ do
   doc <- openDoc fp "haskell"
 
   -- Code actions aren't deferred - need to wait for compilation

--- a/test/functional/HaReSpec.hs
+++ b/test/functional/HaReSpec.hs
@@ -9,7 +9,6 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types hiding (error, context)
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "HaRe" $

--- a/test/functional/HighlightSpec.hs
+++ b/test/functional/HighlightSpec.hs
@@ -11,7 +11,7 @@ import Utils
 
 spec :: Spec
 spec = describe "highlight" $
-  it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+  it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "Highlight.hs" "haskell"
     _ <- skipManyTill loggingNotification $ count 2 noDiagnostics
     highlights <- getHighlights doc (Position 2 2)

--- a/test/functional/HighlightSpec.hs
+++ b/test/functional/HighlightSpec.hs
@@ -7,7 +7,6 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "highlight" $

--- a/test/functional/HoverSpec.hs
+++ b/test/functional/HoverSpec.hs
@@ -13,7 +13,7 @@ import Utils
 
 spec :: Spec
 spec = describe "hover" $
-  it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+  it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "Hover.hs" "haskell"
     _ <- skipManyTill loggingNotification $ count 2 noDiagnostics
     Just h <- getHover doc (Position 1 19)

--- a/test/functional/HoverSpec.hs
+++ b/test/functional/HoverSpec.hs
@@ -16,9 +16,9 @@ spec = describe "hover" $
   it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "Hover.hs" "haskell"
     _ <- skipManyTill loggingNotification $ count 2 noDiagnostics
-    Just hover <- getHover doc (Position 1 19)
+    Just h <- getHover doc (Position 1 19)
     liftIO $ do
-      hover ^. range `shouldBe` Just (Range (Position 1 16) (Position 1 19))
+      h ^. range `shouldBe` Just (Range (Position 1 16) (Position 1 19))
       let hasType (CodeString (LanguageString "haskell" "sum :: [Int] -> Int")) = True
           hasType _ = False
 
@@ -26,5 +26,5 @@ spec = describe "hover" $
 
           hasDoc (PlainString s) = sumDoc `T.isInfixOf` s
           hasDoc _               = False
-      hover ^. contents `shouldSatisfy` any hasType
-      hover ^. contents `shouldSatisfy` any hasDoc
+      h ^. contents `shouldSatisfy` any hasType
+      h ^. contents `shouldSatisfy` any hasDoc

--- a/test/functional/HoverSpec.hs
+++ b/test/functional/HoverSpec.hs
@@ -9,7 +9,6 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "hover" $

--- a/test/functional/LiquidSpec.hs
+++ b/test/functional/LiquidSpec.hs
@@ -19,7 +19,7 @@ import           Utils
 spec :: Spec
 spec = describe "liquid haskell diagnostics" $ do
     it "runs diagnostics on save, no liquid" $
-      runSessionWithConfig noLogConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
+      runSession hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
       -- runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
         doc <- openDoc "liquid/Evens.hs" "haskell"
 
@@ -64,7 +64,7 @@ spec = describe "liquid haskell diagnostics" $ do
     -- ---------------------------------
 
     it "runs diagnostics on save, with liquid haskell" $
-      runSessionWithConfig noLogConfig hieCommand codeActionSupportCaps "test/testdata" $ do
+      runSession hieCommand codeActionSupportCaps "test/testdata" $ do
       -- runSessionWithConfig logConfig hieCommand codeActionSupportCaps "test/testdata" $ do
         doc <- openDoc "liquid/Evens.hs" "haskell"
 

--- a/test/functional/ReferencesSpec.hs
+++ b/test/functional/ReferencesSpec.hs
@@ -10,7 +10,7 @@ import Utils
 
 spec :: Spec
 spec = describe "references" $
-  it "works with definitions" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+  it "works with definitions" $ runSession hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "References.hs" "haskell"
     let pos = Position 2 7 -- foo = bar <--
     refs <- getReferences doc pos True
@@ -23,7 +23,7 @@ spec = describe "references" $
       , mkRange 2 6 2 9
       ]
   -- TODO: Respect withDeclaration parameter
-  -- it "works without definitions" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+  -- it "works without definitions" $ runSession hieCommand fullCaps "test/testdata" $ do
   --   doc <- openDoc "References.hs" "haskell"
   --   let pos = Position 2 7 -- foo = bar <--
   --   refs <- getReferences doc pos False

--- a/test/functional/ReferencesSpec.hs
+++ b/test/functional/ReferencesSpec.hs
@@ -6,7 +6,6 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "references" $

--- a/test/functional/RenameSpec.hs
+++ b/test/functional/RenameSpec.hs
@@ -6,7 +6,6 @@ import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types hiding (rename)
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "rename" $

--- a/test/functional/RenameSpec.hs
+++ b/test/functional/RenameSpec.hs
@@ -10,7 +10,7 @@ import Utils
 
 spec :: Spec
 spec = describe "rename" $
-  it "works" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+  it "works" $ runSession hieCommand fullCaps "test/testdata" $ do
     doc <- openDoc "Rename.hs" "haskell"
     rename doc (Position 3 1) "baz" -- foo :: Int -> Int
     documentContents doc >>= liftIO . flip shouldBe expected

--- a/test/functional/RenameSpec.hs
+++ b/test/functional/RenameSpec.hs
@@ -3,7 +3,7 @@ module RenameSpec where
 
 import Control.Monad.IO.Class
 import Language.Haskell.LSP.Test
-import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types hiding (rename)
 import Test.Hspec
 import TestUtils
 import Utils

--- a/test/functional/SymbolsSpec.hs
+++ b/test/functional/SymbolsSpec.hs
@@ -29,7 +29,7 @@ spec = describe "document symbols" $ do
       bR  = Range (Position 9 14) (Position 9 22)
 
   describe "3.10 hierarchical document symbols" $ do
-    it "provides nested data types and constructors" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "provides nested data types and constructors" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Symbols.hs" "haskell"
       Left symbs <- getDocumentSymbols doc
 
@@ -39,7 +39,7 @@ spec = describe "document symbols" $ do
 
       liftIO $ symbs `shouldContain` [myData]
 
-    it "provides nested where functions" $ runSessionWithConfig noLogConfig hieCommand fullCaps "test/testdata" $ do
+    it "provides nested where functions" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "Symbols.hs" "haskell"
       Left symbs <- getDocumentSymbols doc
 
@@ -53,7 +53,7 @@ spec = describe "document symbols" $ do
     -- TODO: Test module, imports
 
   describe "pre 3.10 symbol information" $ do
-    it "provides nested data types and constructors" $ runSessionWithConfig noLogConfig hieCommand oldCaps "test/testdata" $ do
+    it "provides nested data types and constructors" $ runSession hieCommand oldCaps "test/testdata" $ do
       doc@(TextDocumentIdentifier testUri) <- openDoc "Symbols.hs" "haskell"
       Right symbs <- getDocumentSymbols doc
 
@@ -63,7 +63,7 @@ spec = describe "document symbols" $ do
 
       liftIO $ symbs `shouldContain` [myData, a, b]
 
-    it "provides nested where functions" $ runSessionWithConfig noLogConfig hieCommand oldCaps "test/testdata" $ do
+    it "provides nested where functions" $ runSession hieCommand oldCaps "test/testdata" $ do
       doc@(TextDocumentIdentifier testUri) <- openDoc "Symbols.hs" "haskell"
       Right symbs <- getDocumentSymbols doc
 

--- a/test/functional/SymbolsSpec.hs
+++ b/test/functional/SymbolsSpec.hs
@@ -2,9 +2,9 @@
 module SymbolsSpec where
 
 import Control.Monad.IO.Class
-import Data.Default
 import Language.Haskell.LSP.Test as Test
 import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Capabilities
 import Test.Hspec
 import TestUtils
 import Utils
@@ -76,8 +76,5 @@ spec = describe "document symbols" $ do
       liftIO $ symbs `shouldContain` [foo, bar, dog, cat]
 
 
--- TODO: Replace with capsForVersion
 oldCaps :: ClientCapabilities
-oldCaps = def { Test._textDocument = Just tdcs }
-  where tdcs = def { _documentSymbol = Just dscs }
-        dscs = DocumentSymbolClientCapabilities Nothing Nothing Nothing
+oldCaps = capsForVersion (LSPVersion 3 9)

--- a/test/functional/SymbolsSpec.hs
+++ b/test/functional/SymbolsSpec.hs
@@ -7,7 +7,6 @@ import Language.Haskell.LSP.Types
 import Language.Haskell.LSP.Types.Capabilities
 import Test.Hspec
 import TestUtils
-import Utils
 
 spec :: Spec
 spec = describe "document symbols" $ do


### PR DESCRIPTION
Removes the spam of logs during testing