### PR TITLE
Add example code for haskellforall.com blog post

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -38,6 +38,8 @@ import           Haskell.Ide.Engine.Plugin.HsImport
 import           Haskell.Ide.Engine.Plugin.Liquid
 import           Haskell.Ide.Engine.Plugin.Package
 import           Haskell.Ide.Engine.Plugin.Haddock
+import           Haskell.Ide.Engine.Plugin.HfaAlign
+
 
 -- ---------------------------------------------------------------------
 
@@ -63,6 +65,7 @@ plugins includeExamples = pluginDescToIdePlugins allPlugins
       ]
     examplePlugins =
       [example2Descriptor "eg2"
+      ,hfaAlignDescriptor "hfaa"
       ]
 
 -- ---------------------------------------------------------------------

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -34,6 +34,7 @@ library
                        Haskell.Ide.Engine.Plugin.HaRe
                        Haskell.Ide.Engine.Plugin.Haddock
                        Haskell.Ide.Engine.Plugin.HieExtras
+                       Haskell.Ide.Engine.Plugin.HfaAlign
                        Haskell.Ide.Engine.Plugin.Hoogle
                        Haskell.Ide.Engine.Plugin.HsImport
                        Haskell.Ide.Engine.Plugin.Liquid
@@ -80,6 +81,7 @@ library
                      , optparse-simple >= 0.0.3
                      , parsec
                      , process
+                     , safe
                      , sorted-list >= 0.2.1.0
                      , stm
                      , tagsoup

--- a/src/Haskell/Ide/Engine/LSP/CodeActions.hs
+++ b/src/Haskell/Ide/Engine/LSP/CodeActions.hs
@@ -32,7 +32,8 @@ data FallbackCodeActionParams =
 handleCodeActionReq :: TrackingNumber -> J.CodeActionRequest -> R ()
 handleCodeActionReq tn req = do
 
-  maybeRootDir <- asksLspFuncs Core.rootPath
+  maybeRootDir    <- asksLspFuncs Core.rootPath
+  virtualFileFunc <- asksLspFuncs Core.getVirtualFileFunc
 
   vfsFunc <- asksLspFuncs Core.getVirtualFileFunc
   docVersion <- fmap _version <$> liftIO (vfsFunc docUri)
@@ -44,7 +45,7 @@ handleCodeActionReq tn req = do
         return $ IdeResultOk $ mapMaybe getProvider $ toList m
 
       providersCb providers =
-        let reqs = map (\f -> lift (f docId maybeRootDir range context)) providers
+        let reqs = map (\f -> lift (f docId virtualFileFunc maybeRootDir range context)) providers
         in makeRequests reqs tn (req ^. J.id) (send . concat)
 
   makeRequest (IReq tn (req ^. J.id) providersCb getProviders)

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -64,7 +64,7 @@ data OneHint = OneHint
   } deriving (Eq, Show)
 
 applyOneCmd :: CommandFunc ApplyOneParams WorkspaceEdit
-applyOneCmd = CmdSync $ \(AOP uri pos title) -> do
+applyOneCmd = CmdSync $ \_ (AOP uri pos title) -> do
   applyOneCmd' uri (OneHint pos title)
 
 applyOneCmd' :: Uri -> OneHint -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -82,7 +82,7 @@ applyOneCmd' uri oneHint = pluginGetFile "applyOne: " uri $ \fp -> do
 -- ---------------------------------------------------------------------
 
 applyAllCmd :: CommandFunc Uri WorkspaceEdit
-applyAllCmd = CmdSync $ \uri -> do
+applyAllCmd = CmdSync $ \_ uri -> do
   applyAllCmd' uri
 
 applyAllCmd' :: Uri -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -98,7 +98,7 @@ applyAllCmd' uri = pluginGetFile "applyAll: " uri $ \fp -> do
 -- ---------------------------------------------------------------------
 
 lintCmd :: CommandFunc Uri PublishDiagnosticsParams
-lintCmd = CmdSync $ \uri -> do
+lintCmd = CmdSync $ \_ uri -> do
   lintCmd' uri
 
 -- AZ:TODO: Why is this in IdeGhcM?
@@ -278,7 +278,7 @@ showParseError (Hlint.ParseError location message content) =
 -- ---------------------------------------------------------------------
 
 codeActionProvider :: CodeActionProvider
-codeActionProvider plId docId _ _ context = IdeResultOk <$> hlintActions
+codeActionProvider plId docId _ _ _ context = IdeResultOk <$> hlintActions
   where
 
     hlintActions :: IdeM [LSP.CodeAction]

--- a/src/Haskell/Ide/Engine/Plugin/Base.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Base.hs
@@ -50,14 +50,14 @@ baseDescriptor plId = PluginDescriptor
 -- ---------------------------------------------------------------------
 
 versionCmd :: CommandFunc () T.Text
-versionCmd = CmdSync $ \_ -> return $ IdeResultOk (T.pack version)
+versionCmd = CmdSync $ \_ _ -> return $ IdeResultOk (T.pack version)
 
 pluginsCmd :: CommandFunc () IdePlugins
