### PR TITLE
Copy #674 for make-build-all.bat

### DIFF
--- a/make-build-all.bat
+++ b/make-build-all.bat
@@ -44,7 +44,7 @@ EXIT /B
 
 :hie-8.4.3
 CALL :submodules
-stack --stack-yaml=stack.yaml install
+stack --stack-yaml=stack-8.4.3.yaml install
 COPY "%STACKLOCALBINDIR%\hie.exe" "%STACKLOCALBINDIR%\hie-8.4.3.exe"
 COPY "%STACKLOCALBINDIR%\hie-8.4.3.exe" "%STACKLOCALBINDIR%\hie-8.4.exe"
 EXIT /B
@@ -57,5 +57,5 @@ EXIT /B
 stack --stack-yaml=stack-8.2.1.yaml exec hoogle generate
 stack --stack-yaml=stack-8.2.2.yaml exec hoogle generate
 stack --stack-yaml=stack-8.4.2.yaml exec hoogle generate
-stack --stack-yaml=stack.yaml exec hoogle generate
+stack --stack-yaml=stack-8.4.3.yaml exec hoogle generate
 EXIT /B


### PR DESCRIPTION
#674 introduced `stack-8.4.3.yaml` to `Makefile`. This makes the corresponding change to `make-build-all.bat`.