### PR TITLE
Update to haskell-lsp-0.8 and fix snippet not respecting client capabilities

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,6 +21,3 @@
 [submodule "submodules/haskell-lsp"]
 	path = submodules/haskell-lsp
 	url = https://github.com/alanz/haskell-lsp.git
-[submodule "submodules/haskell-lsp-test"]
-	path = submodules/haskell-lsp-test
-	url = https://github.com/Bubba/haskell-lsp-test.git

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -65,7 +65,7 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp >= 0.5
+                     , haskell-lsp >= 0.8
                      , haskell-src-exts
                      , hie-plugin-api
                      , hlint >= 2.0.11
@@ -271,7 +271,7 @@ test-suite func-test
                      , data-default
                      , directory
                      , filepath
-                     , lsp-test >= 0.3.0
+                     , lsp-test == 0.4.*
                      , haskell-ide-engine
                      -- , hie-test-utils
                      , hie-plugin-api

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCacheTypes.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCacheTypes.hs
@@ -1,0 +1,71 @@
+
+module Haskell.Ide.Engine.ModuleCacheTypes where
+
+import qualified Data.Map as Map
+import Data.Dynamic
+import Data.Typeable
+import GHC (ParsedModule, TypecheckedModule)
+import qualified GhcMod.Cradle as GM
+import Haskell.Ide.Engine.ArtifactMap
+import Language.Haskell.LSP.Types
+
+-- | The GHC module(s), extra information and custom data for
+-- a single module, e.g. Foo.hs.
+data UriCache = UriCache
+  { cachedInfo   :: !CachedInfo
+  , cachedPsMod  :: !ParsedModule
+  , cachedTcMod  :: !(Maybe TypecheckedModule)
+  , cachedData   :: !(Map.Map TypeRep Dynamic)
+  }
+
+instance Show UriCache where
+  show (UriCache _ _ (Just _) dat) =
+    "UriCache { cachedTcMod, cachedData { " ++ show dat ++ " } }"
+  show (UriCache _ _ _ dat) =
+    "UriCache { cachedPsMod, cachedData { " ++ show dat ++ " } }"
+
+-- ---------------------------------------------------------------------
+
+-- | Data related to the modules inside 'UriCache'
+data CachedInfo = CachedInfo
+  { locMap         :: !LocMap
+  , typeMap        :: !TypeMap
+  , moduleMap      :: !ModuleMap
+  , defMap         :: !DefMap
+  , revMap         :: !(FilePath -> FilePath)
+  , newPosToOld    :: !(Position -> Maybe Position)
+  , oldPosToNew    :: !(Position -> Maybe Position)
+  }
+
+-- ---------------------------------------------------------------------
+
+-- | A module that can be cached inside a 'UriCache'
+class CacheableModule a where
+  fromUriCache :: UriCache -> Maybe a
+
+instance CacheableModule TypecheckedModule where
+  fromUriCache (UriCache _ _ mtm _) = mtm
+
+instance CacheableModule ParsedModule where
+  fromUriCache (UriCache _ pm _ _) = Just pm
+
+-- ---------------------------------------------------------------------
+-- The following to move into ghc-mod-core
+
+class (Monad m) => HasIdeCache m where
+  getModuleCache :: m IdeCache
+  setModuleCache :: IdeCache -> m ()
+
+emptyModuleCache :: IdeCache
+emptyModuleCache = IdeCache Map.empty Map.empty
+
+data IdeCache = IdeCache
+  { cradleCache :: !(Map.Map FilePath GM.Cradle)
+                -- ^ map from dirs to cradles
+  , uriCaches   :: !(Map.Map FilePath UriCacheResult)
+                -- ^ map from module paths to module caches
+  } deriving (Show)
+
+data UriCacheResult = UriCacheSuccess UriCache
+                    | UriCacheFailed
+  deriving (Show)

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -41,7 +41,7 @@ library
                      , free
                      , ghc
                      , ghc-mod-core >= 5.9.0.0
-                     , haskell-lsp >= 0.5
+                     , haskell-lsp >= 0.8
                      , hslogger
                      , monad-control
                      , mtl

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -15,6 +15,7 @@ import Haskell.Ide.Engine.LSP.Reactor
 import Haskell.Ide.Engine.Types
 import qualified Language.Haskell.LSP.Core as Core
 import qualified Language.Haskell.LSP.Types as J