-pluginsCmd = CmdSync $ \_ ->
+pluginsCmd = CmdSync $ \_ _ ->
   IdeResultOk <$> getPlugins
 
 commandsCmd :: CommandFunc T.Text [CommandName]
-commandsCmd = CmdSync $ \p -> do
+commandsCmd = CmdSync $ \_ p -> do
   IdePlugins plugins <- getPlugins
   case Map.lookup p plugins of
     Nothing -> return $ IdeResultFail $ IdeError
@@ -68,7 +68,7 @@ commandsCmd = CmdSync $ \p -> do
     Just pl -> return $ IdeResultOk $ map commandName $ pluginCommands pl
 
 commandDetailCmd :: CommandFunc (T.Text, T.Text) T.Text
-commandDetailCmd = CmdSync $ \(p,command) -> do
+commandDetailCmd = CmdSync $ \_ (p,command) -> do
   IdePlugins plugins <- getPlugins
   case Map.lookup p plugins of
     Nothing -> return $ IdeResultFail $ IdeError

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -41,7 +41,7 @@ brittanyDescriptor plId = PluginDescriptor
  where
   cmd :: CommandFunc FormatParams [J.TextEdit]
   cmd =
-    CmdSync $ \(FormatParams tabSize uri range) -> brittanyCmd tabSize uri range
+    CmdSync $ \_ (FormatParams tabSize uri range) -> brittanyCmd tabSize uri range
 
 brittanyCmd :: Int -> Uri -> Maybe Range -> IdeGhcM (IdeResult [J.TextEdit])
 brittanyCmd tabSize uri range =

--- a/src/Haskell/Ide/Engine/Plugin/Build.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Build.hs
@@ -239,7 +239,7 @@ withCommonArgs req a = do
 -----------------------------------------------
 
 prepareHelper :: CommandFunc CommonParams ()
-prepareHelper = CmdSync $ \req -> withCommonArgs req $ do
+prepareHelper = CmdSync $ \_ req -> withCommonArgs req $ do
   ca <- ask
   liftIO $ case caMode ca of
       StackMode -> do
@@ -255,7 +255,7 @@ prepareHelper' distDir cabalExe dir =
 -----------------------------------------------
 
 isConfigured :: CommandFunc CommonParams Bool
-isConfigured = CmdSync $ \req -> withCommonArgs req $ do
+isConfigured = CmdSync $ \_ req -> withCommonArgs req $ do
   distDir <- asks caDistDir
   ret <- liftIO $ doesFileExist $ localBuildInfoFile distDir
   return $ IdeResultOk ret
@@ -263,7 +263,7 @@ isConfigured = CmdSync $ \req -> withCommonArgs req $ do
 -----------------------------------------------
 
 configure :: CommandFunc CommonParams ()
-configure = CmdSync $ \req -> withCommonArgs req $ do
+configure = CmdSync $ \_ req -> withCommonArgs req $ do
   ca <- ask
   _ <- liftIO $ case caMode ca of
       StackMode -> configureStack (caStack ca)
@@ -291,7 +291,7 @@ instance ToJSON ListFlagsParams where
   toJSON = J.genericToJSON $ customOptions 2
 
 listFlags :: CommandFunc ListFlagsParams Object
-listFlags = CmdSync $ \(LF mode) -> do
+listFlags = CmdSync $ \_ (LF mode) -> do
       cwd <- liftIO $ getCurrentDirectory
       flags0 <- liftIO $ case mode of
             "stack" -> listFlagsStack cwd
@@ -355,7 +355,7 @@ instance ToJSON BuildParams where
   toJSON = J.genericToJSON $ customOptions 2
 
 buildDirectory :: CommandFunc BuildParams ()
-buildDirectory = CmdSync $ \(BP m dd c s f mbDir) -> withCommonArgs (CommonParams m dd c s f) $ do
+buildDirectory = CmdSync $ \_ (BP m dd c s f mbDir) -> withCommonArgs (CommonParams m dd c s f) $ do
   ca <- ask
   liftIO $ case caMode ca of
     CabalMode -> do
@@ -394,7 +394,7 @@ instance ToJSON BuildTargetParams where
   toJSON = J.genericToJSON $ customOptions 2
 
 buildTarget :: CommandFunc BuildTargetParams ()
