### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ Install **Nightly** (and hoogle docs):
 
 ```bash
 make hie-8.6.3
-make build-doc-hie-8.6.3
+make build-doc-8.6.3
 ```
 
 Install **LTS** (and hoogle docs):
 
 ```bash
 make hie-8.4.4
-make build-doc-hie-8.4.4
+make build-doc-8.4.4
 ```
 
 This step can take more than 30 minutes, so grab a coffee and please be patient!


### PR DESCRIPTION
```shell
λ> make build-doc-hie-8.6.3
stack --stack-yaml=stack-hie-8.6.3.yaml exec hoogle generate
Could not parse '/home/guchi/.local/share/haskell-ide-engine/stack-hie-8.6.3.yaml':
YAML exception:
Yaml file not found: /home/guchi/.local/share/haskell-ide-engine/stack-hie-8.6.3.yaml
See http://docs.haskellstack.org/en/stable/yaml_configuration/
Makefile:66: recipe for target 'build-doc-hie-8.6.3' failed
make: *** [build-doc-hie-8.6.3] Error 1

λ> make build-doc-8.6.3
stack --stack-yaml=stack-8.6.3.yaml exec hoogle generate
Starting generate
...
```