### PR TITLE
Bump stack resolvers

### DIFF
--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.16 # LTS 12.15 is first to support GHC 8.4.4
+resolver: lts-12.17 # LTS 12.15 is first to support GHC 8.4.4
 packages:
 - .
 - hie-plugin-api

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-09-28 # Last GHC 8.4.3
+resolver: lts-12.17 # GHC 8.4.4
 packages:
 - .
 - hie-plugin-api
@@ -8,23 +8,19 @@ extra-deps:
 - ./submodules/HaRe
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
-
-- aeson-1.3.1.1
 - base-compat-0.9.3
-- base-orphans-0.7
 - cabal-helper-0.8.1.0@rev:0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
-- ekg-json-0.1.0.6
-- ekg-wai-0.1.0.3
+- ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
+- haddock-library-1.6.0
+- haskell-lsp-0.8.0.1
+- haskell-lsp-types-0.8.0.1
 - hsimport-0.8.6
 - lsp-test-0.4.0.0
-- monad-memo-0.4.1
-- semigroupoids-5.2.2
 - syz-0.2.0.0
 - temporary-1.2.1.1
-- yaml-0.8.32
 
 flags:
   haskell-ide-engine:


### PR DESCRIPTION
Bring both the nightly and 8.4.4 stack files to lts12.17. Eventually the nightly will point to the 8.6.1 nightlies?