+import qualified Language.Haskell.LSP.Types.Lens as J
 import qualified Language.Haskell.LSP.Types.Capabilities as C
 import Language.Haskell.LSP.VFS
 import Language.Haskell.LSP.Messages

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -22,6 +22,7 @@ import           Language.Haskell.Exts.Parser
 import           Language.Haskell.Exts.Extension
 import           Language.Haskell.HLint3           as Hlint
 import qualified Language.Haskell.LSP.Types        as LSP
+import qualified Language.Haskell.LSP.Types.Lens   as LSP
 import           Refact.Apply
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -43,6 +43,7 @@ import           Haskell.Ide.Engine.Plugin.HaRe (HarePoint(..))
 import qualified Haskell.Ide.Engine.Plugin.HieExtras as Hie
 import           Haskell.Ide.Engine.ArtifactMap
 import qualified Language.Haskell.LSP.Types        as LSP
+import qualified Language.Haskell.LSP.Types.Lens   as LSP
 import           Language.Haskell.Refact.API       (hsNamessRdr)
 
 import           DynFlags

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -32,6 +32,7 @@ import qualified Haskell.Ide.Engine.Plugin.HieExtras          as Hie
 import           Language.Haskell.GHC.ExactPrint.Print
 import qualified Language.Haskell.LSP.Core                    as Core
 import qualified Language.Haskell.LSP.Types                   as J
+import qualified Language.Haskell.LSP.Types.Lens              as J
 import           Language.Haskell.Refact.API                  hiding (logm)
 import           Language.Haskell.Refact.HaRe
 import           Language.Haskell.Refact.Utils.Monad          hiding (logm)

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -17,7 +17,8 @@ import qualified GHC.Generics                  as Generics
 import qualified GhcMod.Utils                  as GM
 import           HsImport
 import           Haskell.Ide.Engine.MonadTypes
-import qualified Language.Haskell.LSP.Types    as J
+import qualified Language.Haskell.LSP.Types      as J
+import qualified Language.Haskell.LSP.Types.Lens as J
 import           Haskell.Ide.Engine.PluginUtils
 import qualified Haskell.Ide.Engine.Plugin.Hoogle as Hoogle
 import           System.Directory

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -35,7 +35,8 @@ import qualified Haskell.Ide.Engine.Plugin.Package.Compat as L
 #endif
 import           Distribution.Types.Dependency
 import           Distribution.Types.PackageName
-import qualified Language.Haskell.LSP.Types    as J
+import qualified Language.Haskell.LSP.Types      as J
+import qualified Language.Haskell.LSP.Types.Lens as J
 import           Distribution.Verbosity
 import           System.FilePath
 #if MIN_VERSION_filepath(1,4,2)

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -62,6 +62,7 @@ import qualified Language.Haskell.LSP.VFS                as VFS
 import           Language.Haskell.LSP.Diagnostics
 import           Language.Haskell.LSP.Messages
 import qualified Language.Haskell.LSP.Types              as J
+import qualified Language.Haskell.LSP.Types.Lens         as J
 import           Language.Haskell.LSP.Types.Capabilities as C
 import qualified Language.Haskell.LSP.Utility            as U
 import           System.Exit

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -18,7 +18,7 @@ extra-deps:
 - ghc-exactprint-0.5.6.1
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- lsp-test-0.3.0.0
+- lsp-test-0.4.0.0
 - hlint-2.0.11
 # - hlint-2.1.8
 - hsimport-0.8.6

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -19,7 +19,7 @@ extra-deps:
 - haddock-api-2.18.1
 - haddock-library-1.4.4
 - hsimport-0.8.6
-- lsp-test-0.3.0.0
+- lsp-test-0.4.0.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -18,7 +18,7 @@ extra-deps:
 - haddock-library-1.6.0
 - hlint-2.1.8
 - hsimport-0.8.6
-- lsp-test-0.3.0.0
+- lsp-test-0.4.0.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -16,7 +16,7 @@ extra-deps:
 - haddock-api-2.20.0
 - haddock-library-1.6.0
 - hsimport-0.8.6
-- lsp-test-0.3.0.0
+- lsp-test-0.4.0.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -23,7 +23,7 @@ extra-deps:
 - haddock-api-2.20.0
 - hsimport-0.8.6
 - monad-memo-0.4.1
-- lsp-test-0.3.0.0
+- lsp-test-0.4.0.0
 - semigroupoids-5.2.2
 - syz-0.2.0.0
 - temporary-1.2.1.1

--- a/test/dispatcher/Main.hs
+++ b/test/dispatcher/Main.hs
@@ -21,7 +21,7 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.Types
-import           Language.Haskell.LSP.Types hiding (error)
+import           Language.Haskell.LSP.Types
 import           TestUtils
 import           System.Directory
 import           System.FilePath