-buildTarget = CmdSync $ \(BT m dd c s f component package' compType) -> withCommonArgs (CommonParams m dd c s f) $ do
+buildTarget = CmdSync $ \_ (BT m dd c s f component package' compType) -> withCommonArgs (CommonParams m dd c s f) $ do
   ca <- ask
   liftIO $ case caMode ca of
     CabalMode -> do
@@ -424,7 +424,7 @@ data Package = Package {
   }
 
 listTargets :: CommandFunc CommonParams [Value]
-listTargets = CmdSync $ \req -> withCommonArgs req $ do
+listTargets = CmdSync $ \_ req -> withCommonArgs req $ do
   ca <- ask
   targets <- liftIO $ case caMode ca of
       CabalMode -> (:[]) <$> listCabalTargets (caDistDir ca) "."

--- a/src/Haskell/Ide/Engine/Plugin/Example2.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Example2.hs
@@ -42,10 +42,10 @@ example2Descriptor plId = PluginDescriptor
 -- ---------------------------------------------------------------------
 
 sayHelloCmd :: CommandFunc () T.Text
-sayHelloCmd = CmdSync $ \_ -> return (IdeResultOk sayHello)
+sayHelloCmd = CmdSync $ \_ _ -> return (IdeResultOk sayHello)
 
 sayHelloToCmd :: CommandFunc T.Text T.Text
-sayHelloToCmd = CmdSync $ \n -> do
+sayHelloToCmd = CmdSync $ \_ n -> do
   r <- liftIO $ sayHelloTo n
   return $ IdeResultOk r
 
@@ -81,7 +81,7 @@ data TodoParams = TodoParams
   deriving (Show, Eq, Generics.Generic, ToJSON, FromJSON)
 
 todoCmd :: CommandFunc TodoParams J.WorkspaceEdit
-todoCmd = CmdSync $ \(TodoParams uri r) -> return $ IdeResultOk $ makeTodo uri r
+todoCmd = CmdSync $ \_ (TodoParams uri r) -> return $ IdeResultOk $ makeTodo uri r
 
 makeTodo :: J.Uri -> J.Range -> J.WorkspaceEdit
 makeTodo uri (J.Range (J.Position startLine _) _) = res
@@ -99,7 +99,7 @@ makeTodo uri (J.Range (J.Position startLine _) _) = res
 
 
 codeActionProvider :: CodeActionProvider
-codeActionProvider plId docId _ r _context = do
+codeActionProvider plId docId _ _ r _context = do
   cmd <- mkLspCommand plId "todo" title  (Just cmdParams)
   return $ IdeResultOk [codeAction cmd]
   where

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -111,7 +111,7 @@ instance ToJSON HareRange where
 -- ---------------------------------------------------------------------
 
 demoteCmd :: CommandFunc HarePoint WorkspaceEdit
-demoteCmd  = CmdSync $ \(HP uri pos) ->
+demoteCmd  = CmdSync $ \_ (HP uri pos) ->
   demoteCmd' uri pos
 
 demoteCmd' :: Uri -> Position -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -124,7 +124,7 @@ demoteCmd' uri pos =
 -- ---------------------------------------------------------------------
 
 dupdefCmd :: CommandFunc HarePointWithText WorkspaceEdit
-dupdefCmd = CmdSync $ \(HPT uri pos name) ->
+dupdefCmd = CmdSync $ \_ (HPT uri pos name) ->
   dupdefCmd' uri pos name
 
 dupdefCmd' :: Uri -> Position -> T.Text -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -137,7 +137,7 @@ dupdefCmd' uri pos name =
 -- ---------------------------------------------------------------------
 
 iftocaseCmd :: CommandFunc HareRange WorkspaceEdit
-iftocaseCmd = CmdSync $ \(HR uri startPos endPos) ->
+iftocaseCmd = CmdSync $ \_ (HR uri startPos endPos) ->
   iftocaseCmd' uri (Range startPos endPos)
 
 iftocaseCmd' :: Uri -> Range -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -150,7 +150,7 @@ iftocaseCmd' uri (Range startPos endPos) =
 -- ---------------------------------------------------------------------
 
 liftonelevelCmd :: CommandFunc HarePoint WorkspaceEdit
-liftonelevelCmd = CmdSync $ \(HP uri pos) ->
+liftonelevelCmd = CmdSync $ \_ (HP uri pos) ->
   liftonelevelCmd' uri pos
 
 liftonelevelCmd' :: Uri -> Position -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -163,7 +163,7 @@ liftonelevelCmd' uri pos =
 -- ---------------------------------------------------------------------
 
 lifttotoplevelCmd :: CommandFunc HarePoint WorkspaceEdit
-lifttotoplevelCmd = CmdSync $ \(HP uri pos) ->
+lifttotoplevelCmd = CmdSync $ \_ (HP uri pos) ->
   lifttotoplevelCmd' uri pos
 
 lifttotoplevelCmd' :: Uri -> Position -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -176,7 +176,7 @@ lifttotoplevelCmd' uri pos =
 -- ---------------------------------------------------------------------
 
 renameCmd :: CommandFunc HarePointWithText WorkspaceEdit
-renameCmd = CmdSync $ \(HPT uri pos name) ->
+renameCmd = CmdSync $ \_ (HPT uri pos name) ->
   renameCmd' uri pos name
 
 renameCmd' :: Uri -> Position -> T.Text -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -189,7 +189,7 @@ renameCmd' uri pos name =
 -- ---------------------------------------------------------------------
 
 deleteDefCmd :: CommandFunc HarePoint WorkspaceEdit
-deleteDefCmd  = CmdSync $ \(HP uri pos) ->
+deleteDefCmd  = CmdSync $ \_ (HP uri pos) ->
   deleteDefCmd' uri pos
 
 deleteDefCmd' :: Uri -> Position -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -202,7 +202,7 @@ deleteDefCmd' uri pos =
 -- ---------------------------------------------------------------------
 
 genApplicativeCommand :: CommandFunc HarePoint WorkspaceEdit
-genApplicativeCommand  = CmdSync $ \(HP uri pos) ->
+genApplicativeCommand  = CmdSync $ \_ (HP uri pos) ->
   genApplicativeCommand' uri pos
 
 genApplicativeCommand' :: Uri -> Position -> IdeGhcM (IdeResult WorkspaceEdit)
@@ -292,7 +292,7 @@ hoist f a =
 -- ---------------------------------------------------------------------
 
 codeActionProvider :: CodeActionProvider
-codeActionProvider pId docId _ (J.Range pos _) _ =
+codeActionProvider pId docId _ _ (J.Range pos _) _ =
   pluginGetFile "HaRe codeActionProvider: " (docId ^. J.uri) $ \file ->
     ifCachedInfo file (IdeResultOk mempty) $ \info -> do
       let symbols = getArtifactsAtPos pos (defMap info)

--- a/src/Haskell/Ide/Engine/Plugin/HfaAlign.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HfaAlign.hs
@@ -55,7 +55,7 @@ data AlignParams = AlignParams
   deriving (Show, Eq, Generics.Generic, ToJSON, FromJSON)
 
 alignCmd :: CommandFunc AlignParams J.WorkspaceEdit
-alignCmd = CmdSync $ \(AlignParams uri r) -> return $ IdeResultOk $ makeAlign uri r
+alignCmd = CmdSync $ \_ (AlignParams uri r) -> return $ IdeResultOk $ makeAlign uri r
 
 makeAlign :: J.Uri -> J.Range -> J.WorkspaceEdit
 makeAlign uri (J.Range (J.Position startLine _) _) = res
@@ -73,7 +73,7 @@ makeAlign uri (J.Range (J.Position startLine _) _) = res
 
 
 codeActionProvider :: CodeActionProvider
-codeActionProvider plId docId _ r _context = do
+codeActionProvider plId docId _ _ r _context = do
   cmd <- mkLspCommand plId "todo" title  (Just cmdParams)
   return $ IdeResultOk [codeAction cmd]
   where

--- a/src/Haskell/Ide/Engine/Plugin/HfaAlign.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HfaAlign.hs
@@ -10,9 +10,6 @@ module Haskell.Ide.Engine.Plugin.HfaAlign where
 import           Control.Lens
 import           Data.Aeson
 import qualified Data.HashMap.Strict           as H
-#if __GLASGOW_HASKELL__ < 804
-import           Data.Monoid
-#endif
 import qualified GHC.Generics                  as Generics
 import           Haskell.Ide.Engine.MonadTypes hiding (_range)
 import           Haskell.Ide.Engine.Plugin.HieExtras

--- a/src/Haskell/Ide/Engine/Plugin/HfaAlign.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HfaAlign.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- Simple example plugin showing how easy it is to make a plugin, using the operations from
+-- http://www.haskellforall.com/2018/10/detailed-walkthrough-for-beginner.html
+module Haskell.Ide.Engine.Plugin.HfaAlign where
+
+import           Control.Lens
+-- import           Control.Monad.IO.Class
+import           Data.Aeson
+import qualified Data.HashMap.Strict           as H
+#if __GLASGOW_HASKELL__ < 804
+import           Data.Monoid
+#endif
+-- import qualified Data.Map                      as Map
+-- import qualified Data.Set                      as S
+-- import qualified Data.Text                     as T
+import qualified GHC.Generics                  as Generics
+-- import           Haskell.Ide.Engine.MonadFunctions
+import           Haskell.Ide.Engine.MonadTypes hiding (_range)
+import qualified Language.Haskell.LSP.Types      as J
+import qualified Language.Haskell.LSP.Types.Lens as J
+
+-- blog post imports
+import Data.Text (Text)
+
+import qualified Data.Text
+-- import qualified Data.Text.IO
+import qualified Safe
+
+-- ---------------------------------------------------------------------
+
+example2Descriptor :: PluginId -> PluginDescriptor
+example2Descriptor plId = PluginDescriptor
+  { pluginId = plId
+  , pluginName = "Align Equals"
+  , pluginDesc = "An example of writing an HIE plugin\nbased on http://www.haskellforall.com/2018/10/detailed-walkthrough-for-beginner.html"
+  , pluginCommands =
+      [ PluginCommand "align" "Align = in active range" alignCmd
+      ]
+  , pluginCodeActionProvider = Just codeActionProvider
+  , pluginDiagnosticProvider = Nothing
+  , pluginHoverProvider = Nothing
+  , pluginSymbolProvider = Nothing
+  }
+
+-- ---------------------------------------------------------------------
+
+data AlignParams = AlignParams
+  { file  :: Uri
+  , range :: J.Range
+  }
+  deriving (Show, Eq, Generics.Generic, ToJSON, FromJSON)
+
+alignCmd :: CommandFunc AlignParams J.WorkspaceEdit
+alignCmd = CmdSync $ \(AlignParams uri r) -> return $ IdeResultOk $ makeAlign uri r
+
+makeAlign :: J.Uri -> J.Range -> J.WorkspaceEdit
+makeAlign uri (J.Range (J.Position startLine _) _) = res
+  where
+    pos = (J.Position startLine 0)
+    textEdits = J.List
+      [J.TextEdit (J.Range pos pos)
+                  "-- TODO: from example2 plugin\n"
+      ]
+    res = J.WorkspaceEdit
+      (Just $ H.singleton uri textEdits)
+      Nothing
+
+-- ---------------------------------------------------------------------
+
+
+codeActionProvider :: CodeActionProvider
+codeActionProvider plId docId _ r _context = do
+  cmd <- mkLspCommand plId "todo" title  (Just cmdParams)
+  return $ IdeResultOk [codeAction cmd]
+  where
+    codeAction :: J.Command -> J.CodeAction
+    codeAction cmd = J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [])) Nothing (Just cmd)
+    title = "Add TODO marker"
+    cmdParams = [toJSON (AlignParams (docId ^. J.uri) r )]
+
+-- ---------------------------------------------------------------------
+-- Blog post code
+-- ---------------------------------------------------------------------
+
+prefixLength :: Text -> Int
+prefixLength line = Data.Text.length prefix
+  where
+    (prefix, _suffix) = Data.Text.breakOn "=" line
+
+adjustLine :: Int -> Text -> Text
+adjustLine desiredPrefixLength oldLine = newLine
+  where
+    (prefix, suffix) = Data.Text.breakOn "=" oldLine
+
+    actualPrefixLength = Data.Text.length prefix
+
+    additionalSpaces = desiredPrefixLength - actualPrefixLength
+
+    spaces = Data.Text.replicate additionalSpaces " "
+
+    newLine = Data.Text.concat [ prefix, spaces, suffix ]
+
+adjustText :: Text -> Text
+adjustText oldText = newText
+  where
+    oldLines = Data.Text.lines oldText
+
+    prefixLengths = map prefixLength oldLines
+
+    newLines =
+        case Safe.maximumMay prefixLengths of
+            Nothing ->
+                []
+            Just desiredPrefixLength ->
+                map (adjustLine desiredPrefixLength) oldLines
+
+    newText = Data.Text.unlines newLines
+
+-- main :: IO ()
+-- main = Data.Text.IO.interact adjustText

