### PR TITLE
Ignoring the -Werror setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@
 /test/testdata/redundantImportTest/stack.yaml
 /test/testdata/completion/stack.yaml
 /test/testdata/definition/stack.yaml
+/test/testdata/wErrorTest/stack.yaml
 TAGS
 cabal-dev/
 cabal.sandbox.config

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -127,7 +127,11 @@ run opts = do
 
   let vomitOptions = GM.defaultOptions { GM.optOutput = oo { GM.ooptLogLevel = GM.GmVomit}}
       oo = GM.optOutput GM.defaultOptions
-  let ghcModOptions = if optGhcModVomit opts then vomitOptions else GM.defaultOptions
+  let defaultOpts = if optGhcModVomit opts then vomitOptions else GM.defaultOptions
+      -- Running HIE on projects with -Werror breaks most of the features since all warnings
+      -- will be treated with the same severity of type errors. In order to offer a more useful
+      -- experience, we make sure warnings are always reported as warnings by setting -Wwarn
+      ghcModOptions = defaultOpts { GM.optGhcUserOptions = ["-Wwarn"] }
 
   when (optGhcModVomit opts) $
     logm "Enabling --vomit for ghc-mod. Output will be on stderr"

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -20,7 +20,7 @@ spec = describe "diagnostics providers" $ do
     it "runs diagnostics on save" $
       runSession hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
       -- runSessionWithConfig logConfig hieCommandExamplePlugin codeActionSupportCaps "test/testdata" $ do
-        logm $ "starting DiagnosticSpec.runs diagnostic on save"
+        logm "starting DiagnosticSpec.runs diagnostic on save"
         doc <- openDoc "ApplyRefact2.hs" "haskell"
 
         diags@(reduceDiag:_) <- waitForDiagnostics
@@ -54,12 +54,19 @@ spec = describe "diagnostics providers" $ do
           d ^. severity `shouldBe` Nothing
           d ^. code `shouldBe` Nothing
           d ^. source `shouldBe` Just "eg2"
-          d ^. message `shouldBe` (T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave")
+          d ^. message `shouldBe` T.pack "Example plugin diagnostic, triggered byDiagnosticOnSave"
 
   describe "typed hole errors" $
     it "is deferred" $
       runSession hieCommand fullCaps "test/testdata" $ do
         _ <- openDoc "TypedHoles.hs" "haskell"
+        [diag] <- waitForDiagnosticsSource "ghcmod"
+        liftIO $ diag ^. severity `shouldBe` Just DsWarning
+
+  describe "Warnings are warnings" $
+    it "Overrides -Werror" $
+      runSession hieCommand fullCaps "test/testdata/wErrorTest" $ do
+        _ <- openDoc "src/WError.hs" "haskell"
         [diag] <- waitForDiagnosticsSource "ghcmod"
         liftIO $ diag ^. severity `shouldBe` Just DsWarning
 

--- a/test/testdata/wErrorTest/src/WError.hs
+++ b/test/testdata/wErrorTest/src/WError.hs
@@ -1,0 +1,2 @@
+module WError where
+main = undefined

--- a/test/testdata/wErrorTest/test.cabal
+++ b/test/testdata/wErrorTest/test.cabal
@@ -1,0 +1,17 @@
+name:                test
+version:             0.1.0.0
+-- synopsis:
+-- description:
+license:             BSD3
+author:              Author name here
+maintainer:          example@example.com
+copyright:           2017 Author name here
+category:            Web
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  build-depends:       base >= 4.7 && < 5
+  default-language:    Haskell2010
+  ghc-options:         -Wall -Werror

--- a/test/utils/TestUtils.hs
+++ b/test/utils/TestUtils.hs
@@ -108,6 +108,7 @@ files =
    , "./test/testdata/addPackageTest/cabal/"
    , "./test/testdata/addPackageTest/hpack/"
    , "./test/testdata/redundantImportTest/"
+   , "./test/testdata/wErrorTest/"
    , "./test/testdata/completion/"
    , "./test/testdata/definition/"
   ]


### PR DESCRIPTION
When having -Werror enabled, the experience with HIE degrades
significantly as everything is treated as a type error. This makes sure
that warnings are always treated as warnings.

closes #449, #680 and #662