### PR TITLE
Change --recursive to --recurse-submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ In order to avoid problems with long paths on Windows you can do the following:
 #### Download the source code
 
 ```bash
-git clone https://github.com/haskell/haskell-ide-engine --recursive
+git clone https://github.com/haskell/haskell-ide-engine --recurse-submodules
 cd haskell-ide-engine
 ```
 


### PR DESCRIPTION
The `--recursive` option is not listed in the [git-clone documentation](https://www.git-scm.com/docs/git-clone). It seems to have been renamed to `--recurse-submodules`. This commit changes the example `git clone` command in the readme to use the new option.