### PR TITLE
Make install.hs use tar executable

### DIFF
--- a/install.hs
+++ b/install.hs
@@ -1,16 +1,9 @@
 #!/usr/bin/env stack
 {- stack
-  --stack-yaml shake.yaml
-  --install-ghc
-  runghc
+  script
+  --resolver lts-12.25
   --package shake
-  --package tar
-  --package zlib
 -}
-
-import qualified Data.ByteString.Lazy          as BS
-import qualified Codec.Archive.Tar             as Tar
-import qualified Codec.Compression.GZip        as GZip
 
 import           Development.Shake
 import           Development.Shake.Command
@@ -113,11 +106,7 @@ buildDist = do
 
       -- After every hie has been built, pack them into a tar.
       -- Encrypt the resulting tar file with gzip
-      liftIO
-        $   BS.writeFile (hieDistName ++ ".tar.gz")
-        .   GZip.compress
-        .   Tar.write
-        =<< Tar.pack temporaryDir (hieWrapper : hie : map mkHie hieVersions)
+      command_ [] "tar" ["-czf", hieDistName ++ ".tar.gz", "-C", temporaryDir, "."]
     )
   return ()
 

--- a/shake.yaml
+++ b/shake.yaml
@@ -1,7 +1,0 @@
-# Used to provide a different environment for the shake build script
-resolver: lts-12.25 # GHC 8.4.4
-packages:
-- .
-
-nix:
-  packages: [ zlib ]


### PR DESCRIPTION
This has some benefits:
- No `zlib` c library dependency
- No need for `shake.yaml`
- Stack `script` instead of `runghc`
- Everything contained in `install.hs`

`tar` works everywhere, so I see no reason to avoid it.

The behaviour of this code is slightly different. It creates a tar archive containing a folder named "." which in turn contains all the hie binary files. When the tar archive is extracted, it will extract all the hie binaries in the current folder as usual, so this shouldn't affect too much.