### PR TITLE
Use travis to generate MacOS binary releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
     packages:
     - z3
     - stack
-    - cabal-install
 
 cache:
   directories:
@@ -37,13 +36,6 @@ jobs:
      - stage: setup
        env: GHC_VER="8.4.4"
        script: &setup
-         - |
-           if [ ! -f $HOME/.cabal/bin/liquid ]; then
-             stack setup 8.2.2
-             cabal update
-             cabal install liquidhaskell -w $HOME/.stack/programs/x86_64-osx/ghc-8.2.2/bin/ghc
-           fi
-         - export PATH=$HOME/.cabal/bin/:$PATH
          - mkdir -p dist
          - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml setup
          # Build a big package to offload the next stage from doing too much work

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ jobs:
        script: &test
          - stack --no-terminal --stack-yaml=stack-$GHC_VER.yaml install
          - mv $HOME/.local/bin/hie $HOME/.dist/hie-$GHC_VER
+         - ls $HOME/.dist
          - |
            if [ "${GHC_VER}" == "8.4.4" ]; then
              mv $HOME/.local/bin/hie-wrapper $HOME/.dist/hie-wrapper
@@ -109,6 +110,7 @@ jobs:
 
      - stage: deploy
        script:
+         - ls $HOME/.dist
          - upx -q --best $HOME/.dist/hie-8.4.4
          - upx -q --best $HOME/.dist/hie-8.4.3
          - upx -q --best $HOME/.dist/hie-8.4.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,10 +85,10 @@ jobs:
        env: GHC_VER="8.4.4"
        script: &test
          - stack --no-terminal --stack-yaml=stack-$GHC_VER.yaml install
-         - mv .stack-work/install/*/*/$GHC_VER/bin/hie $HOME/.dist/hie-$GHC_VER
+         - mv $HOME/.local/bin/hie $HOME/.dist/hie-$GHC_VER
          - |
            if [ "${GHC_VER}" == "8.4.4" ]; then
-             mv .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper $HOME/.dist/hie-wrapper
+             mv $HOME/.local/bin/hie-wrapper $HOME/.dist/hie-wrapper
            fi
 
      - stage: test
@@ -109,7 +109,11 @@ jobs:
 
      - stage: deploy
        script:
-         - upx -q --best $HOME/.dist/hie*
+         - upx -q --best $HOME/.dist/hie-8.4.4
+         - upx -q --best $HOME/.dist/hie-8.4.3
+         - upx -q --best $HOME/.dist/hie-8.4.2
+         - upx -q --best $HOME/.dist/hie-8.2.2
+         - upx -q --best $HOME/.dist/hie-8.2.1
          - tar czf "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz" $HOME/.dist
        deploy:
          provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ cache:
   - $HOME/.stack
   - $HOME/.cabal/
   - $TRAVIS_BUILD_DIR/.stack-work
+  - $TRAVIS_BUILD_DIR/submodules/brittany/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/HaRe/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/ghc-mod/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/ghc-mod/core/.stack-work
@@ -21,7 +22,7 @@ cache:
   - $TRAVIS_BUILD_DIR/submodules/haskell-lsp/haskell-lsp-types/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/cabal-helper/.stack-work
   - $TRAVIS_BUILD_DIR/hie-plugin-api/.stack-work
-  - $TRAVIS_BUILD_DIR/dist
+  - $TRAVIS_BUILD_DIR/.dist
   timeout: 800
 before_cache:
   - rm -rf $TRAVIS_BUILD_DIR/.stack-work/logs/
@@ -37,7 +38,7 @@ jobs:
      - stage: setup
        env: GHC_VER="8.4.4"
        script: &setup
-         - mkdir -p dist
+         - mkdir -p $TRAVIS_BUILD_DIR/.dist
          - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml setup
          # Build a big package to offload the next stage from doing too much work
          - stack --stack-yaml=stack-$GHC_VER.yaml build lens
@@ -83,10 +84,10 @@ jobs:
        env: GHC_VER="8.4.4"
        script: &test
          - stack --no-terminal --stack-yaml=stack-$GHC_VER.yaml build
-         - mv .stack-work/install/*/*/*/bin/hie dist/hie-$GHC_VER
+         - mv .stack-work/install/*/*/*/bin/hie $TRAVIS_BUILD_DIR/.dist/hie-$GHC_VER
          - |
            if [ "${GHC_VER}" == "8.4.4" ]; then