--- a/test/functional/CommandSpec.hs
+++ b/test/functional/CommandSpec.hs
@@ -7,6 +7,7 @@ import qualified Data.Text as T
 import Data.Char
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types as LSP
+import Language.Haskell.LSP.Types.Lens as LSP
 import Test.Hspec
 import TestUtils
 

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -7,7 +7,8 @@ import Control.Lens hiding ((.=))
 import Data.Aeson
 import Language.Haskell.LSP.Test
 -- import Language.Haskell.LSP.Test.Replay
-import Language.Haskell.LSP.Types hiding (applyEdit)
+import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Lens hiding (applyEdit)
 import Test.Hspec
 import TestUtils
 
@@ -58,54 +59,62 @@ spec = describe "completions" $ do
       item ^. detail `shouldBe` Just "Data.List"
       item ^. kind `shouldBe` Just CiModule
 
-  it "provides snippets for polymorphic types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
-    doc <- openDoc "Completion.hs" "haskell"
-    _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+  describe "snippets" $ do
+    it "work for polymorphic types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+      doc <- openDoc "Completion.hs" "haskell"
+      _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
-    let te = TextEdit (Range (Position 4 7) (Position 4 24)) "fold"
-    _ <- applyEdit doc te
-    
-    compls <- getCompletions doc (Position 4 11)
-    let item = head $ filter ((== "foldl") . (^. label)) compls
-    liftIO $ do
-      item ^. label `shouldBe` "foldl"
-      item ^. kind `shouldBe` Just CiFunction
-      item ^. insertTextFormat `shouldBe` Just Snippet
-      item ^. insertText `shouldBe` Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
+      let te = TextEdit (Range (Position 4 7) (Position 4 24)) "fold"
+      _ <- applyEdit doc te
 
-  it "provides snippets for complex types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
-    doc <- openDoc "Completion.hs" "haskell"
-    _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+      compls <- getCompletions doc (Position 4 11)
+      let item = head $ filter ((== "foldl") . (^. label)) compls
+      liftIO $ do
+        item ^. label `shouldBe` "foldl"
+        item ^. kind `shouldBe` Just CiFunction
+        item ^. insertTextFormat `shouldBe` Just Snippet
+        item ^. insertText `shouldBe` Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
 
-    let te = TextEdit (Range (Position 4 7) (Position 4 24)) "mapM"
-    _ <- applyEdit doc te
-    
-    compls <- getCompletions doc (Position 4 11)
-    let item = head $ filter ((== "mapM") . (^. label)) compls
-    liftIO $ do
-      item ^. label `shouldBe` "mapM"
-      item ^. kind `shouldBe` Just CiFunction
-      item ^. insertTextFormat `shouldBe` Just Snippet
-      item ^. insertText `shouldBe` Just "mapM ${1:a -> m b} ${2:t a}"
+    it "work for complex types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+      doc <- openDoc "Completion.hs" "haskell"
+      _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
-  it "respects snippets configuration" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
-    doc <- openDoc "Completion.hs" "haskell"
-    _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+      let te = TextEdit (Range (Position 4 7) (Position 4 24)) "mapM"
+      _ <- applyEdit doc te
 
-    let config = object ["languageServerHaskell" .= (object ["completionSnippetsOn" .= False])]
+      compls <- getCompletions doc (Position 4 11)
+      let item = head $ filter ((== "mapM") . (^. label)) compls
+      liftIO $ do
+        item ^. label `shouldBe` "mapM"
+        item ^. kind `shouldBe` Just CiFunction
+        item ^. insertTextFormat `shouldBe` Just Snippet
+        item ^. insertText `shouldBe` Just "mapM ${1:a -> m b} ${2:t a}"
 
-    sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams config)
+    it "respects lsp configuration" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+      doc <- openDoc "Completion.hs" "haskell"
+      _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
-    let te = TextEdit (Range (Position 4 7) (Position 4 24)) "fold"
-    _ <- applyEdit doc te
-    
-    compls <- getCompletions doc (Position 4 11)
-    let item = head $ filter ((== "foldl") . (^. label)) compls
-    liftIO $ do
-      item ^. label `shouldBe` "foldl"
-      item ^. kind `shouldBe` Just CiFunction
-      item ^. insertTextFormat `shouldBe` Just PlainText
-      item ^. insertText `shouldBe` Nothing
+      let config = object ["languageServerHaskell" .= (object ["completionSnippetsOn" .= False])]
 
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams config)
 
