### PR TITLE
Strip forall when completing simple types

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HieExtras.hs
@@ -119,10 +119,15 @@ mkCompl CI{origName,importedFrom,thingType,label} =
           | otherwise = label <> " " <> argText
         argText :: T.Text
         argText =  mconcat $ List.intersperse " " $ zipWith snippet [1..] argTypes
+        stripForall t 
+          | T.isPrefixOf "forall" t =
+            -- We drop 2 to remove the '.' and the space after it
+            T.drop 2 (T.dropWhile (/= '.') t)
+          | otherwise               = t
         snippet :: Int -> Type -> T.Text
         snippet i t = T.pack $ "${" <> show i <> ":" <> showGhc t <> "}"
         typeText
-          | Just t <- thingType = Just $ T.pack (showGhc t)
+          | Just t <- thingType = Just . stripForall $ T.pack (showGhc t)
           | otherwise = Nothing
         getArgs :: Type -> [Type]
         getArgs t

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -78,6 +78,26 @@ spec = describe "completions" $ do
     compls <- getCompletions doc (Position 5 7)
     liftIO $ filter ((== "!!") . (^. label)) compls `shouldNotSatisfy` null
 
+  it "have implicit foralls on basic polymorphic types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+    doc <- openDoc "Completion.hs" "haskell"
+    _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+    let te = TextEdit (Range (Position 5 7) (Position 5 9)) "id"
+    _ <- applyEdit doc te
+    compls <- getCompletions doc (Position 5 9)
+    let item = head $ filter ((== "id") . (^. label)) compls
+    liftIO $
+      item ^. detail `shouldBe` Just "a -> a\nPrelude"
+ 
+  it "have implicit foralls with multiple type variables" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
+    doc <- openDoc "Completion.hs" "haskell"
+    _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+    let te = TextEdit (Range (Position 5 7) (Position 5 24)) "flip"
+    _ <- applyEdit doc te
+    compls <- getCompletions doc (Position 5 11)
+    let item = head $ filter ((== "flip") . (^. label)) compls
+    liftIO $
+      item ^. detail `shouldBe` Just "(a -> b -> c) -> b -> a -> c\nPrelude"     
+
   describe "snippets" $ do
     it "work for argumentless constructors" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Completion.hs" "haskell"


### PR DESCRIPTION
resolves #367 

Modify completion so that the `forall a.` part of a simple
signature is stripped.

Higher ranked quantification, e.g. `(forall a. a -> a) -> Int`
isn't affected by this change.

Higher kinded types are also stripped e.g `forall (m :: * -> *).`
will be stripped.


One "edge case" of sorts are when types of multiple kinds are involved:
before, `return`, for example, was completed with:
```haskell
forall (m :: * -> *). Monad m => forall a. a -> m a
```
there's 2 quantifications there. With the somewhat naive way I've implemented forall stripping,
this becomes:
```haskell
Monad m => forall a. a -> m a
```

Should there have been 2 foralls in our completion in the first place?
Can we assume there will only ever be a situation with a single constraint arrow `=>` followed by a forall, so that we can simple strip once, move past the `=>` and the strip again? or will that not work?

Otherwise it works for the use cases described in the issue, but these edge cases might be worth looking into in this PR, or in another issue.