--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -41,8 +41,8 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils
 import qualified Haskell.Ide.Engine.Plugin.Fuzzy              as Fuzzy
 import           HscTypes
-import qualified Language.Haskell.LSP.Core                    as Core
-import qualified Language.Haskell.LSP.VFS                     as VFS
+-- import qualified Language.Haskell.LSP.Core                    as Core
+-- import qualified Language.Haskell.LSP.VFS                     as VFS
 import qualified Language.Haskell.LSP.Types                   as J
 import qualified Language.Haskell.LSP.Types.Lens              as J
 import           Language.Haskell.Refact.API                 (showGhc)
@@ -56,7 +56,7 @@ import           SrcLoc
 import           TcEnv
 import           Type
 import           Var
-import qualified Yi.Rope as Yi
+-- import qualified Yi.Rope as Yi
 
 -- ---------------------------------------------------------------------
 
@@ -475,21 +475,21 @@ findDef uri pos = pluginGetFile "findDef: " uri $ \file ->
 
 -- ---------------------------------------------------------------------
 
-getRangeFromVFS :: (MonadIO m)
-  => Uri -> Range -> m (Maybe T.Text)
-getRangeFromVFS uri (Range (Position lf cf) (Position lt ct)) = do
-  mvf <- liftIO =<< asksLspFuncs Core.getVirtualFileFunc <*> pure uri
-  case mvf of
-    Just (VFS.VirtualFile _ yitext) -> do
-        let headMaybe [] = Nothing
-            headMaybe (x:_) = Just x
-            lastMaybe [] = Nothing
-            lastMaybe xs = Just $ last xs
-        let
-          (_,start) = Yi.splitAtLine lf yitext
-        let beforePos = Yi.take c curLine
-        curWord <- Yi.toText <$> lastMaybe (Yi.words beforePos)
-        let parts = T.split (=='.')
-                      $ T.takeWhileEnd (\x -> isAlphaNum x || x `elem` ("._'"::String)) curWord
-        return $ Just s
-    Nothing -> return Nothing
+-- getRangeFromVFS :: (MonadIO m)
+--   => Uri -> Range -> m (Maybe T.Text)
+-- getRangeFromVFS uri (Range (Position lf cf) (Position lt ct)) = do
+--   mvf <- liftIO =<< asksLspFuncs Core.getVirtualFileFunc <*> pure uri
+--   case mvf of
+--     Just (VFS.VirtualFile _ yitext) -> do
+--         let headMaybe [] = Nothing
+--             headMaybe (x:_) = Just x
+--             lastMaybe [] = Nothing
+--             lastMaybe xs = Just $ last xs
+--         let
+--           (_,start) = Yi.splitAtLine lf yitext
+--         let beforePos = Yi.take c curLine
+--         curWord <- Yi.toText <$> lastMaybe (Yi.words beforePos)
+--         let parts = T.split (=='.')
+--                       $ T.takeWhileEnd (\x -> isAlphaNum x || x `elem` ("._'"::String)) curWord
+--         return $ Just s
+--     Nothing -> return Nothing

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -65,7 +65,7 @@ initializeHoogleDb = do
     return Nothing
 
 infoCmd :: CommandFunc T.Text T.Text
