### PR TITLE
Make casesplit a HaRe action

### DIFF
--- a/test/functional/HaReSpec.hs
+++ b/test/functional/HaReSpec.hs
@@ -49,6 +49,13 @@ spec = describe "HaRe" $
           expected = "\nmain = putStrLn \"hello\"\n\n\
                      \foo x = y + 3\n  where\n    y = 7\n"
         in execCodeAction "HaReDemote.hs" r "Demote y one level" expected
+    context "casesplit argument" $ it "works" $
+      let r = Range (Position 4 5) (Position 4 6)
+          expected = "\nmain = putStrLn \"hello\"\n\n\
+                     \foo :: Maybe Int -> ()\n\
+                     \foo Nothing = ()\n\
+                     \foo (Just x) = ()\n"
+        in execCodeAction "GhcModCaseSplit.hs" r "Case split on x" expected
 
 
 getCANamed :: T.Text -> [CAResult] -> CodeAction

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -3,6 +3,7 @@
 module GhcModPluginSpec where
 
 import           Control.Exception
+import qualified Data.HashMap.Strict                 as H
 import qualified Data.Map                            as Map
 #if __GLASGOW_HASKELL__ < 804
 import           Data.Monoid
@@ -10,9 +11,11 @@ import           Data.Monoid
 import qualified Data.Set                            as S
 import qualified Data.Text                           as T
 import           Haskell.Ide.Engine.MonadTypes
+import           Haskell.Ide.Engine.Plugin.GhcMod
+import           Haskell.Ide.Engine.Plugin.HieExtras
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
-import           Haskell.Ide.Engine.Plugin.GhcMod
+import           Language.Haskell.LSP.Types          (TextEdit (..))
 import           System.Directory
 import           TestUtils
 
@@ -112,3 +115,38 @@ ghcmodSpec =
               ,(Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
               ]
         testCommand testPlugins act "ghcmod" "type"dummyVfs arg res
+
+    -- ---------------------------------
+
+    it "runs the casesplit command" $ cdAndDo "./test/testdata" $ do
+      fp <- makeAbsolute "GhcModCaseSplit.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            splitCaseCmd' uri (toPos (5,5))
+          arg = HP uri (toPos (5,5))
+          res = IdeResultOk $ WorkspaceEdit
+            (Just $ H.singleton uri
+                                $ List [TextEdit (Range (Position 4 0) (Position 4 10))
+                                          "foo Nothing = ()\nfoo (Just x) = ()"])
+            Nothing
+      testCommand testPlugins act "ghcmod" "casesplit" dummyVfs arg res
+
+    it "runs the casesplit command with an absolute path from another folder, correct params" $ do
+      fp <- makeAbsolute "./test/testdata/GhcModCaseSplit.hs"
+      cd <- getCurrentDirectory
+      cd2 <- getHomeDirectory
+      bracket (setCurrentDirectory cd2)
+              (\_-> setCurrentDirectory cd)
+              $ \_-> do
+        let uri = filePathToUri fp
+            act = do
+              _ <- setTypecheckedModule uri
+              splitCaseCmd' uri (toPos (5,5))
+            arg = HP uri (toPos (5,5))
+            res = IdeResultOk $ WorkspaceEdit
+              (Just $ H.singleton uri
+                                  $ List [TextEdit (Range (Position 4 0) (Position 4 10))
+                                            "foo Nothing = ()\nfoo (Just x) = ()"])
+              Nothing
+        testCommand testPlugins act "ghcmod" "casesplit" dummyVfs arg res

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -3,7 +3,6 @@
 module GhcModPluginSpec where
 
 import           Control.Exception
-import qualified Data.HashMap.Strict                 as H
 import qualified Data.Map                            as Map
 #if __GLASGOW_HASKELL__ < 804
 import           Data.Monoid
@@ -14,8 +13,6 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginDescriptor
 import           Haskell.Ide.Engine.PluginUtils
 import           Haskell.Ide.Engine.Plugin.GhcMod
-import           Haskell.Ide.Engine.Plugin.HaRe ( HarePoint(..) )
-import           Language.Haskell.LSP.Types     ( TextEdit(..) )
 import           System.Directory
 import           TestUtils
 
@@ -115,38 +112,3 @@ ghcmodSpec =
               ,(Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
               ]
         testCommand testPlugins act "ghcmod" "type"dummyVfs arg res
-
-    -- ---------------------------------
-
-    it "runs the casesplit command" $ cdAndDo "./test/testdata" $ do
-      fp <- makeAbsolute "GhcModCaseSplit.hs"
-      let uri = filePathToUri fp
-          act = do
-            _ <- setTypecheckedModule uri
-            splitCaseCmd' uri (toPos (5,5))
-          arg = HP uri (toPos (5,5))
-          res = IdeResultOk $ WorkspaceEdit
-            (Just $ H.singleton uri
-                                $ List [TextEdit (Range (Position 4 0) (Position 4 10))
-                                          "foo Nothing = ()\nfoo (Just x) = ()"])
-            Nothing
-      testCommand testPlugins act "ghcmod" "casesplit" dummyVfs arg res
-
-    it "runs the casesplit command with an absolute path from another folder, correct params" $ do
-      fp <- makeAbsolute "./test/testdata/GhcModCaseSplit.hs"
-      cd <- getCurrentDirectory
-      cd2 <- getHomeDirectory
-      bracket (setCurrentDirectory cd2)
-              (\_-> setCurrentDirectory cd)
-              $ \_-> do
-        let uri = filePathToUri fp
-            act = do
-              _ <- setTypecheckedModule uri
-              splitCaseCmd' uri (toPos (5,5))
-            arg = HP uri (toPos (5,5))
-            res = IdeResultOk $ WorkspaceEdit
-              (Just $ H.singleton uri
-                                  $ List [TextEdit (Range (Position 4 0) (Position 4 10))
-                                            "foo Nothing = ()\nfoo (Just x) = ()"])
-              Nothing
-        testCommand testPlugins act "ghcmod" "casesplit" dummyVfs arg res

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module HaRePluginSpec where
 
