### PR TITLE
Add windns extra-dep for 8.4.2

### DIFF
--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -25,6 +25,7 @@ extra-deps:
 - temporary-1.2.1.1
 - yaml-0.8.32
 - yi-rope-0.11
+- windns-0.1.0.0
 
 flags:
   haskell-ide-engine:


### PR DESCRIPTION
Don't know why this is needed all of a sudden, should hopefully fix appveyor builds