-             mv .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper dist/hie-wrapper
+             mv .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper $TRAVIS_BUILD_DIR/.dist/hie-wrapper
            fi
 
      - stage: test
@@ -107,8 +108,8 @@ jobs:
 
      - stage: deploy
        script:
-         - upx -q --best --ultra-brute dist/hie*
-         - tar czf "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz" dist
+         - upx -q --best --ultra-brute $TRAVIS_BUILD_DIR/.dist/hie*
+         - tar czf "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz" $TRAVIS_BUILD_DIR/.dist
        deploy:
          provider: releases
          api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
          - mkdir -p dist
          - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml setup
          # Build a big package to offload the next stage from doing too much work
-         - stack $ARGS build lens
+         - stack --stack-yaml=stack-$GHC_VER.yaml build lens
 
      - stage: setup
        env: GHC_VER="8.4.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
   - $TRAVIS_BUILD_DIR/submodules/haskell-lsp/haskell-lsp-types/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/cabal-helper/.stack-work
   - $TRAVIS_BUILD_DIR/hie-plugin-api/.stack-work
-  - $HOME/.dist
   timeout: 800
 before_cache:
   - rm -rf $TRAVIS_BUILD_DIR/.stack-work/logs/
@@ -38,7 +37,6 @@ jobs:
      - stage: setup
        env: GHC_VER="8.4.4"
        script: &setup
-         - mkdir -p $HOME/.dist
          - ls .stack-work/install/*/*/*/bin/hie || true
          - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml setup
          # Build a big package to offload the next stage from doing too much work
@@ -85,12 +83,6 @@ jobs:
        env: GHC_VER="8.4.4"
        script: &test
          - stack --no-terminal --stack-yaml=stack-$GHC_VER.yaml install
-         - mv $HOME/.local/bin/hie $HOME/.dist/hie-$GHC_VER
-         - ls $HOME/.dist
-         - |
-           if [ "${GHC_VER}" == "8.4.4" ]; then
-             mv $HOME/.local/bin/hie-wrapper $HOME/.dist/hie-wrapper
-           fi
 
      - stage: test
        env: GHC_VER="8.4.3"
@@ -109,22 +101,42 @@ jobs:
        script: *test
 
      - stage: deploy
-       script:
-         - ls $HOME/.dist
-         - upx -q --best $HOME/.dist/hie-8.4.4
-         - upx -q --best $HOME/.dist/hie-8.4.3
-         - upx -q --best $HOME/.dist/hie-8.4.2
-         - upx -q --best $HOME/.dist/hie-8.2.2
-         - upx -q --best $HOME/.dist/hie-8.2.1
-         - tar czf "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz" $HOME/.dist
-       deploy:
+       env: GHC_VER="8.4.4"
+       script: &deploy
+         - mkdir -p $HOME/.dist
+         - cp .stack-work/install/*/*/$GHC_VER/bin/hie $HOME/.dist
+         - cp .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper $HOME/.dist
+         - upx -q --best $HOME/.dist/hie-$GHC_VER
+         - upx -q --best $HOME/.dist/hie-wrapper
+         - tar czf "hie-$GHC_VER-Darwin.tar.gz" $HOME/.dist
+       deploy: &upload
          provider: releases
          api_key:
            secure: K12xUSzK+VWpnS4gRo04rJjfi71sBi0zuMWKmAcsK1igvmdbsEjyuyX4SxFI58/sM4x5qlyXg/nWSPfECKjpQS7/Q/GG1ub+AjU9kq5iyiWACWjXpDLN9Jz9iLBceyPLaf3y3rswri45v7LdwvMNwSI/wYNKEz97IfJ3VkCR16kWv/cqHGdJUYWZk7lBJX/BL94Bof4zOoXwSiy0GbaSCptcSHm1qwtN1qYsYnmihgLYR0RtLRz6tvBPHmqDjsWAXMDhaEyi0zfZ06igITkm7E4at+c3/wssYfgSg15AT2fd5T+v9keyzyanBzGh9xHYcMmflIA9dAvQawl/vw8sGsnQRaddhmTd0bqKFrtrnMO5dRsbkIyu1r178BQCJVjvy5KqyVpXy1ycDcO17E5qONVr2V838x6eg9uPJBNGR30XMg3ZF+GPsbz0xhzxf2Hhab82pJ+lAAsBlnaPdDNVchs/wjEFMp94hcL+IL4ydaXk91piPVhs3VPsLfGboQ72sUnyPUI2aiKfkk5P4Xug+2UqbX17fXfLgnkRbfyCd/4IeM4IwHgRAKa3tT7017KGSZBShihqe2dDJBjS8MlIxDD+U69HR2TIkAJaDnJe+UFAndoc8w4Ajd2OJ1/C+ey236SZq9R7D3dqyFi6Sxc1kSpNguVmjjvlEUk/Jpz1ckA=
          file:
-           - "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz"
+           - "hie-$GHC_VER-Darwin.tar.gz"
          skip_cleanup: true
          draft: true
          tag_name: "${TRAVIS_TAG}"
          on:
           tags: true
+
+     - stage: deploy
+       env: GHC_VER="8.4.3"
+       script: *deploy
+       deploy: *upload
+
+     - stage: deploy
+       env: GHC_VER="8.4.2"
+       script: *deploy
+       deploy: *upload
+
+     - stage: deploy
+       env: GHC_VER="8.2.2"
+       script: *deploy
+       deploy: *upload
+
+     - stage: deploy
+       env: GHC_VER="8.2.1"
+       script: *deploy
+       deploy: *upload

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
   - $TRAVIS_BUILD_DIR/submodules/haskell-lsp/haskell-lsp-types/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/cabal-helper/.stack-work
   - $TRAVIS_BUILD_DIR/hie-plugin-api/.stack-work
-  - $TRAVIS_BUILD_DIR/.dist
+  - $HOME/.dist
   timeout: 800
 before_cache:
   - rm -rf $TRAVIS_BUILD_DIR/.stack-work/logs/
@@ -38,7 +38,8 @@ jobs:
      - stage: setup
        env: GHC_VER="8.4.4"
        script: &setup
-         - mkdir -p $TRAVIS_BUILD_DIR/.dist
+         - mkdir -p $HOME/.dist
+         - ls $HOME/.dist
          - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml setup
          # Build a big package to offload the next stage from doing too much work
          - stack --stack-yaml=stack-$GHC_VER.yaml build lens
@@ -84,10 +85,10 @@ jobs:
        env: GHC_VER="8.4.4"
        script: &test
          - stack --no-terminal --stack-yaml=stack-$GHC_VER.yaml build
-         - mv .stack-work/install/*/*/*/bin/hie $TRAVIS_BUILD_DIR/.dist/hie-$GHC_VER
+         - mv .stack-work/install/*/*/$GHC_VER/bin/hie $HOME/.dist/hie-$GHC_VER
          - |
            if [ "${GHC_VER}" == "8.4.4" ]; then
-             mv .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper $TRAVIS_BUILD_DIR/.dist/hie-wrapper
+             mv .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper $HOME/.dist/hie-wrapper
            fi
 
      - stage: test
@@ -108,8 +109,8 @@ jobs:
 
      - stage: deploy
        script:
-         - upx -q --best $TRAVIS_BUILD_DIR/.dist/hie*
-         - tar czf "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz" $TRAVIS_BUILD_DIR/.dist
+         - upx -q --best $HOME/.dist/hie*
+         - tar czf "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz" $HOME/.dist
        deploy:
          provider: releases
          api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ jobs:
 
      - stage: deploy
        script:
-         - upx -q --best --ultra-brute $TRAVIS_BUILD_DIR/.dist/hie*
+         - upx -q --best $TRAVIS_BUILD_DIR/.dist/hie*
          - tar czf "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz" $TRAVIS_BUILD_DIR/.dist
        deploy:
          provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
        env: GHC_VER="8.4.4"
        script: &setup
          - mkdir -p $HOME/.dist
-         - ls $HOME/.dist
+         - ls .stack-work/install/*/*/*/bin/hie || true
          - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml setup
          # Build a big package to offload the next stage from doing too much work
          - stack --stack-yaml=stack-$GHC_VER.yaml build lens
@@ -84,7 +84,7 @@ jobs:
      - stage: test
        env: GHC_VER="8.4.4"
        script: &test