+      checkNoSnippets doc
 
+    it "respects client capabilities" $ runSession hieCommand noSnippetsCaps "test/testdata/completion" $ do
+      doc <- openDoc "Completion.hs" "haskell"
+      _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+
+      checkNoSnippets doc
+  where
+    checkNoSnippets doc = do
+      let te = TextEdit (Range (Position 4 7) (Position 4 24)) "fold"
+      _ <- applyEdit doc te
+
+      compls <- getCompletions doc (Position 4 11)
+      let item = head $ filter ((== "foldl") . (^. label)) compls
+      liftIO $ do
+        item ^. label `shouldBe` "foldl"
+        item ^. kind `shouldBe` Just CiFunction
+        item ^. insertTextFormat `shouldBe` Just PlainText
+        item ^. insertText `shouldBe` Nothing
+    noSnippetsCaps = (textDocument . _Just . completion . _Just . completionItem . _Just . snippetSupport ?~ False) fullCaps

--- a/test/functional/DeferredSpec.hs
+++ b/test/functional/DeferredSpec.hs
@@ -11,8 +11,9 @@ import Data.Aeson
 import qualified Data.HashMap.Strict as H
 import Data.Maybe
 import Language.Haskell.LSP.Test
-import Language.Haskell.LSP.Types hiding (message)
-import qualified Language.Haskell.LSP.Types as LSP (id)
+import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Lens hiding (id, message)
+import qualified Language.Haskell.LSP.Types.Lens as LSP
 import Test.Hspec
 import System.Directory
 import System.FilePath

--- a/test/functional/DefinitionSpec.hs
+++ b/test/functional/DefinitionSpec.hs
@@ -4,6 +4,7 @@ import Control.Lens
 import Control.Monad.IO.Class
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Lens
 import System.Directory
 import Test.Hspec
 import TestUtils

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -7,7 +7,8 @@ import           Control.Monad.IO.Class
 import qualified Data.Text as T
 import           Haskell.Ide.Engine.MonadFunctions
 import           Language.Haskell.LSP.Test hiding (message)
-import           Language.Haskell.LSP.Types as LSP hiding (contents, error )
+import           Language.Haskell.LSP.Types as LSP
+import           Language.Haskell.LSP.Types.Lens as LSP hiding (contents, error )
 import           Test.Hspec
 import           TestUtils
 import           Utils

--- a/test/functional/FunctionalLiquidSpec.hs
+++ b/test/functional/FunctionalLiquidSpec.hs
@@ -8,7 +8,8 @@ import           Data.Aeson
 import qualified Data.Text as T
 import           Language.Haskell.LSP.Test hiding (message)
 -- import           Language.Haskell.LSP       as LSP
-import           Language.Haskell.LSP.Types as LSP hiding (contents, error )
+import           Language.Haskell.LSP.Types as LSP
+import           Language.Haskell.LSP.Types.Lens as LSP hiding (contents, error )
 import           Haskell.Ide.Engine.LSP.Config
 import           Test.Hspec
 import           TestUtils

--- a/test/functional/HaReSpec.hs
+++ b/test/functional/HaReSpec.hs
@@ -6,7 +6,7 @@ import Control.Monad.IO.Class
 import Data.Maybe
 import qualified Data.Text as T
 import Language.Haskell.LSP.Test
-import Language.Haskell.LSP.Types hiding (error, context)
+import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
 

--- a/test/functional/HoverSpec.hs
+++ b/test/functional/HoverSpec.hs
@@ -7,6 +7,7 @@ import Control.Monad.IO.Class
 import qualified Data.Text as T
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Lens
 import Test.Hspec
 import TestUtils
 

--- a/test/functional/ReferencesSpec.hs
+++ b/test/functional/ReferencesSpec.hs
@@ -4,6 +4,7 @@ import Control.Lens
 import Control.Monad.IO.Class
 import Language.Haskell.LSP.Test
 import Language.Haskell.LSP.Types
+import Language.Haskell.LSP.Types.Lens
 import Test.Hspec
 import TestUtils
 

--- a/test/functional/RenameSpec.hs
+++ b/test/functional/RenameSpec.hs
@@ -3,7 +3,7 @@ module RenameSpec where
 
 import Control.Monad.IO.Class
 import Language.Haskell.LSP.Test
-import Language.Haskell.LSP.Types hiding (rename)
+import Language.Haskell.LSP.Types
 import Test.Hspec
 import TestUtils
 


### PR DESCRIPTION
Closes #822 
The haskell-lsp-0.8 update mainly involves importing/removing Lens imports. 