### PR TITLE
Adding hie-nix instructions to readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ we talk to clients.__
         - [ArchLinux](#archlinux)
     - [Configuration](#configuration)
     - [Editor Integration](#editor-integration)
-        - Using HIE with [VS Code](#using-hie-with-vs-code), [Sublime Text](#using-hie-with-sublime-text), [Vim/Neovim](#using-hie-with-vim-or-neovim), [Atom](#using-hie-with-atom), [Oni](#using-hie-with-oni), [Emacs](#using-hie-with-emacs) or [Spacemacs](#using-hie-with-spacemacs)
+        - Using HIE with [VS Code](#using-hie-with-vs-code), [Sublime Text](#using-hie-with-sublime-text), [Vim/Neovim](#using-hie-with-vim-or-neovim), [Atom](#using-hie-with-atom), [Oni](#using-hie-with-oni), [Emacs](#using-hie-with-emacs), [Spacemacs](#using-hie-with-spacemacs) or [Spacemacs+Nix](#using-hie-with-spacemacs-on-nix-based-projects)
     - [Docs on hover/completion](#docs-on-hovercompletion)
     - [Contributing](#contributing)
         - [Planned Features](#planned-features)
@@ -436,6 +436,18 @@ and then activate [`lsp-haskell`](https://github.com/emacs-lsp/lsp-haskell) in y
 ```
 
 Now you should be able to use HIE in Spacemacs. I still recommend checking out [lsp-ui](https://github.com/emacs-lsp/lsp-ui) and [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
+
+### Using HIE with Spacemacs on Nix Based Projects
+
+If you use HIE with spacemacs on nix-built haskell projects, you may want to try
+out [this spacemacs layer](https://github.com/benkolera/spacemacs-hie-nix). It
+has installation instructions which includes a nix expression to install
+everything that hie needs in your environment. It wraps the hie binary calls to
+use nix-sandbox to find the closest ancestor directory that has nixfiles.
+
+It is still pretty new and may change drastically as the author understands the
+lsp, lsp-ui, lsp-haskell, hie stack a bit better. PRs and feedback are very
+welcome on the layer's repo if you find it useful and/or lacking in some way.
 
 ### Using HIE with Oni
 


### PR DESCRIPTION
I made a spacemacs layer and nix expression for those interested in spacemacs+hie+nix. It is the simplest thing that works rather than layering it on the haskell layer while I don't fully grok all the layers and interactions yet. This links it to the hie readme at @alanz 's request on irc.

May morph into a layer that can handle nix and non-nix hie project, get layered on the haskell layer or get merged into the official layer one day. Don't know which option is best yet, but it is a start! :slightly_smiling_face: 