### PR TITLE
Add GHC 8.4.4 support to all commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ build-docs:
 	stack --stack-yaml=stack-8.2.1.yaml exec hoogle generate \
 	&& stack --stack-yaml=stack-8.2.2.yaml exec hoogle generate \
 	&& stack --stack-yaml=stack-8.4.2.yaml exec hoogle generate \
-	&& stack --stack-yaml=stack-8.4.3.yaml exec hoogle generate
+	&& stack --stack-yaml=stack-8.4.3.yaml exec hoogle generate \
+	&& stack --stack-yaml=stack-8.4.4.yaml exec hoogle generate
 .PHONY: build-docs
 
 
@@ -79,14 +80,16 @@ test: submodules
 	stack --stack-yaml=stack-8.2.1.yaml test \
 	&& stack --stack-yaml=stack-8.2.2.yaml test \
 	&& stack --stack-yaml=stack-8.4.2.yaml test \
-	&& stack --stack-yaml=stack-8.4.3.yaml test
+	&& stack --stack-yaml=stack-8.4.3.yaml test \
+	&& stack --stack-yaml=stack-8.4.4.yaml test
 .PHONY: test
 
 build-copy-compiler-tool: submodules
 	stack --stack-yaml=stack-8.2.1.yaml build --copy-compiler-tool \
 	&& stack --stack-yaml=stack-8.2.2.yaml build --copy-compiler-tool \
 	&& stack --stack-yaml=stack-8.4.2.yaml build --copy-compiler-tool \
-	&& stack --stack-yaml=stack-8.4.3.yaml build --copy-compiler-tool
+	&& stack --stack-yaml=stack-8.4.3.yaml build --copy-compiler-tool \
+	&& stack --stack-yaml=stack-8.4.4.yaml build --copy-compiler-tool
 .PHONY: build-copy-compiler-tool
 
 ## Fixes icu related problems in MacOS
@@ -108,6 +111,9 @@ icu-macos-fix-build:
 	  --extra-lib-dirs=/usr/local/opt/icu4c/lib            \
 	  --extra-include-dirs=/usr/local/opt/icu4c/include    \
 	&& stack --stack-yaml=stack-8.4.3.yaml build text-icu  \
+	  --extra-lib-dirs=/usr/local/opt/icu4c/lib            \
+	  --extra-include-dirs=/usr/local/opt/icu4c/include    \
+	&& stack --stack-yaml=stack-8.4.4.yaml build text-icu  \
 	  --extra-lib-dirs=/usr/local/opt/icu4c/lib            \
 	  --extra-include-dirs=/usr/local/opt/icu4c/include
 .PHONY: icu-macos-fix-build


### PR DESCRIPTION
There were a few commands missing the stack-8.4.4.yaml, namely build-docs, test, 
build-copy-compiler-tool and icu-macos-fix-build.