-         - stack --no-terminal --stack-yaml=stack-$GHC_VER.yaml build
+         - stack --no-terminal --stack-yaml=stack-$GHC_VER.yaml install
          - mv .stack-work/install/*/*/$GHC_VER/bin/hie $HOME/.dist/hie-$GHC_VER
          - |
            if [ "${GHC_VER}" == "8.4.4" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 sudo: false
 language: c
 os: osx
-env:
-- GHC_VER=8.4.3
-- GHC_VER=8.4.2
-- GHC_VER=8.2.2
-- GHC_VER=8.2.1
+
 addons:
   homebrew:
     packages:
     - z3
     - stack
     - cabal-install
+
 cache:
   directories:
   - $HOME/.stack
-  - $HOME/.local/bin
   - $HOME/.cabal/
   - $TRAVIS_BUILD_DIR/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/HaRe/.stack-work
@@ -24,37 +20,105 @@ cache:
   - $TRAVIS_BUILD_DIR/submodules/haskell-lsp/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/haskell-lsp/haskell-lsp-types/.stack-work
   - $TRAVIS_BUILD_DIR/submodules/cabal-helper/.stack-work
-  - $TRAVIS_BUILD_DIR/submodules/brittany/.stack-work
   - $TRAVIS_BUILD_DIR/hie-plugin-api/.stack-work
+  - $TRAVIS_BUILD_DIR/dist
   timeout: 800
 before_cache:
   - rm -rf $TRAVIS_BUILD_DIR/.stack-work/logs/
-install:
-- |
-  if [ ! -f $HOME/.cabal/bin/liquid ]; then
-    stack setup 8.2.2
-    cabal update
-    cabal install liquidhaskell -w $HOME/.stack/programs/x86_64-osx/ghc-8.2.2/bin/ghc
-  fi
-- export PATH=$HOME/.cabal/bin/:$PATH
-script:
-- stack build --stack-yaml=stack-$GHC_VER.yaml
-- stack exec hoogle generate --stack-yaml=stack-$GHC_VER.yaml
-- stack test --stack-yaml=stack-$GHC_VER.yaml
-before_deploy:
-- mv .stack-work/install/*/*/*/bin/hie hie-$GHC_VER
-- |
-  if [ "${GHC_VER}" == "8.4.3" ]; then
-    mv .stack-work/install/*/*/8.4.3/bin/hie-wrapper hie-wrapper
-  fi
-deploy:
-  provider: releases
-  api_key:
-    secure: K12xUSzK+VWpnS4gRo04rJjfi71sBi0zuMWKmAcsK1igvmdbsEjyuyX4SxFI58/sM4x5qlyXg/nWSPfECKjpQS7/Q/GG1ub+AjU9kq5iyiWACWjXpDLN9Jz9iLBceyPLaf3y3rswri45v7LdwvMNwSI/wYNKEz97IfJ3VkCR16kWv/cqHGdJUYWZk7lBJX/BL94Bof4zOoXwSiy0GbaSCptcSHm1qwtN1qYsYnmihgLYR0RtLRz6tvBPHmqDjsWAXMDhaEyi0zfZ06igITkm7E4at+c3/wssYfgSg15AT2fd5T+v9keyzyanBzGh9xHYcMmflIA9dAvQawl/vw8sGsnQRaddhmTd0bqKFrtrnMO5dRsbkIyu1r178BQCJVjvy5KqyVpXy1ycDcO17E5qONVr2V838x6eg9uPJBNGR30XMg3ZF+GPsbz0xhzxf2Hhab82pJ+lAAsBlnaPdDNVchs/wjEFMp94hcL+IL4ydaXk91piPVhs3VPsLfGboQ72sUnyPUI2aiKfkk5P4Xug+2UqbX17fXfLgnkRbfyCd/4IeM4IwHgRAKa3tT7017KGSZBShihqe2dDJBjS8MlIxDD+U69HR2TIkAJaDnJe+UFAndoc8w4Ajd2OJ1/C+ey236SZq9R7D3dqyFi6Sxc1kSpNguVmjjvlEUk/Jpz1ckA=
-  file:
-    - hie-$GHC_VER
-    - hie-wrapper
-  file_glob: true
-  skip_cleanup: true
-  on:
-    tags: true
+
+stages:
+  - setup
+  - dependencies
+  - test
+  - deploy
+
+jobs:
+   include:
+     - stage: setup
+       env: GHC_VER="8.4.4"
+       script: &setup
+         - |
+           if [ ! -f $HOME/.cabal/bin/liquid ]; then
+             stack setup 8.2.2
+             cabal update
+             cabal install liquidhaskell -w $HOME/.stack/programs/x86_64-osx/ghc-8.2.2/bin/ghc
+           fi
+         - export PATH=$HOME/.cabal/bin/:$PATH
+         - mkdir -p dist
+         - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml setup
+         # Build a big package to offload the next stage from doing too much work
+         - stack $ARGS build lens
+
+     - stage: setup
+       env: GHC_VER="8.4.3"
+       script: *setup
+
+     - stage: setup
+       env: GHC_VER="8.4.2"
+       script: *setup
+
+     - stage: setup
+       env: GHC_VER="8.2.2"
+       script: *setup
+
+     - stage: setup
+       env: GHC_VER="8.2.1"
+       script: *setup
+
+     - stage: dependencies
+       env: GHC_VER="8.4.4"
+       script: &dependencies
+         - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml test --only-dependencies --no-run-tests
+
+     - stage: dependencies
+       env: GHC_VER="8.4.3"
+       script: *dependencies
+
+     - stage: dependencies
+       env: GHC_VER="8.4.2"
+       script: *dependencies
+
+     - stage: dependencies
+       env: GHC_VER="8.2.2"
+       script: *dependencies
+
+     - stage: dependencies
+       env: GHC_VER="8.2.1"
+       script: *dependencies
+
+     - stage: test
+       env: GHC_VER="8.4.4"
+       script: &test
+         - stack --no-terminal --stack-yaml=stack-$GHC_VER.yaml build
+         - mv .stack-work/install/*/*/*/bin/hie dist/hie-$GHC_VER
+         - |
+           if [ "${GHC_VER}" == "8.4.4" ]; then
+             mv .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper dist/hie-wrapper
+           fi
+
+     - stage: test
+       env: GHC_VER="8.4.3"
+       script: *test
+
+     - stage: test
+       env: GHC_VER="8.4.2"
+       script: *test
+
+     - stage: test
+       env: GHC_VER="8.2.2"
+       script: *test
+
+     - stage: test
+       env: GHC_VER="8.2.1"
+       script: *test
+
+     - stage: deploy
+       script: skip
+       deploy:
+         provider: releases
+         api_key:
+           secure: K12xUSzK+VWpnS4gRo04rJjfi71sBi0zuMWKmAcsK1igvmdbsEjyuyX4SxFI58/sM4x5qlyXg/nWSPfECKjpQS7/Q/GG1ub+AjU9kq5iyiWACWjXpDLN9Jz9iLBceyPLaf3y3rswri45v7LdwvMNwSI/wYNKEz97IfJ3VkCR16kWv/cqHGdJUYWZk7lBJX/BL94Bof4zOoXwSiy0GbaSCptcSHm1qwtN1qYsYnmihgLYR0RtLRz6tvBPHmqDjsWAXMDhaEyi0zfZ06igITkm7E4at+c3/wssYfgSg15AT2fd5T+v9keyzyanBzGh9xHYcMmflIA9dAvQawl/vw8sGsnQRaddhmTd0bqKFrtrnMO5dRsbkIyu1r178BQCJVjvy5KqyVpXy1ycDcO17E5qONVr2V838x6eg9uPJBNGR30XMg3ZF+GPsbz0xhzxf2Hhab82pJ+lAAsBlnaPdDNVchs/wjEFMp94hcL+IL4ydaXk91piPVhs3VPsLfGboQ72sUnyPUI2aiKfkk5P4Xug+2UqbX17fXfLgnkRbfyCd/4IeM4IwHgRAKa3tT7017KGSZBShihqe2dDJBjS8MlIxDD+U69HR2TIkAJaDnJe+UFAndoc8w4Ajd2OJ1/C+ey236SZq9R7D3dqyFi6Sxc1kSpNguVmjjvlEUk/Jpz1ckA=
+         file:
+           - dist/*
+         file_glob: true
+         skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,12 +103,12 @@ jobs:
      - stage: deploy
        env: GHC_VER="8.4.4"
        script: &deploy
-         - mkdir -p $HOME/.dist
-         - cp .stack-work/install/*/*/$GHC_VER/bin/hie $HOME/.dist
-         - cp .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper $HOME/.dist
-         - upx -q --best $HOME/.dist/hie-$GHC_VER
-         - upx -q --best $HOME/.dist/hie-wrapper
-         - tar czf "hie-$GHC_VER-Darwin.tar.gz" $HOME/.dist
+         - mkdir -p $HOME/hie-macos
+         - cp .stack-work/install/*/*/$GHC_VER/bin/hie $HOME/hie-macos
+         - cp .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper $HOME/hie-macos
+         - upx -q --best $HOME/hie-macos/hie
+         - upx -q --best $HOME/hie-macos/hie-wrapper
+         - tar czf "hie-$GHC_VER-Darwin.tar.gz" $HOME/hie-macos
        deploy: &upload
          provider: releases
          api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ jobs:
      - stage: dependencies
        env: GHC_VER="8.4.4"
        script: &dependencies
-         - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml test --only-dependencies --no-run-tests
+         - travis_retry stack --no-terminal --install-ghc --stack-yaml=stack-$GHC_VER.yaml build --only-dependencies
 
      - stage: dependencies
        env: GHC_VER="8.4.3"
@@ -114,3 +114,7 @@ jobs:
            - dist/*
          file_glob: true
          skip_cleanup: true
+         draft: true
+         tag_name: "${TRAVIS_TAG}"
+         on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     packages:
     - z3
     - stack
+    - upx
 
 cache:
   directories:
@@ -105,14 +106,15 @@ jobs:
        script: *test
 
      - stage: deploy
-       script: skip
+       script:
+         - upx -q --best --ultra-brute dist/hie*
+         - tar czf "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz" dist
        deploy:
          provider: releases
          api_key:
            secure: K12xUSzK+VWpnS4gRo04rJjfi71sBi0zuMWKmAcsK1igvmdbsEjyuyX4SxFI58/sM4x5qlyXg/nWSPfECKjpQS7/Q/GG1ub+AjU9kq5iyiWACWjXpDLN9Jz9iLBceyPLaf3y3rswri45v7LdwvMNwSI/wYNKEz97IfJ3VkCR16kWv/cqHGdJUYWZk7lBJX/BL94Bof4zOoXwSiy0GbaSCptcSHm1qwtN1qYsYnmihgLYR0RtLRz6tvBPHmqDjsWAXMDhaEyi0zfZ06igITkm7E4at+c3/wssYfgSg15AT2fd5T+v9keyzyanBzGh9xHYcMmflIA9dAvQawl/vw8sGsnQRaddhmTd0bqKFrtrnMO5dRsbkIyu1r178BQCJVjvy5KqyVpXy1ycDcO17E5qONVr2V838x6eg9uPJBNGR30XMg3ZF+GPsbz0xhzxf2Hhab82pJ+lAAsBlnaPdDNVchs/wjEFMp94hcL+IL4ydaXk91piPVhs3VPsLfGboQ72sUnyPUI2aiKfkk5P4Xug+2UqbX17fXfLgnkRbfyCd/4IeM4IwHgRAKa3tT7017KGSZBShihqe2dDJBjS8MlIxDD+U69HR2TIkAJaDnJe+UFAndoc8w4Ajd2OJ1/C+ey236SZq9R7D3dqyFi6Sxc1kSpNguVmjjvlEUk/Jpz1ckA=
          file:
-           - dist/*
-         file_glob: true
+           - "hie-${TRAVIS_TAG}-x86_64-Darwin.tar.gz"
          skip_cleanup: true
          draft: true
          tag_name: "${TRAVIS_TAG}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,8 +106,8 @@ jobs:
          - mkdir -p $HOME/hie-macos
          - cp .stack-work/install/*/*/$GHC_VER/bin/hie $HOME/hie-macos
          - cp .stack-work/install/*/*/$GHC_VER/bin/hie-wrapper $HOME/hie-macos
-         - upx -q --best $HOME/hie-macos/hie
-         - upx -q --best $HOME/hie-macos/hie-wrapper
+         - upx --best $HOME/hie-macos/hie
+         - upx --best $HOME/hie-macos/hie-wrapper
          - tar czf "hie-$GHC_VER-Darwin.tar.gz" $HOME/hie-macos
        deploy: &upload
          provider: releases


### PR DESCRIPTION
The use of travis stages is so that we can stay in the allowed time limits for travis. Removed the testing part out of travis, since we have plenty tests already, but it can be added back with no problem.