### PR TITLE
Makefile shows help by default instead of building all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,20 @@
 BASEDIR=$(CURDIR)
 STACKLOCALBINDIR:=$(shell stack path --local-bin)
 
+all: help
+.PHONY: all
+
+## Builds hie for all supported GHC versions (8.2.1, 8.2.2, 8.4.2 and 8.4.3)
 build: hie-8.2.1 hie-8.2.2 hie-8.4.2 hie-8.4.3
 .PHONY: build
 
+## Builds hie and hoogle databases for all supported GHC versions
 build-all: build build-docs
 .PHONY: build-all
 
-submodules:
-	git submodule update --init
-.PHONY: submodules
-
 # ------------------------------------------------------
 
+## Builds hie for GHC version 8.2.1 only
 hie-8.2.1: submodules
 	stack --stack-yaml=stack-8.2.1.yaml install happy
 	stack --stack-yaml=stack-8.2.1.yaml build
@@ -21,6 +23,7 @@ hie-8.2.1: submodules
 		&& cp '$(STACKLOCALBINDIR)/hie-8.2.1' '$(STACKLOCALBINDIR)/hie-8.2'
 .PHONY: hie-8.2.1
 
+## Builds hie for GHC version 8.2.2 only
 hie-8.2.2: submodules
 	stack --stack-yaml=stack-8.2.2.yaml install happy
 	stack --stack-yaml=stack-8.2.2.yaml build
@@ -29,6 +32,7 @@ hie-8.2.2: submodules
 		&& cp '$(STACKLOCALBINDIR)/hie-8.2.2' '$(STACKLOCALBINDIR)/hie-8.2'
 .PHONY: hie-8.2.2
 
+## Builds hie for GHC version 8.4.2 only
 hie-8.4.2: submodules
 	stack --stack-yaml=stack-8.4.2.yaml build
 	stack --stack-yaml=stack-8.4.2.yaml install                                \
@@ -36,6 +40,7 @@ hie-8.4.2: submodules
 		&& cp '$(STACKLOCALBINDIR)/hie-8.4.2' '$(STACKLOCALBINDIR)/hie-8.4'
 .PHONY: hie-8.2.2
 
+## Builds hie for GHC version 8.4.3 only
 hie-8.4.3: submodules
 	stack --stack-yaml=stack-8.4.3.yaml build
 	stack --stack-yaml=stack-8.4.3.yaml install                                      \
@@ -45,6 +50,12 @@ hie-8.4.3: submodules
 
 # ------------------------------------------------------
 
+## Updates local git submodules
+submodules:
+	git submodule update --init
+.PHONY: submodules
+
+## Builds the Hoogle database for all supported GHC versions
 build-docs:
 	stack --stack-yaml=stack-8.2.1.yaml exec hoogle generate \
 	&& stack --stack-yaml=stack-8.2.2.yaml exec hoogle generate \
@@ -55,6 +66,7 @@ build-docs:
 
 # ------------------------------------------------------
 
+## Runs hie tests
 test: submodules
 	stack --stack-yaml=stack-8.2.1.yaml test \
 	&& stack --stack-yaml=stack-8.2.2.yaml test \
@@ -69,6 +81,7 @@ build-copy-compiler-tool: submodules
 	&& stack --stack-yaml=stack-8.4.3.yaml build --copy-compiler-tool
 .PHONY: build-copy-compiler-tool
 
+## Fixes icu related problems in MacOS
 icu-macos-fix: icu-macos-fix-install icu-macos-fix-build
 .PHONY: icu-macos-fix
 
@@ -90,3 +103,32 @@ icu-macos-fix-build:
 	  --extra-lib-dirs=/usr/local/opt/icu4c/lib            \
 	  --extra-include-dirs=/usr/local/opt/icu4c/include
 .PHONY: icu-macos-fix-build
+
+#######################################################################################################################
+# Help task
+#######################################################################################################################
+
+# COLORS
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+RESET  := $(shell tput -Txterm sgr0)
+
+TARGET_MAX_CHAR_NUM=20
+
+## Show help
+help:
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk '/^[a-zA-Z\-\.\_0-9]+:/ { \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+		  helpCommand = $$1; sub(/:$$/, "", helpCommand); \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)


### PR DESCRIPTION
It now executes "make help" by default and shows what is possible, instead of building all versions immediately. This is a sample output:

<img width="785" alt="screenshot 2018-10-11 at 20 27 22" src="https://user-images.githubusercontent.com/37621/46825903-fa1f2880-cd94-11e8-8d3f-0b7df540148e.png">


refs #856
[ci skip]