### PR TITLE
Fix install.hs stack comment formatting

### DIFF
--- a/install.hs
+++ b/install.hs
@@ -1,10 +1,11 @@
 #!/usr/bin/env stack
-{- stack 
-  --stack-yaml=shake.yaml  
-  --install-ghc runghc 
-    --package shake 
-    --package tar 
-    --package zlib
+{- stack
+  --stack-yaml shake.yaml
+  --install-ghc
+  runghc
+  --package shake
+  --package tar
+  --package zlib
 -}
 
 import qualified Data.ByteString.Lazy          as BS


### PR DESCRIPTION
The existing indention is uneven, and `runghc` isn't on its own line. I also removed the trailing whitespace.