-infoCmd = CmdSync $ \expr -> do
+infoCmd = CmdSync $ \_ expr -> do
   res <- liftToGhc $ bimap hoogleErrorToIdeError id <$> infoCmd' expr
   return $ case res of
     Left err -> IdeResultFail err
@@ -128,7 +128,7 @@ searchTargets f term = do
 ------------------------------------------------------------------------
 
 lookupCmd :: CommandFunc T.Text [T.Text]
-lookupCmd = CmdSync $ \term -> do
+lookupCmd = CmdSync $ \_ term -> do
   res <- liftToGhc $ bimap hoogleErrorToIdeError id <$> lookupCmd' 10 term
   return $ case res of
     Left err -> IdeResultFail err

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -43,7 +43,7 @@ data ImportParams = ImportParams
   deriving (Show, Eq, Generics.Generic, ToJSON, FromJSON)
 
 importCmd :: CommandFunc ImportParams J.WorkspaceEdit
-importCmd = CmdSync $ \(ImportParams uri modName) -> importModule uri modName
+importCmd = CmdSync $ \_ (ImportParams uri modName) -> importModule uri modName
 
 importModule :: Uri -> T.Text -> IdeGhcM (IdeResult J.WorkspaceEdit)
 importModule uri modName =
@@ -72,7 +72,7 @@ importModule uri modName =
           return $ IdeResultOk workspaceEdit
 
 codeActionProvider :: CodeActionProvider