-import           Control.Exception
 import           Control.Monad.Trans.Free
 import           Control.Monad.IO.Class
 import           Data.Aeson
@@ -171,41 +170,6 @@ hareSpec = do
             (Just $ H.singleton uri textEdits)
             Nothing
       testCommand testPlugins act "hare" "genapplicative" dummyVfs arg res
-
-    -- ---------------------------------
-
-    it "runs the casesplit command" $ cdAndDo "./test/testdata" $ do
-      fp <- makeAbsolute "GhcModCaseSplit.hs"
-      let uri = filePathToUri fp
-          act = do
-            _ <- setTypecheckedModule uri
-            splitCaseCmd' uri (toPos (5,5))
-          arg = HP uri (toPos (5,5))
-          res = IdeResultOk $ WorkspaceEdit
-            (Just $ H.singleton uri
-                                $ List [TextEdit (Range (Position 4 0) (Position 4 10))
-                                          "foo Nothing = ()\nfoo (Just x) = ()"])
-            Nothing
-      testCommand testPlugins act "hare" "casesplit" dummyVfs arg res
-
-    it "runs the casesplit command with an absolute path from another folder, correct params" $ do
-      fp <- makeAbsolute "./test/testdata/GhcModCaseSplit.hs"
-      cd <- getCurrentDirectory
-      cd2 <- getHomeDirectory
-      bracket (setCurrentDirectory cd2)
-              (\_-> setCurrentDirectory cd)
-              $ \_-> do
-        let uri = filePathToUri fp
-            act = do
-              _ <- setTypecheckedModule uri
-              splitCaseCmd' uri (toPos (5,5))
-            arg = HP uri (toPos (5,5))
-            res = IdeResultOk $ WorkspaceEdit
-              (Just $ H.singleton uri
-                                  $ List [TextEdit (Range (Position 4 0) (Position 4 10))
-                                            "foo Nothing = ()\nfoo (Just x) = ()"])
-              Nothing
-        testCommand testPlugins act "hare" "casesplit" dummyVfs arg res
 
     -- ---------------------------------
 

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module HaRePluginSpec where
 
+import           Control.Exception
 import           Control.Monad.Trans.Free
 import           Control.Monad.IO.Class
 import           Data.Aeson
@@ -170,6 +171,41 @@ hareSpec = do
             (Just $ H.singleton uri textEdits)
             Nothing
       testCommand testPlugins act "hare" "genapplicative" dummyVfs arg res
+
+    -- ---------------------------------
+
+    it "runs the casesplit command" $ cdAndDo "./test/testdata" $ do
+      fp <- makeAbsolute "GhcModCaseSplit.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            splitCaseCmd' uri (toPos (5,5))
+          arg = HP uri (toPos (5,5))
+          res = IdeResultOk $ WorkspaceEdit
+            (Just $ H.singleton uri
+                                $ List [TextEdit (Range (Position 4 0) (Position 4 10))
+                                          "foo Nothing = ()\nfoo (Just x) = ()"])
+            Nothing
+      testCommand testPlugins act "hare" "casesplit" dummyVfs arg res
+
+    it "runs the casesplit command with an absolute path from another folder, correct params" $ do
+      fp <- makeAbsolute "./test/testdata/GhcModCaseSplit.hs"
+      cd <- getCurrentDirectory
+      cd2 <- getHomeDirectory
+      bracket (setCurrentDirectory cd2)
+              (\_-> setCurrentDirectory cd)
+              $ \_-> do
+        let uri = filePathToUri fp
+            act = do
+              _ <- setTypecheckedModule uri
+              splitCaseCmd' uri (toPos (5,5))
+            arg = HP uri (toPos (5,5))
+            res = IdeResultOk $ WorkspaceEdit
+              (Just $ H.singleton uri
+                                  $ List [TextEdit (Range (Position 4 0) (Position 4 10))
+                                            "foo Nothing = ()\nfoo (Just x) = ()"])
+              Nothing
+        testCommand testPlugins act "hare" "casesplit" dummyVfs arg res
 
     -- ---------------------------------
 

--- a/test/unit/JsonSpec.hs
+++ b/test/unit/JsonSpec.hs
@@ -10,6 +10,7 @@ import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Plugin.ApplyRefact
 import           Haskell.Ide.Engine.Plugin.GhcMod
 import           Haskell.Ide.Engine.Plugin.HaRe
+import           Haskell.Ide.Engine.Plugin.HieExtras
 import           Haskell.Ide.Engine.LSP.Config
 
 import           Data.Aeson


### PR DESCRIPTION
Move `splitCaseCmd` from the GhcMod plugin to the HaRe plugin in order to avoid a circular dependency. 
Move the `casesplit`  tests to HaRe tests file. 
Add a `casesplit` CodeAction test.
I have created an associated [pull request](https://github.com/alanz/vscode-hie-server/pull/121) to avoid breaking vscode-hie-server use of `ghcmod:casesplit`.

closes: https://github.com/haskell/haskell-ide-engine/issues/907