### PR TITLE
Fix unit tests clogging CircleCI builds

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -181,8 +181,9 @@ test-suite unit-test
                      , ghc-mod-core
                      , hslogger
                      , yaml
-
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wredundant-constraints
+  -- don't multithread i.e. --with-rtsopts=-N
+  -- otherwise ghc-mod operations become super slow on CircleCI
+  ghc-options:         -Wall -Wredundant-constraints
   if flag(pedantic)
      ghc-options:      -Werror
   default-language:    Haskell2010


### PR DESCRIPTION
Previously the CircleCI builds were getting choked on the unit tests which took up to 30 minutes. 
As it turned out this was caused by ghc-mod stuff slowing down to crawl when run on a multithreaded program, i.e. anything with a large number of a Haskell thread capabilities. When tested on circleCI the unit tests ran with 36 of them. In comparison the functional tests only have 1 thread capability which explains why the ghc-mod parts weren't slowed down on it.
I'm not sure why ghc-mod slows down when multithreaded, but for now it was sufficient to just disable threading on the unit tests.
The test suite now runs in 6 minutes total! Closes #980 