### PR TITLE
Add completion for Language Extensions

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -343,9 +343,11 @@ getCompletions uri prefixInfo (WithSnippets withSnippets) = pluginGetFile "getCo
       filtExtensionCompls = filtListWith mkExtCompl cachedExtensions
 
       result
-        | "import " `T.isPrefixOf` fullLine      = filtImportCompls
-        | "{-# LANGUAGE" `T.isPrefixOf` fullLine = filtExtensionCompls
-        | otherwise                              =
+        | "import " `T.isPrefixOf` fullLine =
+          filtImportCompls
+        | "{-# language" `T.isPrefixOf` T.toLower fullLine = 
+          filtExtensionCompls
+        | otherwise =
           filtModNameCompls ++ map (toggleSnippets . mkCompl) filtCompls
     in return $ IdeResultOk result
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -141,7 +141,7 @@ mkModCompl label =
 
 mkExtCompl :: T.Text -> J.CompletionItem
 mkExtCompl label =
-  J.CompletionItem label (Just J.CiModule) Nothing
+  J.CompletionItem label (Just J.CiKeyword) Nothing
     Nothing Nothing Nothing Nothing Nothing Nothing Nothing
     Nothing Nothing Nothing Nothing Nothing
 

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -70,7 +70,7 @@ spec = describe "completions" $ do
     let item = head $ filter ((== "OverloadedStrings") . (^. label)) compls
     liftIO $ do
       item ^. label `shouldBe` "OverloadedStrings"
-      item ^. kind `shouldBe` Just CiModule   
+      item ^. kind `shouldBe` Just CiKeyword   
   
   it "completes with no prefix" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -35,10 +35,10 @@ spec = describe "completions" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
-    let te = TextEdit (Range (Position 0 17) (Position 0 26)) "Data.M"
+    let te = TextEdit (Range (Position 1 17) (Position 1 26)) "Data.M"
     _ <- applyEdit doc te
 
-    compls <- getCompletions doc (Position 0 22)
+    compls <- getCompletions doc (Position 1 22)
     let item = head $ filter ((== "Maybe") . (^. label)) compls
     liftIO $ do
       item ^. label `shouldBe` "Maybe"
@@ -49,20 +49,33 @@ spec = describe "completions" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
-    let te = TextEdit (Range (Position 1 17) (Position 0 25)) "Dat"
+    let te = TextEdit (Range (Position 2 17) (Position 1 25)) "Dat"
     _ <- applyEdit doc te
 
-    compls <- getCompletions doc (Position 0 19)
+    compls <- getCompletions doc (Position 1 19)
     let item = head $ filter ((== "Data.List") . (^. label)) compls
     liftIO $ do
       item ^. label `shouldBe` "Data.List"
       item ^. detail `shouldBe` Just "Data.List"
       item ^. kind `shouldBe` Just CiModule
+ 
+  it "completes language extensions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+    doc <- openDoc "Completion.hs" "haskell"
+    _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+
+    let te = TextEdit (Range (Position 0 24) (Position 0 31)) ""
+    _ <- applyEdit doc te
+
+    compls <- getCompletions doc (Position 0 24)
+    let item = head $ filter ((== "OverloadedStrings") . (^. label)) compls
+    liftIO $ do
+      item ^. label `shouldBe` "OverloadedStrings"
+      item ^. kind `shouldBe` Just CiModule   
   
   it "completes with no prefix" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
     _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
-    compls <- getCompletions doc (Position 4 7)
+    compls <- getCompletions doc (Position 5 7)
     liftIO $ filter ((== "!!") . (^. label)) compls `shouldNotSatisfy` null
 
   describe "snippets" $ do
@@ -70,10 +83,10 @@ spec = describe "completions" $ do
       doc <- openDoc "Completion.hs" "haskell"
       _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
-      let te = TextEdit (Range (Position 4 7) (Position 4 24)) "Nothing"
+      let te = TextEdit (Range (Position 5 7) (Position 5 24)) "Nothing"
       _ <- applyEdit doc te
 
-      compls <- getCompletions doc (Position 4 14)
+      compls <- getCompletions doc (Position 5 14)
       let item = head $ filter ((== "Nothing") . (^. label)) compls
       liftIO $ do
         item ^. insertTextFormat `shouldBe` Just Snippet
@@ -83,10 +96,10 @@ spec = describe "completions" $ do
       doc <- openDoc "Completion.hs" "haskell"
       _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
-      let te = TextEdit (Range (Position 4 7) (Position 4 24)) "fold"
+      let te = TextEdit (Range (Position 5 7) (Position 5 24)) "fold"
       _ <- applyEdit doc te
 
-      compls <- getCompletions doc (Position 4 11)
+      compls <- getCompletions doc (Position 5 11)
       let item = head $ filter ((== "foldl") . (^. label)) compls
       liftIO $ do
         item ^. label `shouldBe` "foldl"
@@ -98,10 +111,10 @@ spec = describe "completions" $ do
       doc <- openDoc "Completion.hs" "haskell"
       _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
 
-      let te = TextEdit (Range (Position 4 7) (Position 4 24)) "mapM"
+      let te = TextEdit (Range (Position 5 7) (Position 5 24)) "mapM"
       _ <- applyEdit doc te
 
-      compls <- getCompletions doc (Position 4 11)
+      compls <- getCompletions doc (Position 5 11)
       let item = head $ filter ((== "mapM") . (^. label)) compls
       liftIO $ do
         item ^. label `shouldBe` "mapM"
@@ -126,10 +139,10 @@ spec = describe "completions" $ do
       checkNoSnippets doc
   where
     checkNoSnippets doc = do
-      let te = TextEdit (Range (Position 4 7) (Position 4 24)) "fold"
+      let te = TextEdit (Range (Position 5 7) (Position 5 24)) "fold"
       _ <- applyEdit doc te
 
-      compls <- getCompletions doc (Position 4 11)
+      compls <- getCompletions doc (Position 5 11)
       let item = head $ filter ((== "foldl") . (^. label)) compls
       liftIO $ do
         item ^. label `shouldBe` "foldl"

--- a/test/testdata/completion/Completion.hs
+++ b/test/testdata/completion/Completion.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 import           Data.Maybe
 import qualified Data.List
 


### PR DESCRIPTION
First try at resolving #867.

This adds completion for language extensions.

This changes the behaviour of completion generation to only generate completions for language extensions on lines beginning with "{-# LANGUAGE", perhaps we should modify this so it works even if the line just contains "LANGUAGE": `{-#LANGUAGE` and `{-#   LANGUAGE` would then also work.

This adds a `cachedExtensions` field to the `CachedCompletions` record, which is filled via the Ghc api. Going through GhcMod would be much more complicated, since [in ghcmod](https://github.com/DanielG/ghc-mod/blob/master/GhcMod/Exe/Lang.hs#L10) a nice list of language extensions is squashed into a string, which we'd have to parse back. Instead I just get the list via [this](https://hackage.haskell.org/package/ghc-8.6.1/docs/DynFlags.html#v:supportedLanguagesAndExtensions)

I wasn't sure what kind of [completion](https://github.com/alanz/haskell-lsp/blob/2bdec6b34f7fa76b71c4d0931557f64ae9077c75/haskell-lsp-types/src/Language/Haskell/LSP/Types/Completion.hs#L22) to give Language Extensions, so I went with `CiModule` since it seemed the most appropriate