### PR TITLE
Show message for build-doc-% on make/shake help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ cabal:
 build-docs: $(foreach version, $(GHC_VERSIONS), build-doc-$(version))
 .PHONY: build-docs
 
+## Builds the Hoogle database for GHC version % only
 build-doc-%:
 	stack --stack-yaml=stack-$*.yaml exec hoogle generate
 

--- a/README.md
+++ b/README.md
@@ -274,14 +274,14 @@ Install **Nightly** (and hoogle docs):
 
 ```bash
 stack ./install.hs hie-8.6.3
-stack ./install.hs build-doc-hie-8.6.3
+stack ./install.hs build-doc-8.6.3
 ```
 
 Install **LTS** (and hoogle docs):
 
 ```bash
 stack ./install.hs hie-8.4.4
-stack ./install.hs build-doc-hie-8.4.4
+stack ./install.hs build-doc-8.4.4
 ```
 
 #### Install *all* available GHC versions with Shake

--- a/install.hs
+++ b/install.hs
@@ -60,12 +60,12 @@ main = do
     phony "build"      (need (reverse $ map ("hie-" ++) hieVersions))
     phony "build-all"  (need ["build"] >> need ["build-docs"])
     phony "dist"       buildDist
-    phony "build-docs" (need (reverse $ map ("build-doc-hie-" ++) hieVersions))
+    phony "build-docs" (need (reverse $ map ("build-doc-" ++) hieVersions))
     phony "test"       (forM_ hieVersions test)
     phony "build-copy-compiler-tool" $ forM_ hieVersions buildCopyCompilerTool
 
     forM_ hieVersions
-          (\version -> phony ("build-doc-hie-" ++ version) $ buildDoc version)
+          (\version -> phony ("build-doc-" ++ version) $ buildDoc version)
 
     forM_
       hieVersions
@@ -213,9 +213,9 @@ helpMessage = do
   hieTarget version =
     ("hie-" ++ version, "Builds hie for GHC version " ++ version ++ " only")
 
-  buildDocHieTarget :: VersionNumber -> (String, String)
-  buildDocHieTarget version =
-    ("build-doc-hie-" ++ version, "Builds the Hoogle database for GHC version " ++ version ++ " only")
+  buildDocTarget :: VersionNumber -> (String, String)
+  buildDocTarget version =
+    ("build-doc-" ++ version, "Builds the Hoogle database for GHC version " ++ version ++ " only")
 
   allVersionMessage :: String
   allVersionMessage =
@@ -243,7 +243,7 @@ helpMessage = do
       , ("help"         , "Show help")
       ]
       ++ map hieTarget hieVersions
-      ++ map buildDocHieTarget hieVersions
+      ++ map buildDocTarget hieVersions
 
 execStackWithYaml_ :: VersionNumber -> [String] -> Action ()
 execStackWithYaml_ versionNumber args = do

--- a/install.hs
+++ b/install.hs
@@ -209,9 +209,13 @@ helpMessage = do
     target ++ replicate (space - length target) ' ' ++ msg
 
   -- |Target for a specific ghc version
-  hieTarget :: String -> (String, String)
+  hieTarget :: VersionNumber -> (String, String)
   hieTarget version =
     ("hie-" ++ version, "Builds hie for GHC version " ++ version ++ " only")
+
+  buildDocHieTarget :: VersionNumber -> (String, String)
+  buildDocHieTarget version =
+    ("build-doc-hie-" ++ version, "Builds the Hoogle database for GHC version " ++ version ++ " only")
 
   allVersionMessage :: String
   allVersionMessage =
@@ -239,6 +243,7 @@ helpMessage = do
       , ("help"         , "Show help")
       ]
       ++ map hieTarget hieVersions
+      ++ map buildDocHieTarget hieVersions
 
 execStackWithYaml_ :: VersionNumber -> [String] -> Action ()
 execStackWithYaml_ versionNumber args = do


### PR DESCRIPTION
Both `make help` and `./install.hs help` have not displayed a message for `build-doc-%`. 

I also noticed that the command name differs between make and shake (`build-doc-%` in make, `build-doc-hie-%` in shake). Is this intended?