### PR TITLE
Add dist command to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,31 @@ icu-macos-fix-build:
 	  --extra-include-dirs=/usr/local/opt/icu4c/include
 .PHONY: icu-macos-fix-build
 
+# ------------------------------------------------------
+
+HIE_GIT_REF:=$(shell git symbolic-ref -q --short HEAD || git describe --tags --exact-match)
+HIE_DIST_NAME:=hie-${HIE_GIT_REF}-`uname -m`-`uname -s`
+HIE_DIST_DIR:=/tmp/${HIE_DIST_NAME}
+## Creates a tarball containing all the hie binaries
+dist:
+	mkdir ${HIE_DIST_DIR}
+	stack --stack-yaml=stack-8.2.1.yaml build
+	cp .stack-work/install/*/*/8.2.1/bin/hie ${HIE_DIST_DIR}/hie-8.2.1
+	stack --stack-yaml=stack-8.2.2.yaml build
+	cp .stack-work/install/*/*/8.2.2/bin/hie ${HIE_DIST_DIR}/hie-8.2.2
+	stack --stack-yaml=stack-8.4.2.yaml build
+	cp .stack-work/install/*/*/8.4.2/bin/hie ${HIE_DIST_DIR}/hie-8.4.2
+	stack --stack-yaml=stack-8.4.3.yaml build
+	cp .stack-work/install/*/*/8.4.3/bin/hie ${HIE_DIST_DIR}/hie-8.4.3
+	stack --stack-yaml=stack-8.4.4.yaml build
+	cp .stack-work/install/*/*/8.4.4/bin/hie ${HIE_DIST_DIR}/hie
+	cp .stack-work/install/*/*/8.4.4/bin/hie ${HIE_DIST_DIR}/hie-8.4.4
+	cp .stack-work/install/*/*/8.4.4/bin/hie-wrapper ${HIE_DIST_DIR}/hie-wrapper
+	tar -czf ${HIE_DIST_NAME}.tar.gz -C ${HIE_DIST_DIR} .
+	rm -r ${HIE_DIST_DIR}
+.PHONY: dist
+
+
 #######################################################################################################################
 # Help task
 #######################################################################################################################


### PR DESCRIPTION
Builds and tars up all binaries into a tarball with the name based off of the tag + platform it was built on. Only tested on Darwin so far, can windows/linux people try this out?