-codeActionProvider plId docId _ _ context = do
+codeActionProvider plId docId _ _ _ context = do
   let J.List diags = context ^. J.diagnostics
       terms = mapMaybe getImportables diags
 

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -52,10 +52,10 @@ liquidDescriptor plId = PluginDescriptor
 -- ---------------------------------------------------------------------
 
 sayHelloCmd :: CommandFunc () T.Text
-sayHelloCmd = CmdSync $ \_ -> return (IdeResultOk sayHello)
+sayHelloCmd = CmdSync $ \_ _ -> return (IdeResultOk sayHello)
 
 sayHelloToCmd :: CommandFunc T.Text T.Text
-sayHelloToCmd = CmdSync $ \n -> do
+sayHelloToCmd = CmdSync $ \_ n -> do
   r <- liftIO $ sayHelloTo n
   return $ IdeResultOk r
 

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -72,7 +72,7 @@ data AddParams = AddParams
   deriving (Eq, Show, Read, Generic, ToJSON, FromJSON)
 
 addCmd :: CommandFunc AddParams J.WorkspaceEdit
-addCmd = CmdSync $ \(AddParams rootDir modulePath pkg) -> do
+addCmd = CmdSync $ \_ (AddParams rootDir modulePath pkg) -> do
 
   packageType <- liftIO $ findPackageType rootDir
   fileMap <- GM.mkRevRedirMapFunc
@@ -233,7 +233,7 @@ editCabalPackage file modulePath pkgName fileMap = do
             newDeps = oldDeps ++ [Dependency (mkPackageName dep) anyVersion]
 
 codeActionProvider :: CodeActionProvider
-codeActionProvider plId docId mRootDir _ context = do
+codeActionProvider plId docId _ mRootDir _ context = do
   let J.List diags = context ^. J.diagnostics
       pkgs = mapMaybe getAddablePackages diags
 

--- a/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/JsonStdio.hs
@@ -112,8 +112,9 @@ run dispatcherProc cin = flip E.catches handlers $ do
         case mreq of
           Nothing -> return()
           Just req -> do
+            let vfsFunc _ = return Nothing -- TODO: Stub for now, what to do?
             let preq = GReq 0 (context req) Nothing (Just $ J.IdInt rid) (liftIO . callback)
-                  $ runPluginCommand (plugin req) (command req) (arg req)
+                  $ runPluginCommand (plugin req) (command req) vfsFunc (arg req)
                 rid = reqId req
                 callback = sendResponse rid . dynToJSON
             atomically $ writeTChan cin preq
@@ -142,5 +143,4 @@ getNextReq = do
           rest <- readReqByteString
           let cur = B.charUtf8 char
           return $ Just $ maybe cur (cur <>) rest
-
 

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -564,6 +564,7 @@ reactor inp diagIn = do
                   Nothing -> reactorSend $ RspExecuteCommand $ Core.makeResponseMessage req $ dynToJSON obj
 
               execCmd cmdId args = do
+                vfsFunc <- asksLspFuncs Core.getVirtualFileFunc
                 -- The parameters to the HIE command are always the first element
                 let cmdParams = case args of
                      Just (J.List (x:_)) -> x
@@ -598,7 +599,7 @@ reactor inp diagIn = do
                   -- Just an ordinary HIE command
                   Just (plugin, cmd) ->
                     let preq = GReq tn Nothing Nothing (Just $ req ^. J.id) callback
-                               $ runPluginCommand plugin cmd cmdParams
+                               $ runPluginCommand plugin cmd vfsFunc cmdParams
                     in makeRequest preq
 
                   -- Couldn't parse the command identifier

