### PR TITLE
WIP: Don't need to reversemap files

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -225,7 +225,11 @@ cacheModule uri modul = do
         let defInfo = CachedInfo mempty mempty mempty mempty rfm return return
         return $ case muc of
           Just (UriCacheSuccess uc) ->
-            let newCI = (cachedInfo uc) { revMap = rfm }
+            let newCI = oldCI { revMap = rfm . revMap oldCI }
+                    --                         ^^^^^^^^^^^^
+                    -- We have to retain the old mapping state, since the
+                    -- old TypecheckedModule still contains spans relative to that
+                oldCI = cachedInfo uc
               in uc { cachedPsMod = pm, cachedInfo = newCI }
           _ -> UriCache defInfo pm Nothing mempty
 


### PR DESCRIPTION
Goes along with the changes in https://github.com/alanz/ghc-mod/pull/17

This paves the way to removing mappedFiles altogether.

This also fixes a bug: With current master, open a file, and, without saving, write something like

```haskell
foo id = id
```

You will get a diagnostic for name shadowing, but the file mentioned in the diagnostic will be the temporary mapped file instead of the actual file. This behaviour will not happen after the changes in this PR are applied. 

This eliminates the need for reverseMap altogether, and probably fixes a bunch of other bugs in the process, involving returning the mapped file to vscode instead of the actual file.

Needs testing.  It also needs to tested against code with TH and CPP. 

To test, you will need to

```bash
$ cd submodules/ghc-mod
$ git remote add wz1000 https://github.com/wz1000/ghc-mod
$ git fetch wz1000
$ git checkout wz1000/proper-mapped-files
```
and then build normally.