### PR TITLE
Display error message on stack-compilation errors

### DIFF
--- a/shake.yaml
+++ b/shake.yaml
@@ -1,5 +1,5 @@
 # Used to provide a different environment for the shake build script
-resolver: lts-12.25 # GHC 8.4.4
+resolver: lts-13.4 # GHC 8.6.3, shake 0.17.4
 packages:
 - .
 

--- a/shake.yaml
+++ b/shake.yaml
@@ -1,7 +1,10 @@
 # Used to provide a different environment for the shake build script
-resolver: lts-13.4 # GHC 8.6.3, shake 0.17.4
+resolver: lts-12.25 # GHC 8.4.4
 packages:
 - .
+
+extra-packages:
+- shake-0.17.4
 
 nix:
   packages: [ zlib ]


### PR DESCRIPTION
closes #1049. This introduces an error message when a `stack build` fails from the `install.hs`. The error message suggests to call `stack clean` and retry the build.

It was necessary to upgrade to the latest version of `shake`