### PR TITLE
Switches to ekg-wai

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -21,7 +21,7 @@ import qualified Paths_haskell_ide_engine              as Meta
 import           System.Directory
 import           System.Environment
 import qualified System.Log.Logger                     as L
-import qualified System.Remote.Monitoring              as EKG
+import qualified System.Remote.Monitoring.Wai          as EKG
 
 -- ---------------------------------------------------------------------
 -- plugins

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -100,7 +100,7 @@ executable hie
   other-modules:       Paths_haskell_ide_engine
   build-depends:       base
                      , directory
-                     , ekg
+                     , ekg-wai
                      , ghc-mod-core
                      , haskell-ide-engine
                      , haskell-lsp

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@ extra-deps:
 - cabal-helper-0.8.1.0@rev:0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
-- ekg-0.4.0.15
+- ekg-wai-0.1.0.3
 - ekg-json-0.1.0.6
 # - ghc-exactprint-0.5.8.0
 - haddock-api-2.20.0


### PR DESCRIPTION
`haskell-ide-engine` depends on `warp` and `wai`, but `ekg` pulls in `snap` and the associated `io-streams` libraries. 

This PR switches from `ekg` to `ekg-wai`, which is a drop-in replacement for `ekg` that only depends on the `wai` ecosystem and drops total dependencies from 237 to 235 (it adds `wai-app-static` and `wai-extra`).

Dunno if this is meaningfully useful to the project, but I figured it's an easy win to avoid compiling an additional web framework and streaming library 😄 