--- a/test/dispatcher/Main.hs
+++ b/test/dispatcher/Main.hs
@@ -112,7 +112,7 @@ dispatchGhcRequest tn ctx n cin lc plugin com arg = do
     logger x = logToChan lc (ctx, Right x)
 
   let req = GReq tn Nothing Nothing (Just (IdInt n)) logger $
-        runPluginCommand plugin com (toJSON arg)
+        runPluginCommand plugin com  dummyVfs(toJSON arg)
   atomically $ writeTChan cin req
 
 dispatchIdeRequest :: (Typeable a, ToJSON a)

--- a/test/unit/ApplyRefactPluginSpec.hs
+++ b/test/unit/ApplyRefactPluginSpec.hs
@@ -47,7 +47,7 @@ applyRefactSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton applyRefactPath textEdits)
             Nothing
-      testCommand testPlugins act "applyrefact" "applyOne" arg res
+      testCommand testPlugins act "applyrefact" "applyOne" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -59,8 +59,8 @@ applyRefactSpec = do
                            , TextEdit (Range (Position 3 0) (Position 3 15)) "foo x = x + 1" ]
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton applyRefactPath textEdits)
-            Nothing            
-      testCommand testPlugins act "applyrefact" "applyAll" arg res
+            Nothing
+      testCommand testPlugins act "applyrefact" "applyAll" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -85,7 +85,7 @@ applyRefactSpec = do
                             "Redundant bracket\nFound:\n  (x + 1)\nWhy not:\n  x + 1\n"
                             Nothing
                ]}
-      testCommand testPlugins act "applyrefact" "lint" arg res
+      testCommand testPlugins act "applyrefact" "lint" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -105,7 +105,7 @@ applyRefactSpec = do
                            , _source = Just "hlint"
                            , _message = "Parse error: :~:\n  import           Data.Type.Equality            ((:~:) (..), (:~~:) (..))\n  \n> data instance Sing (z :: (a :~: b)) where\n      SRefl :: Sing Refl\n\n"
                            , _relatedInformation = Nothing }]}
-      testCommand testPlugins act "applyrefact" "lint" arg res
+      testCommand testPlugins act "applyrefact" "lint" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -144,4 +144,3 @@ applyRefactSpec = do
             , _diagnostics = List []
             }
            ))
-

--- a/test/unit/BrittanySpec.hs
+++ b/test/unit/BrittanySpec.hs
@@ -39,7 +39,7 @@ brittanySpec = describe "brittany plugin commands" $ do
             , _newText = "foo :: Int -> String -> IO ()\nfoo x y = do\n    print x\n    return 42\n"
             }
         ]
-    testCommand testPlugins act "brittany" "format" arg res
+    testCommand testPlugins act "brittany" "format" dummyVfs arg res
 
   it "formats a document with CRLF endings" $ do
     let
@@ -54,7 +54,7 @@ brittanySpec = describe "brittany plugin commands" $ do
             , _newText = "foo :: Int -> String -> IO ()\nfoo x y = do\n    print x\n    return 42\n"
             }
         ]
-    testCommand testPlugins act "brittany" "format" arg res
+    testCommand testPlugins act "brittany" "format" dummyVfs arg res
 
   it "formats a range with LF endings" $ do
     let r   = Range (Position 1 0) (Position 2 22)
@@ -69,7 +69,7 @@ brittanySpec = describe "brittany plugin commands" $ do
               , _newText = "foo x y = do\n    print x\n    return 42\n"
               }
           ]
-    testCommand testPlugins act "brittany" "format" arg res
+    testCommand testPlugins act "brittany" "format" dummyVfs arg res
 
   it "formats a range with CRLF endings" $ do
     let r   = Range (Position 1 0) (Position 2 22)
@@ -84,4 +84,4 @@ brittanySpec = describe "brittany plugin commands" $ do
               , _newText = "foo x y = do\n    print x\n    return 42\n"
               }
           ]
-    testCommand testPlugins act "brittany" "format" arg res
+    testCommand testPlugins act "brittany" "format" dummyVfs arg res

--- a/test/unit/ExtensibleStateSpec.hs
+++ b/test/unit/ExtensibleStateSpec.hs
@@ -22,8 +22,8 @@ extensibleStateSpec =
   describe "stores and retrieves in the state" $
     it "stores the first one" $ do
       r <- runIGM testPlugins $ do
-          r1 <- makeRequest "test" "cmd1" ()
-          r2 <- makeRequest "test" "cmd2" ()
+          r1 <- makeRequest "test" "cmd1" dummyVfs ()
+          r2 <- makeRequest "test" "cmd2" dummyVfs ()
           return (r1,r2)
       fmap fromDynJSON (fst r) `shouldBe` IdeResultOk (Just "result:put foo" :: Maybe T.Text)
       fmap fromDynJSON (snd r) `shouldBe` IdeResultOk (Just "result:got:\"foo\"" :: Maybe T.Text)
@@ -51,12 +51,12 @@ testDescriptor plId = PluginDescriptor
 -- ---------------------------------------------------------------------
 
 cmd1 :: CommandFunc () T.Text
