### PR TITLE
Add Shakefile as possible build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ test-logs/
 .hspec-failures
 /test/testdata/addPragmas/stack.yaml
 .vscode
+
+# shake build information
+_build/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ we talk to clients.__
         - [macOS](#installation-on-macos)
         - [Nix](#installation-with-nix)
         - [ArchLinux](#installation-on-archlinux)
+        - [Shake](#installation-with-shake)
     - [Configuration](#configuration)
     - [Editor Integration](#editor-integration)
         - Using HIE with [VS Code](#using-hie-with-vs-code), [Sublime Text](#using-hie-with-sublime-text), [Vim/Neovim](#using-hie-with-vim-or-neovim), [Atom](#using-hie-with-atom), [Oni](#using-hie-with-oni), [Emacs](#using-hie-with-emacs), [Spacemacs](#using-hie-with-spacemacs) or [Spacemacs+Nix](#using-hie-with-spacemacs-on-nix-based-projects)
@@ -294,6 +295,62 @@ Using [Aura](https://github.com/aurapm/aura):
 ```
 # aura -A haskell-ide-engine-git
 ```
+
+### Installation with Shake
+
+Experimental build script for HIE. Feedback is appreciated.
+Uses the [shake](https://shakebuild.com/) build system for predictable builds.
+The build script is platform independent and the only prerequisites are that `git` and `stack` are installed. The dependency on `make` and other linux specific commands has been dropped.
+
+Note, on first invocation of the build script, a GHC is being installed for execution. However, if you build HIE for every GHC, no GHC is downloaded twice.
+The GHC used for the `Shakefile.hs` can be adjusted in `shake.yaml` by using a different resolver.
+
+Available commands can be seen with:
+
+```bash
+stack ./Shakefile.hs help
+```
+
+Remember, this will take time to download a Stackage-LTS and an appropriate GHC. However, afterwards all commands should work as expected. 
+
+#### Install specific GHC Version with Shake
+
+Install **Nightly** (and hoogle docs):
+
+```bash
+stack ./Shakefile.hs hie-8.6.3
+stack ./Shakefile.hs build-doc-8.6.3
+```
+
+Install **LTS** (and hoogle docs):
+
+```bash
+stack ./Shakefile.hs hie-8.4.4
+stack ./Shakefile.hs build-doc-8.4.4
+```
+
+#### Install *all* available GHC versions with Shake
+
+*Warning*: Requires 20+ GB of space and potentially more than 2 hours to install, so please be patient!
+
+This will:
+
+* install all supported GHC versions (8.2.1 - 8.6.3)
+* name them as expected by the VS Code plugin
+* build local hoogle docs for each version
+
+```bash
+stack ./Shakefile.hs build-all
+```
+
+Then add
+
+```json
+"languageServerHaskell.useCustomHieWrapper": true,
+"languageServerHaskell.useCustomHieWrapperPath": "hie-wrapper",
+```
+
+to VS Code user settings.
 
 ## Configuration
 There are some settings that can be configured via a `settings.json` file:

--- a/README.md
+++ b/README.md
@@ -154,20 +154,20 @@ You can install an specific version or [all available GHC versions](#install-all
 
 #### Install a specific GHC version 8.2.1 - 8.6.3
 
-We will use the `shake` tools here to wrap `stack install`. The preferred installation mechanism is via `./Shakefile.hs`, as it makes sure the repo is synced, installs the required cabal libraries if missing, and makes copies of the executables with suffixes to be able to tell them apart.
+We will use the `make` tools here to wrap `stack install`. The preferred installation mechanism is via `make`, as it makes sure the repo is synced, installs the required cabal libraries if missing, and makes copies of the executables with suffixes to be able to tell them apart.
 
 Install **Nightly** (and hoogle docs):
 
 ```bash
-./Shakefile.hs hie-8.6.3
-./Shakefile.hs build-doc-8.6.3
+make hie-8.6.3
+make build-doc-8.6.3
 ```
 
 Install **LTS** (and hoogle docs):
 
 ```bash
-./Shakefile.hs hie-8.4.4
-./Shakefile.hs build-doc-8.4.4
+make hie-8.4.4
+make build-doc-8.4.4
 ```
 
 This step can take more than 30 minutes, so grab a coffee and please be patient!
@@ -200,10 +200,10 @@ This will:
 * name them as expected by the VS Code plugin
 * build local hoogle docs for each version
 
-For this you need the `shake` tool. Use the command:
+For this you need the `make` tool (on Windows, see the further advice below). Use the command:
 
 ```bash
-./Shakefile.hs build-all
+make build-all
 ```
 
 Then add
@@ -234,6 +234,32 @@ stack install cabal-install
 cabal update
 ```
 
+#### Install *all* available GHC versions
+
+*Warning*: Requires 20+ GB of space and potentially more than 2 hours to install, so please be patient!
+
+This will:
+
+* install all supported GHC versions (8.2.1 - 8.6.3)
+* name them as expected by the VS Code plugin
+* build local hoogle docs for each version
+
+`make` doesn't work on Windows due to several UNIX-specific things, such
+as the `cp` command or extensionless executable names. Instead, a PowerShell
+script is provided specifically for this purpose:
+
+**PowerShell:**
+
+```
+./build-all.ps1
+```
+
+**cmd.exe:**
+
+```
+powershell -ExecutionPolicy RemoteSigned -c ./build-all.ps1
+```
+
 #### Long paths
 
 In order to avoid problems with long paths on Windows you can do the following:
@@ -252,7 +278,7 @@ Download the pre-built binaries from the [releases page](https://github.com/hask
 ln -s hie-bin-dir/hie* /usr/local/bin/
 ```
 
-Alternatively, you can install from source with `./Shakefile.hs build`. 
+Alternatively, you can install from source with `make build`. 
 
 ### Installation with Nix
 

--- a/README.md
+++ b/README.md
@@ -154,20 +154,20 @@ You can install an specific version or [all available GHC versions](#install-all
 
 #### Install a specific GHC version 8.2.1 - 8.6.3
 
-We will use the `make` tools here to wrap `stack install`. The preferred installation mechanism is via `make`, as it makes sure the repo is synced, installs the required cabal libraries if missing, and makes copies of the executables with suffixes to be able to tell them apart.
+We will use the `shake` tools here to wrap `stack install`. The preferred installation mechanism is via `./Shakefile.hs`, as it makes sure the repo is synced, installs the required cabal libraries if missing, and makes copies of the executables with suffixes to be able to tell them apart.
 
 Install **Nightly** (and hoogle docs):
 
 ```bash
-make hie-8.6.3
-make build-doc-8.6.3
+./Shakefile.hs hie-8.6.3
+./Shakefile.hs build-doc-8.6.3
 ```
 
 Install **LTS** (and hoogle docs):
 
 ```bash
-make hie-8.4.4
-make build-doc-8.4.4
+./Shakefile.hs hie-8.4.4
+./Shakefile.hs build-doc-8.4.4
 ```
 
 This step can take more than 30 minutes, so grab a coffee and please be patient!
@@ -200,10 +200,10 @@ This will:
 * name them as expected by the VS Code plugin
 * build local hoogle docs for each version
 
-For this you need the `make` tool (on Windows, see the further advice below). Use the command:
+For this you need the `shake` tool. Use the command:
 
 ```bash
-make build-all
+./Shakefile.hs build-all
 ```
 
 Then add
@@ -234,32 +234,6 @@ stack install cabal-install
 cabal update
 ```
 
-#### Install *all* available GHC versions
-
-*Warning*: Requires 20+ GB of space and potentially more than 2 hours to install, so please be patient!
-
-This will:
-
-* install all supported GHC versions (8.2.1 - 8.6.3)
-* name them as expected by the VS Code plugin
-* build local hoogle docs for each version
-
-`make` doesn't work on Windows due to several UNIX-specific things, such
-as the `cp` command or extensionless executable names. Instead, a PowerShell
-script is provided specifically for this purpose:
-
-**PowerShell:**
-
-```
-./build-all.ps1
-```
-
-**cmd.exe:**
-
-```
-powershell -ExecutionPolicy RemoteSigned -c ./build-all.ps1
-```
-
 #### Long paths
 
 In order to avoid problems with long paths on Windows you can do the following:
@@ -278,7 +252,7 @@ Download the pre-built binaries from the [releases page](https://github.com/hask
 ln -s hie-bin-dir/hie* /usr/local/bin/
 ```
 
-Alternatively, you can install from source with `make build`. 
+Alternatively, you can install from source with `./Shakefile.hs build`. 
 
 ### Installation with Nix
 

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver lts-12.21 --install-ghc runghc --package shake
+-- stack --stack-yaml=shake.yaml  --install-ghc runghc --package shake
 
 import           Development.Shake
 import           Development.Shake.Command
@@ -40,7 +40,8 @@ main = shakeArgs shakeOptions { shakeFiles = "_build" } $ do
         forM_
             hies
             (\hie -> phony hie $ do
-                need ["submodules", "cabal"]
+                need ["submodules"]
+                need ["cabal"]
                 stackLocalDir <- getLocalBin
                 let versionNumber = drop 4 hie
                 buildHie stackLocalDir versionNumber

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -81,9 +81,9 @@ buildHie localBinDir versionNumber = do
     $ execStackWithYaml versionNumber ["install", "happy"]
   execStackWithYaml versionNumber ["build"]
   execStackWithYaml versionNumber ["install"]
-  cmd_ "cp"
-       [localBinDir </> "hie" <.> exe]
-       [localBinDir </> "hie-" ++ versionNumber <.> exe]
+  copyFile'
+       (localBinDir </> "hie" <.> exe)
+       (localBinDir </> "hie-" ++ versionNumber <.> exe)
 
 buildCopyCompilerTool :: VersionNumber -> Action ()
 buildCopyCompilerTool versionNumber =

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -42,6 +42,7 @@ main = do
   -- unset GHC_PACKAGE_PATH for cabal
   unsetEnv "GHC_PACKAGE_PATH"
   shakeArgs shakeOptions { shakeFiles = "_build" } $ do
+    want ["help"]
     phony "ghc" $ do
       ghc <- getGhcPath
       command_ [] ghc ["--version"]

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -54,9 +54,15 @@ main = do
     phony "build"      (need (reverse $ map ("hie-" ++) hieVersions))
     phony "build-all"  (need ["build"] >> need ["build-docs"])
     phony "dist"       buildDist
-    phony "build-docs" (forM_ hieVersions buildDoc)
+    phony "build-docs" (need (reverse $ map ("build-doc-hie-" ++) hieVersions))
     phony "test"       (forM_ hieVersions test)
     phony "build-copy-compiler-tool" $ forM_ hieVersions buildCopyCompilerTool
+
+    forM_
+      hieVersions
+      (\version -> phony ("build-doc-hie-" ++ version) $ do
+        buildDoc version
+      )
 
     forM_
       hieVersions
@@ -170,7 +176,7 @@ helpMessage = do
   out ""
   out "Targets:"
   out
-    "    build                Builds hie for all supported GHC versions (8.2.1, 8.2.2, 8.4.2, 8.4.3, 8.4.4, 8.6.1 and 8.6.2)"
+    "    build                Builds hie for all supported GHC versions (8.2.1, 8.2.2, 8.4.2, 8.4.3, 8.4.4, 8.6.1, 8.6.2 and 8.6.3)"
   out
     "    build-all            Builds hie and hoogle databases for all supported GHC versions"
   out "    hie-8.2.1            Builds hie for GHC version 8.2.1 only"
@@ -180,6 +186,7 @@ helpMessage = do
   out "    hie-8.4.4            Builds hie for GHC version 8.4.4 only"
   out "    hie-8.6.1            Builds hie for GHC version 8.6.1 only"
   out "    hie-8.6.2            Builds hie for GHC version 8.6.2 only"
+  out "    hie-8.6.3            Builds hie for GHC version 8.6.3 only"
   out "    submodules           Updates local git submodules"
   out
     "    cabal                NOTE 3: This is needed for stack only projects too"

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -29,7 +29,7 @@ type GhcPath = String
 -- |Defines all different hie versions that are buildable.
 -- If they are edited, 
 hieVersions :: [VersionNumber]
-hieVersions = ["8.2.1", "8.2.2", "8.4.2", "8.4.3", "8.4.4", "8.6.1", "8.6.2"]
+hieVersions = ["8.2.2", "8.4.3", "8.4.4", "8.6.1", "8.6.2", "8.6.3"]
 
 -- |Most recent version of hie.
 -- Important for `dist`, the `hie-wrapper` of the most recent hie 
@@ -147,7 +147,7 @@ installHie versionNumber = do
   copyFile' (localInstallRoot </> "bin" </> hie)
             (localBinDir </> "hie-" ++ versionNumber <.> exe)
   copyFile' (localInstallRoot </> "bin" </> hie)
-          (localBinDir </> "hie-" ++ dropExtension versionNumber <.> exe)
+            (localBinDir </> "hie-" ++ dropExtension versionNumber <.> exe)
 
 buildCopyCompilerTool :: VersionNumber -> Action ()
 buildCopyCompilerTool versionNumber =

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -6,6 +6,8 @@ import           Development.Shake.Command
 import           Development.Shake.FilePath
 import           Development.Shake.Util
 import           Control.Monad
+import           System.Environment
+
 
 type VersionNumber = String
 type GhcPath = String
@@ -21,7 +23,10 @@ hies = [ "hie-8.2.1"
        ]
 
 main :: IO ()
-main = shakeArgs shakeOptions { shakeFiles = "_build" } $ do
+main = do
+    -- unset GHC_PACKAGE_PATH for cabal
+    unsetEnv "GHC_PACKAGE_PATH" 
+    shakeArgs shakeOptions { shakeFiles = "_build" } $ do
         phony "ghc" $ do
             ghc <- readGhcPath
             command_ [] ghc ["--version"]

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -1,5 +1,15 @@
 #!/usr/bin/env stack
--- stack --stack-yaml=shake.yaml  --install-ghc runghc --package shake
+{- stack 
+  --stack-yaml=shake.yaml  
+  --install-ghc runghc 
+    --package shake 
+    --package tar 
+    --package zlib
+-}
+
+import qualified Data.ByteString.Lazy          as BS
+import qualified Codec.Archive.Tar             as Tar
+import qualified Codec.Compression.GZip        as GZip
 
 import           Development.Shake
 import           Development.Shake.Command
@@ -7,7 +17,7 @@ import           Development.Shake.FilePath
 import           Development.Shake.Util
 import           Control.Monad
 import           System.Environment
-
+import           System.Info
 
 type VersionNumber = String
 type GhcPath = String
@@ -17,23 +27,23 @@ hieVersions = ["8.2.1", "8.2.2", "8.4.2", "8.4.3", "8.4.4", "8.6.1", "8.6.2"]
 
 main :: IO ()
 main = do
-    -- unset GHC_PACKAGE_PATH for cabal
+  -- unset GHC_PACKAGE_PATH for cabal
   unsetEnv "GHC_PACKAGE_PATH"
   shakeArgs shakeOptions { shakeFiles = "_build" } $ do
     phony "ghc" $ do
       ghc <- readGhcPath
       command_ [] ghc ["--version"]
-      putNormal "GHC"
-
-    phony "submodules" buildSubmodules
-    phony "cabal" $ readGhcPath >>= installCabal
-
-    phony "all"       helpMessage
-    phony "help"      helpMessage
-
-    phony "build"     (need (map ("hie-" ++) hieVersions))
-
-    phony "build-all" (need ["build"] >> need ["build-docs"])
+      liftIO $ putStrLn "GHC"
+    phony "submodules" updateSubmodules
+    phony "cabal"      (readGhcPath >>= installCabal)
+    phony "all"        helpMessage
+    phony "help"       helpMessage
+    phony "build"      (need (map ("hie-" ++) hieVersions))
+    phony "build-all"  (need ["build"] >> need ["build-docs"])
+    phony "dist"       buildDist
+    phony "build-docs" (forM_ hieVersions buildDoc)
+    phony "test"       (forM_ hieVersions test)
+    phony "build-copy-compiler-tool" $ forM_ hieVersions buildCopyCompilerTool
 
     forM_
       hieVersions
@@ -41,27 +51,46 @@ main = do
         need ["submodules"]
         need ["cabal"]
         stackLocalDir <- getLocalBin
-        buildHie stackLocalDir version
+        buildHie version
+        installHie stackLocalDir version
       )
 
-    phony "build-docs" $ forM_ hieVersions buildDoc
+buildDist :: Action ()
+buildDist = do
+  Stdout gitRef' <- command [] "git" ["describe", "--tags"]
+  let gitRef      = init gitRef'
+  let hieDistName = concat ["hie-", gitRef, "-", arch, "-", os]
+  withTempDir
+    (\temporaryDir -> do
+      forM_ hieVersions $ \hieVersion -> do
+        buildHie hieVersion
+        Stdout localInstallRoot' <- execStackWithYaml
+          hieVersion
+          ["path", "--local-install-root"]
+        let localInstallRoot = init localInstallRoot'
+        copyFile' (localInstallRoot </> "bin" </> "hie")
+                  (temporaryDir </> "hie-" ++ hieVersion)
 
-    phony "build-copy-compiler-tool" $ forM_ hieVersions buildCopyCompilerTool
+        -- if the most recent hie-* version is copied,
+        -- copy it again as the default hie version
+        -- Also, add the newest hie-wrapper to the tar archive 
+        when (hieVersion == "8.6.2") $ do
+          copyFile' (localInstallRoot </> "bin" </> "hie-wrapper")
+                    (temporaryDir </> "hie-wrapper")
+          copyFile' (localInstallRoot </> "bin" </> "hie")
+                    (temporaryDir </> "hie")
 
-    phony "test" $ forM_ hieVersions test
+      liftIO
+        $   BS.writeFile (hieDistName ++ "tar.gz")
+        .   GZip.compress
+        .   Tar.write
+        =<< Tar.pack temporaryDir
+                     ("hie-wrapper" : "hie" : map ("hie-" ++) hieVersions)
+    )
+  return ()
 
-readGhcPath :: Action GhcPath
-readGhcPath = do
-  Stdout ghc' <- execStack ["path", "--compiler-exe"]
-  return (init ghc')
-
-getLocalBin :: Action FilePath
-getLocalBin = do
-  Stdout stackLocalDir' <- execStack ["path", "--local-bin"]
-  return (init stackLocalDir')
-
-buildSubmodules :: Action ()
-buildSubmodules = do
+updateSubmodules :: Action ()
+updateSubmodules = do
   command_ [] "git" ["submodule", "sync"]
   command_ [] "git" ["submodule", "update", "--init"]
 
@@ -73,64 +102,72 @@ installCabal ghc = do
 
 installHappy :: VersionNumber -> Action ()
 installHappy versionNumber =
-  execStackWithYaml versionNumber ["install", "happy"]
+  execStackWithYaml_ versionNumber ["install", "happy"]
 
-buildHie :: FilePath -> VersionNumber -> Action ()
-buildHie localBinDir versionNumber = do
+buildHie :: VersionNumber -> Action ()
+buildHie versionNumber = do
   when (versionNumber `elem` ["hie-8.2.2", "hie-8.2.1"])
-    $ execStackWithYaml versionNumber ["install", "happy"]
-  execStackWithYaml versionNumber ["build"]
-  execStackWithYaml versionNumber ["install"]
-  copyFile'
-       (localBinDir </> "hie" <.> exe)
-       (localBinDir </> "hie-" ++ versionNumber <.> exe)
+    $ execStackWithYaml_ versionNumber ["install", "happy"]
+  execStackWithYaml_ versionNumber ["build"]
+
+installHie :: FilePath -> VersionNumber -> Action ()
+installHie localBinDir versionNumber = do
+  execStackWithYaml_ versionNumber ["install"]
+  copyFile' (localBinDir </> "hie" <.> exe)
+            (localBinDir </> "hie-" ++ versionNumber <.> exe)
 
 buildCopyCompilerTool :: VersionNumber -> Action ()
 buildCopyCompilerTool versionNumber =
-  execStackWithYaml versionNumber ["build", "--copy-compiler-tool"]
+  execStackWithYaml_ versionNumber ["build", "--copy-compiler-tool"]
 
 test :: VersionNumber -> Action ()
-test versionNumber = execStackWithYaml versionNumber ["test"]
+test versionNumber = execStackWithYaml_ versionNumber ["test"]
 
 buildDoc :: VersionNumber -> Action ()
 buildDoc versionNumber = do
-  execStackWithYaml versionNumber ["install", "hoogle"]
-  execStackWithYaml versionNumber ["exec", "hoogle", "generate"]
+  execStackWithYaml_ versionNumber ["install", "hoogle"]
+  execStackWithYaml_ versionNumber ["exec", "hoogle", "generate"]
 
 helpMessage :: Action ()
 helpMessage = do
-  putNormal ""
-  putNormal "Usage:"
-  putNormal "    make <target>"
-  putNormal ""
-  putNormal "Targets:"
-  putNormal
+  let out = liftIO . putStrLn
+  out ""
+  out "Usage:"
+  out "    make <target>"
+  out ""
+  out "Targets:"
+  out
     "    build                Builds hie for all supported GHC versions (8.2.1, 8.2.2, 8.4.2 and 8.4.3, 8.4.4)"
-  putNormal
+  out
     "    build-all            Builds hie and hoogle databases for all supported GHC versions"
-  putNormal "    hie-8.2.1            Builds hie for GHC version 8.2.1 only"
-  putNormal "    hie-8.2.2            Builds hie for GHC version 8.2.2 only"
-  putNormal "    hie-8.4.2            Builds hie for GHC version 8.4.2 only"
-  putNormal "    hie-8.4.3            Builds hie for GHC version 8.4.3 only"
-  putNormal "    hie-8.4.4            Builds hie for GHC version 8.4.4 only"
-  putNormal "    hie-8.6.1            Builds hie for GHC version 8.6.1 only"
-  putNormal "    hie-8.6.2            Builds hie for GHC version 8.6.2 only"
-  putNormal "    submodules           Updates local git submodules"
-  putNormal
+  out "    hie-8.2.1            Builds hie for GHC version 8.2.1 only"
+  out "    hie-8.2.2            Builds hie for GHC version 8.2.2 only"
+  out "    hie-8.4.2            Builds hie for GHC version 8.4.2 only"
+  out "    hie-8.4.3            Builds hie for GHC version 8.4.3 only"
+  out "    hie-8.4.4            Builds hie for GHC version 8.4.4 only"
+  out "    hie-8.6.1            Builds hie for GHC version 8.6.1 only"
+  out "    hie-8.6.2            Builds hie for GHC version 8.6.2 only"
+  out "    submodules           Updates local git submodules"
+  out
     "    cabal                NOTE 3: This is needed for stack only projects too"
-  putNormal
+  out
     "    build-docs           Builds the Hoogle database for all supported GHC versions"
-  putNormal "    test                 Runs hie tests"
-  putNormal "    icu-macos-fix        Fixes icu related problems in MacOS"
-  putNormal
+  out "    test                 Runs hie tests"
+  out "    icu-macos-fix        Fixes icu related problems in MacOS"
+  out
     "    dist                 Creates a tarball containing all the hie binaries"
-  putNormal "    help                 Show help"
-  putNormal ""
+  out "    help                 Show help"
+  out ""
 
-execStackWithYaml :: VersionNumber -> [String] -> Action ()
-execStackWithYaml versionNumber args = do
+execStackWithYaml_ :: VersionNumber -> [String] -> Action ()
+execStackWithYaml_ versionNumber args = do
   let stackFile = "stack-" ++ versionNumber ++ ".yaml"
   command_ [] "stack" (("--stack-yaml=" ++ stackFile) : args)
+
+execStackWithYaml :: CmdResult r => VersionNumber -> [String] -> Action r
+execStackWithYaml versionNumber args = do
+  let stackFile = "stack-" ++ versionNumber ++ ".yaml"
+  command [] "stack" (("--stack-yaml=" ++ stackFile) : args)
 
 execStack :: CmdResult r => [String] -> Action r
 execStack = command [] "stack"
@@ -140,3 +177,13 @@ execStack_ = command_ [] "stack"
 
 execCabal_ :: [String] -> Action ()
 execCabal_ = command_ [] "cabal"
+
+readGhcPath :: Action GhcPath
+readGhcPath = do
+  Stdout ghc' <- execStack ["path", "--compiler-exe"]
+  return (init ghc')
+
+getLocalBin :: Action FilePath
+getLocalBin = do
+  Stdout stackLocalDir' <- execStack ["path", "--local-bin"]
+  return (init stackLocalDir')

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -12,143 +12,131 @@ import           System.Environment
 type VersionNumber = String
 type GhcPath = String
 
-hies :: [FilePath]
-hies = [ "hie-8.2.1"
-       , "hie-8.2.2"
-       , "hie-8.4.2" 
-       , "hie-8.4.3" 
-       , "hie-8.4.4"
-       , "hie-8.6.1" 
-       , "hie-8.6.2"
-       ]
+hieVersions :: [FilePath]
+hieVersions = ["8.2.1", "8.2.2", "8.4.2", "8.4.3", "8.4.4", "8.6.1", "8.6.2"]
 
 main :: IO ()
 main = do
     -- unset GHC_PACKAGE_PATH for cabal
-    unsetEnv "GHC_PACKAGE_PATH" 
-    shakeArgs shakeOptions { shakeFiles = "_build" } $ do
-        phony "ghc" $ do
-            ghc <- readGhcPath
-            command_ [] ghc ["--version"]
-            putNormal "GHC"
+  unsetEnv "GHC_PACKAGE_PATH"
+  shakeArgs shakeOptions { shakeFiles = "_build" } $ do
+    phony "ghc" $ do
+      ghc <- readGhcPath
+      command_ [] ghc ["--version"]
+      putNormal "GHC"
 
-        phony "submodules" buildSubmodules
-        phony "cabal" $ readGhcPath >>= installCabal
+    phony "submodules" buildSubmodules
+    phony "cabal" $ readGhcPath >>= installCabal
 
-        phony "all"   helpMessage
-        phony "help"  helpMessage
+    phony "all"       helpMessage
+    phony "help"      helpMessage
 
-        phony "build" (need hies)
+    phony "build"     (need (map ("hie-" ++) hieVersions))
 
-        phony "build-all" (need ["build", "build-docs"])
+    phony "build-all" (need ["build"] >> need ["build-docs"])
 
-        forM_
-            hies
-            (\hie -> phony hie $ do
-                need ["submodules"]
-                need ["cabal"]
-                stackLocalDir <- getLocalBin
-                let versionNumber = drop 4 hie
-                buildHie stackLocalDir versionNumber
-            )
+    forM_
+      hieVersions
+      (\version -> phony ("hie-" ++ version) $ do
+        need ["submodules"]
+        need ["cabal"]
+        stackLocalDir <- getLocalBin
+        buildHie stackLocalDir version
+      )
 
-        phony "build-docs" $ forM_ hies $ \hie -> do
-            let versionNumber = drop 4 hie
-            buildDoc versionNumber
+    phony "build-docs" $ forM_ hieVersions buildDoc
 
-        phony "build-copy-compiler-tool" $ forM_ hies $ \hie -> do 
-            let versionNumber = drop 4 hie
-            buildCopyCompilerTool versionNumber
+    phony "build-copy-compiler-tool" $ forM_ hieVersions buildCopyCompilerTool
 
-        phony "test" $ forM_ hies $ \hie -> do 
-            let versionNumber = drop 4 hie
-            test versionNumber
+    phony "test" $ forM_ hieVersions test
 
 readGhcPath :: Action GhcPath
 readGhcPath = do
-    Stdout ghc' <- execStack ["path", "--compiler-exe"]
-    return (init ghc')
+  Stdout ghc' <- execStack ["path", "--compiler-exe"]
+  return (init ghc')
 
 getLocalBin :: Action FilePath
 getLocalBin = do
-    Stdout stackLocalDir' <- execStack ["path", "--local-bin"]
-    return (init stackLocalDir')
+  Stdout stackLocalDir' <- execStack ["path", "--local-bin"]
+  return (init stackLocalDir')
 
 buildSubmodules :: Action ()
 buildSubmodules = do
-    command_ [] "git" ["submodule", "sync"]
-    command_ [] "git" ["submodule", "update", "--init"]
+  command_ [] "git" ["submodule", "sync"]
+  command_ [] "git" ["submodule", "update", "--init"]
 
 installCabal :: GhcPath -> Action ()
 installCabal ghc = do
-    execStack_ ["install", "cabal-install"]
-    execCabal_ ["v1-update"]
-    execCabal_ ["v1-install", "Cabal-2.4.1.0", "--with-compiler=" ++ ghc]
+  execStack_ ["install", "cabal-install"]
+  execCabal_ ["v1-update"]
+  execCabal_ ["v1-install", "Cabal-2.4.1.0", "--with-compiler=" ++ ghc]
 
 installHappy :: VersionNumber -> Action ()
-installHappy versionNumber = execStackWithYaml versionNumber [ "install", "happy"]
+installHappy versionNumber =
+  execStackWithYaml versionNumber ["install", "happy"]
 
 buildHie :: FilePath -> VersionNumber -> Action ()
 buildHie localBinDir versionNumber = do
-    when (versionNumber `elem` ["hie-8.2.2", "hie-8.2.1"]) $
-        execStackWithYaml versionNumber ["install", "happy"]
-    execStackWithYaml versionNumber [ "build"]
-    execStackWithYaml versionNumber [ "install"]
-    cmd_
-        "cp"
-        [ localBinDir </> "hie" <.> exe]
-        [ localBinDir </> "hie-" ++ versionNumber <.> exe
-        ]
+  when (versionNumber `elem` ["hie-8.2.2", "hie-8.2.1"])
+    $ execStackWithYaml versionNumber ["install", "happy"]
+  execStackWithYaml versionNumber ["build"]
+  execStackWithYaml versionNumber ["install"]
+  cmd_ "cp"
+       [localBinDir </> "hie" <.> exe]
+       [localBinDir </> "hie-" ++ versionNumber <.> exe]
 
-buildCopyCompilerTool :: VersionNumber -> Action () 
-buildCopyCompilerTool versionNumber = do 
-    execStackWithYaml versionNumber ["build", "--copy-compiler-tool"]
+buildCopyCompilerTool :: VersionNumber -> Action ()
+buildCopyCompilerTool versionNumber =
+  execStackWithYaml versionNumber ["build", "--copy-compiler-tool"]
 
-test :: VersionNumber -> Action () 
+test :: VersionNumber -> Action ()
 test versionNumber = execStackWithYaml versionNumber ["test"]
 
 buildDoc :: VersionNumber -> Action ()
 buildDoc versionNumber = do
-    execStackWithYaml versionNumber ["install", "hoogle"]
-    execStackWithYaml versionNumber ["exec", "hoogle", "generate"]
+  execStackWithYaml versionNumber ["install", "hoogle"]
+  execStackWithYaml versionNumber ["exec", "hoogle", "generate"]
 
 helpMessage :: Action ()
-helpMessage = do 
-    putNormal ""
-    putNormal "Usage:"
-    putNormal "    make <target>"
-    putNormal ""
-    putNormal "Targets:"
-    putNormal "    build                Builds hie for all supported GHC versions (8.2.1, 8.2.2, 8.4.2 and 8.4.3, 8.4.4)"
-    putNormal "    build-all            Builds hie and hoogle databases for all supported GHC versions"
-    putNormal "    hie-8.2.1            Builds hie for GHC version 8.2.1 only"
-    putNormal "    hie-8.2.2            Builds hie for GHC version 8.2.2 only"
-    putNormal "    hie-8.4.2            Builds hie for GHC version 8.4.2 only"
-    putNormal "    hie-8.4.3            Builds hie for GHC version 8.4.3 only"
-    putNormal "    hie-8.4.4            Builds hie for GHC version 8.4.4 only"
-    putNormal "    hie-8.6.1            Builds hie for GHC version 8.6.1 only"
-    putNormal "    hie-8.6.2            Builds hie for GHC version 8.6.2 only"
-    putNormal "    submodules           Updates local git submodules"
-    putNormal "    cabal                NOTE 3: This is needed for stack only projects too"
-    putNormal "    build-docs           Builds the Hoogle database for all supported GHC versions"
-    putNormal "    test                 Runs hie tests"
-    putNormal "    icu-macos-fix        Fixes icu related problems in MacOS"
-    putNormal "    dist                 Creates a tarball containing all the hie binaries"
-    putNormal "    help                 Show help"
-    putNormal ""
+helpMessage = do
+  putNormal ""
+  putNormal "Usage:"
+  putNormal "    make <target>"
+  putNormal ""
+  putNormal "Targets:"
+  putNormal
+    "    build                Builds hie for all supported GHC versions (8.2.1, 8.2.2, 8.4.2 and 8.4.3, 8.4.4)"
+  putNormal
+    "    build-all            Builds hie and hoogle databases for all supported GHC versions"
+  putNormal "    hie-8.2.1            Builds hie for GHC version 8.2.1 only"
+  putNormal "    hie-8.2.2            Builds hie for GHC version 8.2.2 only"
+  putNormal "    hie-8.4.2            Builds hie for GHC version 8.4.2 only"
+  putNormal "    hie-8.4.3            Builds hie for GHC version 8.4.3 only"
+  putNormal "    hie-8.4.4            Builds hie for GHC version 8.4.4 only"
+  putNormal "    hie-8.6.1            Builds hie for GHC version 8.6.1 only"
+  putNormal "    hie-8.6.2            Builds hie for GHC version 8.6.2 only"
+  putNormal "    submodules           Updates local git submodules"
+  putNormal
+    "    cabal                NOTE 3: This is needed for stack only projects too"
+  putNormal
+    "    build-docs           Builds the Hoogle database for all supported GHC versions"
+  putNormal "    test                 Runs hie tests"
+  putNormal "    icu-macos-fix        Fixes icu related problems in MacOS"
+  putNormal
+    "    dist                 Creates a tarball containing all the hie binaries"
+  putNormal "    help                 Show help"
+  putNormal ""
 
 execStackWithYaml :: VersionNumber -> [String] -> Action ()
-execStackWithYaml versionNumber args = do 
-    let stackFile = "stack-" ++ versionNumber ++ ".yaml"
-    command_ []
-             "stack"
-             (["--stack-yaml=" ++ stackFile] ++ args)
+execStackWithYaml versionNumber args = do
+  let stackFile = "stack-" ++ versionNumber ++ ".yaml"
+  command_ [] "stack" (("--stack-yaml=" ++ stackFile) : args)
 
 execStack :: CmdResult r => [String] -> Action r
-execStack = command [] "stack" 
+execStack = command [] "stack"
 
 execStack_ :: [String] -> Action ()
-execStack_ = command_ [] "stack" 
+execStack_ = command_ [] "stack"
 
 execCabal_ :: [String] -> Action ()
 execCabal_ = command_ [] "cabal"

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -77,8 +77,8 @@ buildSubmodules = do
 installCabal :: GhcPath -> Action ()
 installCabal ghc = do
     execStack_ ["install", "cabal-install"]
-    execCabal_ ["update"]
-    execCabal_ ["install", "Cabal-2.4.1.0", "--with-compiler=" ++ ghc]
+    execCabal_ ["v1-update"]
+    execCabal_ ["v1-install", "Cabal-2.4.1.0", "--with-compiler=" ++ ghc]
 
 installHappy :: VersionNumber -> Action ()
 installHappy versionNumber = execStackWithYaml versionNumber [ "install", "happy"]

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -51,7 +51,7 @@ main = do
     phony "cabal"      (getGhcPath >>= installCabal)
     phony "all"        helpMessage
     phony "help"       helpMessage
-    phony "build"      (need (map ("hie-" ++) hieVersions))
+    phony "build"      (need (reverse $ map ("hie-" ++) hieVersions))
     phony "build-all"  (need ["build"] >> need ["build-docs"])
     phony "dist"       buildDist
     phony "build-docs" (forM_ hieVersions buildDoc)
@@ -132,16 +132,6 @@ installCabal ghc = do
   execCabal_ ["v1-update"]
   execCabal_ ["v1-install", "Cabal-2.4.1.0", "--with-compiler=" ++ ghc]
 
-hieBin :: VersionNumber -> Action FilePath
-hieBin versionNumber = do
-  localBin <- getLocalBin
-  return $ localBin </> "hie-" ++ versionNumber <.> exe
-
-localHieBin :: VersionNumber -> Action FilePath
-localHieBin versionNumber = do
-  localInstallRoot <- getLocalInstallRoot versionNumber
-  return $ localInstallRoot </> "bin" </> "hie" <.> exe
-
 buildHie :: VersionNumber -> Action ()
 buildHie versionNumber = do
   when (versionNumber `elem` ["hie-8.2.2", "hie-8.2.1"])
@@ -156,6 +146,8 @@ installHie versionNumber = do
   let hie = "hie" <.> exe
   copyFile' (localInstallRoot </> "bin" </> hie)
             (localBinDir </> "hie-" ++ versionNumber <.> exe)
+  copyFile' (localInstallRoot </> "bin" </> hie)
+          (localBinDir </> "hie-" ++ dropExtension versionNumber <.> exe)
 
 buildCopyCompilerTool :: VersionNumber -> Action ()
 buildCopyCompilerTool versionNumber =

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -1,0 +1,122 @@
+import           Development.Shake
+import           Development.Shake.Command
+import           Development.Shake.FilePath
+import           Development.Shake.Util
+import           Control.Monad.IO.Class
+import           Control.Monad
+
+type VersionNumber = String
+type GhcVersion = String
+
+hies :: [FilePath]
+hies = [ "hie-8.2.2"
+       , "hie-8.4.2" 
+       , "hie-8.4.3" 
+       , "hie-8.4.4"
+       , "hie-8.6.1" 
+       , "hie-8.6.2"]
+
+main :: IO ()
+main = shakeArgs shakeOptions { shakeFiles = "_build" } $ do
+    phony "ghc" $ do
+        ghc <- readGhcVersion
+        command_ [] ghc ["--version"]
+        putNormal "GHC"
+
+    phony "submodules" buildSubmodules
+    phony "cabal" $ readGhcVersion >>= installCabal
+
+    phony "all"   helpMessage
+    phony "help"  helpMessage
+
+    phony "build" (need hies)
+
+    phony "build-all" (need ["build", "build-docs"])
+
+    forM_
+        hies
+        (\hie -> phony hie $ do
+            need ["submodules", "cabal"]
+            stackLocalDir <- getLocalBin
+            let versionNumber = drop 4 hie
+            buildHie stackLocalDir versionNumber
+        )
+
+    phony "build-docs" $ forM_ hies $ \hie -> do
+        let versionNumber = drop 4 hie
+        buildDoc versionNumber
+
+    phony "build-copy-compiler-tool" $ forM_ hies $ \hie -> do 
+        let versionNumber = drop 4 hie
+        buildCopyCompilerTool versionNumber
+
+    phony "test" $ forM_ hies $ \hie -> do 
+        let versionNumber = drop 4 hie
+        test versionNumber
+
+readGhcVersion :: Action GhcVersion
+readGhcVersion = do
+    Stdout ghc' <- execStack ["path", "--compiler-exe"]
+    return (init ghc')
+
+getLocalBin :: Action FilePath
+getLocalBin = do
+    Stdout stackLocalDir' <- execStack ["path", "--local-bin"]
+    return (init stackLocalDir')
+
+buildSubmodules :: Action ()
+buildSubmodules = do
+    command_ [] "git" ["submodule", "sync"]
+    command_ [] "git" ["submodule", "update", "--init"]
+
+installCabal :: GhcVersion -> Action ()
+installCabal ghc = do
+    execStack_ ["install", "cabal-install"]
+    execCabal_ ["update"]
+    execCabal_ ["install", "Cabal-2.4.1.0", "--with-compiler=" ++ ghc]
+
+installHappy :: VersionNumber -> Action ()
+installHappy versionNumber = execStackWithGhcVersion versionNumber [ "install", "happy"]
+
+buildHie :: FilePath -> VersionNumber -> Action ()
+buildHie localBinDir versionNumber = do
+    when (versionNumber `elem` ["hie-8.2.2", "hie-8.2.1"]) $
+        execStackWithGhcVersion versionNumber ["install", "happy"]
+    execStackWithGhcVersion versionNumber [ "build"]
+    execStackWithGhcVersion versionNumber [ "install"]
+    cmd_
+        "cp"
+        [ localBinDir </> "hie" <.> exe]
+        [ localBinDir </> "hie-" ++ versionNumber <.> exe
+        ]
+
+buildCopyCompilerTool :: VersionNumber -> Action () 
+buildCopyCompilerTool versionNumber = do 
+    execStackWithGhcVersion versionNumber ["build", "--copy-compiler-tool"]
+
+test :: VersionNumber -> Action () 
+test versionNumber = execStackWithGhcVersion versionNumber ["test"]
+
+buildDoc :: VersionNumber -> Action ()
+buildDoc versionNumber = do
+    execStackWithGhcVersion versionNumber ["install", "hoogle"]
+    execStackWithGhcVersion versionNumber ["exec", "hoogle", "generate"]
+
+helpMessage :: Action ()
+helpMessage = putNormal "Let me help you!"
+
+execStackWithGhcVersion :: VersionNumber -> [String] -> Action ()
+execStackWithGhcVersion versionNumber args = do 
+    let stackFile = "stack-" ++ versionNumber ++ ".yaml"
+    command_ []
+             "stack"
+             (["--stack-yaml=" ++ stackFile] ++ args)
+
+execStack :: CmdResult r => [String] -> Action r
+execStack = command [] "stack" 
+
+execStack_ :: [String] -> Action ()
+execStack_ = command_ [] "stack" 
+
+execCabal_ :: [String] -> Action ()
+execCabal_ = command_ [] "cabal"

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -81,7 +81,7 @@ buildDist = do
                     (temporaryDir </> "hie")
 
       liftIO
-        $   BS.writeFile (hieDistName ++ "tar.gz")
+        $   BS.writeFile (hieDistName ++ ".tar.gz")
         .   GZip.compress
         .   Tar.write
         =<< Tar.pack temporaryDir

--- a/Shakefile.hs
+++ b/Shakefile.hs
@@ -55,6 +55,11 @@ main = do
         installHie stackLocalDir version
       )
 
+    phony "icu-macos-fix"
+          (need ["icu-macos-fix-install"] >> need ["icu-macos-fix-build"])
+    phony "icu-macos-fix-install" (command_ [] "brew" ["install", "icu4c"])
+    phony "icu-macos-fix-build" $ mapM_ buildIcuMacosFix hieVersions
+
 buildDist :: Action ()
 buildDist = do
   Stdout gitRef' <- command [] "git" ["describe", "--tags"]
@@ -88,6 +93,15 @@ buildDist = do
                      ("hie-wrapper" : "hie" : map ("hie-" ++) hieVersions)
     )
   return ()
+
+buildIcuMacosFix :: VersionNumber -> Action ()
+buildIcuMacosFix version = execStackWithYaml_
+  version
+  [ "build"
+  , "text-icu"
+  , "--extra-lib-dirs=/usr/local/opt/icu4c/lib"
+  , "--extra-include-dirs=/usr/local/opt/icu4c/include"
+  ]
 
 updateSubmodules :: Action ()
 updateSubmodules = do

--- a/shake.yaml
+++ b/shake.yaml
@@ -1,0 +1,7 @@
+# Used to provide a different environment for the shake build script
+resolver: nightly-2018-12-01 # GHC 8.6.2
+packages:
+- .
+
+nix:
+  packages: [ icu libcxx zlib ]

--- a/shake.yaml
+++ b/shake.yaml
@@ -4,4 +4,4 @@ packages:
 - .
 
 nix:
-  packages: [ icu libcxx zlib ]
+  packages: [ zlib ]

--- a/shake.yaml
+++ b/shake.yaml
@@ -1,5 +1,5 @@
 # Used to provide a different environment for the shake build script
-resolver: nightly-2018-12-01 # GHC 8.6.2
+resolver: lts-13.0 # GHC 8.6.2
 packages:
 - .
 

--- a/shake.yaml
+++ b/shake.yaml
@@ -1,5 +1,5 @@
 # Used to provide a different environment for the shake build script
-resolver: lts-13.0 # GHC 8.6.2
+resolver: lts-12.25 # GHC 8.4.4
 packages:
 - .
 


### PR DESCRIPTION
Closes #650 
I implemented the Shakefile to be run directly from `stack`.

```
# one-stop-shop build everything
stack Shakefile.hs build-all
```

Features:

* `stack` is the only build requirement
* `shake` is used instead of `make`
* should work on all platforms (not fully tested yet)
* `dist` target works on windows out of the box, making it easier to create releases for windows
* submodules are synced / updated at the start -> works after clean clone of project

Quirks:
* `shake.yaml` is necessary to start the `stack Shakefile.hs ...` command before submodules are loaded.
* On first execution, a compiler is downloaded. However, no compiler is downloaded more than once.

Tested on: 
* [X] Fedora
* [X] Arch Linux
* [x] Windows
* [ ] MacOS
* [X] NixOS

Working on NixOS with the following commands:
```bash
nix-shell -p "haskellPackages.ghcWithPackages (pkgs: with pkgs; [zlib tar shake])" zlib
export PATH=$NIX_USER_PROFILE_DIR/profile/bin:$PATH && ghc -O2 ./Shakefile.hs && ./Shakefile build
```
However, the ghc versions 8.2.1 and 8.4.2 are not easily accessible and must be removed from the list of hieVersions in `Shakefile.hs` in order to make it work.