### PR TITLE
 hie-wrapper deals with missing System GHC

### DIFF
--- a/app/HieWrapper.hs
+++ b/app/HieWrapper.hs
@@ -83,7 +83,10 @@ run opts = do
 
   let
     hieBin = "hie-" ++ ghcVersion
-    backupHieBin = "hie-" ++ init (dropWhileEnd (/='.') ghcVersion)
+    backupHieBin =
+      case dropWhileEnd (/='.') ghcVersion of
+        [] -> "hie"
+        xs -> "hie-" ++ init xs
     candidates' = [hieBin, backupHieBin, "hie"]
     candidates = map (++ exeExtension) candidates'
 


### PR DESCRIPTION
Closes alanz/vscode-hie-server#110
Closes #803

Sample log lines

```
2018-12-28 14:36:23.081677593 [ThreadId 4] - run entered for hie-wrapper(hie-wrapper) Version 0.4.0.1, Git revision 4f0c017 (dirty) (2286 commits) x86_64 ghc-8.6.3
2018-12-28 14:36:23.08184515 [ThreadId 4] - Current directory:/tmp/ff
2018-12-28 14:36:23.0846877 [ThreadId 4] - Cradle directory:/tmp/ff
2018-12-28 14:36:23.084807006 [ThreadId 4] - Using plain GHC version
2018-12-28 14:36:23.084980989 [ThreadId 4] - Project GHC version:No System GHC found
2018-12-28 14:36:23.085006736 [ThreadId 4] - hie exe candidates :["hie-No System GHC found","hie","hie"]
2018-12-28 14:36:23.085201395 [ThreadId 4] - found hie exe at:/home/alanz/.local/bin/hie
2018-12-28 14:36:23.085228858 [ThreadId 4] - args:["--lsp","-d","-l","/tmp/hie.log"]
2018-12-28 14:36:23.085252547 [ThreadId 4] - launching ....

2018-12-28 14:36:23.087026804 [ThreadId 4] - Using plain GHC version
2018-12-28 14:36:23.08731647 [ThreadId 4] - Mismatching GHC versions: Project is No System GHC found, HIE is 8.6.3
2018-12-28 14:36:23.087376738 [ThreadId 4] - Run entered for HIE(hie) Version 0.4.0.1, Git revision 4f0c017 (dirty) (2286 commits) x86_64 ghc-8.6.3
2018-12-28 14:36:23.087474913 [ThreadId 4] - Current directory:/tmp/ff
2018-12-28 14:36:23.087594646 [ThreadId 4] -
```