-cmd1 = CmdSync $ \_ -> do
+cmd1 = CmdSync $ \_ _ -> do
   put (MS1 "foo")
   return (IdeResultOk (T.pack "result:put foo"))
 
 cmd2 :: CommandFunc () T.Text
-cmd2 = CmdSync $ \_ -> do
+cmd2 = CmdSync $ \_ _ -> do
   (MS1 v) <- get
   return (IdeResultOk (T.pack $ "result:got:" ++ show v))
 

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -54,7 +54,7 @@ ghcmodSpec =
                             "Variable not in scope: x"
                             Nothing
 
-      testCommand testPlugins act "ghcmod" "check" arg res
+      testCommand testPlugins act "ghcmod" "check" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -68,7 +68,7 @@ ghcmodSpec =
 #else
           res = IdeResultOk (T.pack fp <> ":6:9: Warning: Redundant do\NULFound:\NUL  do return (3 + x)\NULWhy not:\NUL  return (3 + x)\n")
 #endif
-      testCommand testPlugins act "ghcmod" "lint" arg res
+      testCommand testPlugins act "ghcmod" "lint" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -79,7 +79,7 @@ ghcmodSpec =
           arg = IP uri "main"
           res = IdeResultOk "main :: IO () \t-- Defined at HaReRename.hs:2:1\n"
       -- ghc-mod tries to load the test file in the context of the hie project if we do not cd first.
-      testCommand testPlugins act "ghcmod" "info" arg res
+      testCommand testPlugins act "ghcmod" "info" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -95,7 +95,7 @@ ghcmodSpec =
             ,(Range (toPos (5,9)) (toPos (5,14)), "Int")
             ,(Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
             ]
-      testCommand testPlugins act "ghcmod" "type" arg res
+      testCommand testPlugins act "ghcmod" "type" dummyVfs arg res
 
     it "runs the type command with an absolute path from another folder, correct params" $ do
       fp <- makeAbsolute "./test/testdata/HaReRename.hs"
@@ -114,7 +114,7 @@ ghcmodSpec =
               ,(Range (toPos (5,9)) (toPos (5,14)), "Int")
               ,(Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
               ]
-        testCommand testPlugins act "ghcmod" "type" arg res
+        testCommand testPlugins act "ghcmod" "type"dummyVfs arg res
 
     -- ---------------------------------
 
@@ -130,7 +130,7 @@ ghcmodSpec =
                                 $ List [TextEdit (Range (Position 4 0) (Position 4 10))
                                           "foo Nothing = ()\nfoo (Just x) = ()"])
             Nothing
-      testCommand testPlugins act "ghcmod" "casesplit" arg res
+      testCommand testPlugins act "ghcmod" "casesplit" dummyVfs arg res
 
     it "runs the casesplit command with an absolute path from another folder, correct params" $ do
       fp <- makeAbsolute "./test/testdata/GhcModCaseSplit.hs"
@@ -149,4 +149,4 @@ ghcmodSpec =
                                   $ List [TextEdit (Range (Position 4 0) (Position 4 10))
                                             "foo Nothing = ()\nfoo (Just x) = ()"])
               Nothing
-        testCommand testPlugins act "ghcmod" "casesplit" arg res
+        testCommand testPlugins act "ghcmod" "casesplit" dummyVfs arg res

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -64,7 +64,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "rename" arg res
+      testCommand testPlugins act "hare" "rename" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -75,7 +75,7 @@ hareSpec = do
           res = IdeResultFail
                   IdeError { ideCode = PluginError
                            , ideMessage = "rename: \"Invalid cursor position!\"", ideInfo = Null}
-      testCommand testPlugins act "hare" "rename" arg res
+      testCommand testPlugins act "hare" "rename" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -87,7 +87,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "demote" arg res
+      testCommand testPlugins act "hare" "demote" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -99,7 +99,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "dupdef" arg res
+      testCommand testPlugins act "hare" "dupdef" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -114,7 +114,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "iftocase" arg res
+      testCommand testPlugins act "hare" "iftocase" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -128,7 +128,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "liftonelevel" arg res
+      testCommand testPlugins act "hare" "liftonelevel" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -144,7 +144,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "lifttotoplevel" arg res
+      testCommand testPlugins act "hare" "lifttotoplevel" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -156,7 +156,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "deletedef" arg res
+      testCommand testPlugins act "hare" "deletedef" dummyVfs arg res
 
     -- ---------------------------------
 
@@ -169,7 +169,7 @@ hareSpec = do
           res = IdeResultOk $ WorkspaceEdit
             (Just $ H.singleton uri textEdits)
             Nothing
-      testCommand testPlugins act "hare" "genapplicative" arg res
+      testCommand testPlugins act "hare" "genapplicative" dummyVfs arg res
 
     -- ---------------------------------
 


### PR DESCRIPTION
http://www.haskellforall.com/2018/10/detailed-walkthrough-for-beginner.html

As demonstrated at haskellX 2018.

A lot of this is plumbing through access to the VFS to be able to get the source text for a LSP `Range`, which is useful for all plugins anyway.

The actual work is in `HfaPlugin.hs`, where only the first 75 lines are for the plugin the rest is the code from @Gabriel439 's blog post.
