### PR TITLE
Add ReqTypeDefinition to reactor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,7 @@
 	url = https://github.com/ennocramer/floskell
 	# url = https://github.com/alanz/floskell
 
+[submodule "submodules/lsp-test"]
+	path = submodules/lsp-test
+	url = https://github.com/bubba/lsp-test
+	# url = https://github.com/alanz/floskell

--- a/.gitmodules
+++ b/.gitmodules
@@ -36,8 +36,3 @@
 	path = submodules/floskell
 	url = https://github.com/ennocramer/floskell
 	# url = https://github.com/alanz/floskell
-
-[submodule "submodules/lsp-test"]
-	path = submodules/lsp-test
-	url = https://github.com/bubba/lsp-test
-	# url = https://github.com/alanz/floskell

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -87,6 +87,7 @@ library
                      , safe
                      , sorted-list >= 0.2.1.0
                      , stm
+                     , syb
                      , tagsoup
                      , text
                      , transformers

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -87,7 +87,6 @@ library
                      , safe
                      , sorted-list >= 0.2.1.0
                      , stm
-                     , syb
                      , tagsoup
                      , text
                      , transformers

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -265,6 +265,7 @@ test-suite func-test
                      , ReferencesSpec
                      , RenameSpec
                      , SymbolsSpec
+                     , TypeDefinitionSpec
                      , Utils
   -- This cannot currently be handled by hie (cabal-helper)
   -- build-tool-depends:  haskell-ide-engine:hie

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -182,6 +182,9 @@ mkPragmaCompl label insertText =
 safeTyThingId :: TyThing -> Maybe Id
 safeTyThingId (AnId i)                    = Just i
 safeTyThingId (AConLike (RealDataCon dc)) = Just $ dataConWrapId dc
+safeTyThingId (ATyCon tyCon)              = case GHC.tyConTyVars tyCon of
+    [] -> Nothing
+    (a:_) -> Just a
 safeTyThingId _                           = Nothing
 
 -- Associates a module's qualifier with its members

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -707,7 +707,7 @@ reactor inp diagIn = do
           makeRequest hreq
 
         ReqTypeDefinition req -> do
-          liftIO $ U.logs $ "reactor:got DefinitionRequest:" ++ show req
+          liftIO $ U.logs $ "reactor:got DefinitionTypeRequest:" ++ show req
           let params = req ^. J.params
               doc = params ^. J.textDocument . J.uri
               pos = params ^. J.position

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -713,7 +713,7 @@ reactor inp diagIn = do
               pos = params ^. J.position
               callback = reactorSend . RspTypeDefinition . Core.makeResponseMessage req
           let hreq = IReq tn (req ^. J.id) callback
-                       $ fmap J.MultiLoc <$> Hie.findDef doc pos
+                       $ fmap J.MultiLoc <$> Hie.findTypeDef doc pos
           makeRequest hreq
 
         ReqFindReferences req -> do

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -25,6 +25,7 @@ extra-deps:
 - hsimport-0.8.6
 - lsp-test-0.5.0.2
 - monad-dijkstra-0.1.1.2
+- mtl-2.2.2
 - pretty-show-1.8.2
 - sorted-list-0.2.1.0
 - syz-0.2.0.0

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -19,11 +19,11 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.8.0.1
+- haskell-lsp-0.8.1.0
 - haskell-lsp-types-0.8.0.1
 - hlint-2.0.11
 - hsimport-0.8.6
-- lsp-test-0.5.0.2
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2
 - mtl-2.2.2
 - pretty-show-1.8.2

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -20,13 +20,13 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.8.0.1
+- haskell-lsp-0.8.1.0
 - haskell-lsp-types-0.8.0.1
 - haskell-src-exts-1.21.0
 - hlint-2.1.15
 - hoogle-5.0.17.5
 - hsimport-0.8.8
-- lsp-test-0.5.0.2
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - sorted-list-0.2.1.0

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -18,13 +18,13 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.8.0.1
+- haskell-lsp-0.8.1.0
 - haskell-lsp-types-0.8.0.1
 - haskell-src-exts-1.21.0
 - hlint-2.1.15
 - hoogle-5.0.17.5
 - hsimport-0.8.8
-- lsp-test-0.5.0.2
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - syz-0.2.0.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -17,13 +17,13 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.8.0.1
+- haskell-lsp-0.8.1.0
 - haskell-lsp-types-0.8.0.1
 - haskell-src-exts-1.21.0
 - hlint-2.1.15
 - hoogle-5.0.17.5
 - hsimport-0.8.8
-- lsp-test-0.5.0.2
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - syz-0.2.0.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -17,13 +17,13 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.8.0.1
+- haskell-lsp-0.8.1.0
 - haskell-lsp-types-0.8.0.1
 - haskell-src-exts-1.21.0
 - hlint-2.1.15
 - hoogle-5.0.17.5
 - hsimport-0.8.8
-- lsp-test-0.5.0.2
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2
 - optparse-simple-0.1.0
 - pretty-show-1.9.5

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -19,13 +19,13 @@ extra-deps:
 - czipwith-1.0.1.1
 - data-tree-print-0.1.0.2
 - haddock-api-2.21.0
-- haskell-lsp-0.8.0.1
+- haskell-lsp-0.8.1.0
 - haskell-lsp-types-0.8.0.1
 - haskell-src-exts-1.21.0
 - hlint-2.1.15
 - hoogle-5.0.17.5
 - hsimport-0.8.8
-- lsp-test-0.5.0.2
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - monoid-subclasses-0.4.6.1

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -16,9 +16,11 @@ extra-deps:
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.21.0
 - haskell-src-exts-1.21.0
+- haskell-lsp-0.8.1.0
 - hlint-2.1.15
 - hoogle-5.0.17.5
 - hsimport-0.8.8
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -16,9 +16,11 @@ extra-deps:
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.21.0
 - haskell-src-exts-1.21.0
+- haskell-lsp-0.8.1.0
 - hlint-2.1.15
 - hoogle-5.0.17.5
 - hsimport-0.8.8
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -19,6 +19,7 @@ extra-deps:
 - hlint-2.1.15
 - hsimport-0.8.8
 - hoogle-5.0.17.6
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -20,6 +20,7 @@ extra-deps:
 - haddock-api-2.22.0
 - hlint-2.1.15
 - hsimport-0.8.8
+- lsp-test-0.5.1.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/test/functional/TypeDefinitionSpec.hs
+++ b/test/functional/TypeDefinitionSpec.hs
@@ -1,0 +1,99 @@
+module TypeDefinitionSpec where
+
+import           Control.Monad.IO.Class
+import           Language.Haskell.LSP.Test
+import           Language.Haskell.LSP.Types
+import           Haskell.Ide.Engine.PluginUtils
+import           System.Directory
+import           Test.Hspec
+import           TestUtils
+
+spec :: Spec
+spec = describe "type definitions" $ do
+  it "finds local definition of record variable"
+    $ runSession hieCommand fullCaps "test/testdata/gototest"
+    $ do
+        doc  <- openDoc "src/Lib.hs" "haskell"
+        defs <- getTypeDefinitions doc (toPos (11, 23))
+        liftIO $ do
+          fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
+          defs
+            `shouldBe` [ Location (filePathToUri fp)
+                                  (Range (toPos (8, 1)) (toPos (8, 29)))
+                       ]
+  it "finds local definition of newtype variable"
+    $ runSession hieCommand fullCaps "test/testdata/gototest"
+    $ do
+        doc  <- openDoc "src/Lib.hs" "haskell"
+        defs <- getTypeDefinitions doc (toPos (16, 21))
+        liftIO $ do
+          fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
+          defs
+            `shouldBe` [ Location (filePathToUri fp)
+                                  (Range (toPos (13, 1)) (toPos (13, 30)))
+                       ]
+  it "finds local definition of sum type variable"
+    $ runSession hieCommand fullCaps "test/testdata/gototest"
+    $ do
+        doc  <- openDoc "src/Lib.hs" "haskell"
+        defs <- getTypeDefinitions doc (toPos (21, 13))
+        liftIO $ do
+          fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
+          defs
+            `shouldBe` [ Location (filePathToUri fp)
+                                  (Range (toPos (18, 1)) (toPos (18, 26)))
+                       ]
+  it "finds local definition of sum type contructor"
+    $ runSession hieCommand fullCaps "test/testdata/gototest"
+    $ do
+        doc  <- openDoc "src/Lib.hs" "haskell"
+        defs <- getTypeDefinitions doc (toPos (24, 7))
+        liftIO $ do
+          fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
+          defs
+            `shouldBe` [ Location (filePathToUri fp)
+                                  (Range (toPos (18, 1)) (toPos (18, 26)))
+                       ]
+  it "can not find non-local definition of type def"
+    $ runSession hieCommand fullCaps "test/testdata/gototest"
+    $ do
+        doc  <- openDoc "src/Lib.hs" "haskell"
+        defs <- getTypeDefinitions doc (toPos (30, 17))
+        liftIO $ defs `shouldBe` []
+
+  it "find local definition of type def"
+    $ runSession hieCommand fullCaps "test/testdata/gototest"
+    $ do
+        doc      <- openDoc "src/Lib2.hs" "haskell"
+        otherDoc <- openDoc "src/Lib.hs" "haskell"
+        closeDoc otherDoc
+        defs <- getTypeDefinitions doc (toPos (35, 16))
+        liftIO $ do
+          fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
+          defs
+            `shouldBe` [ Location (filePathToUri fp)
+                                  (Range (toPos (18, 1)) (toPos (18, 26)))
+                       ]
+
+  it "find type-definition of type def in component"
+    $ runSession hieCommand fullCaps "test/testdata/gototest"
+    $ do
+        doc  <- openDoc "src/Lib.hs" "haskell"
+        defs <- getTypeDefinitions doc (toPos (13, 20))
+        liftIO $ do
+          fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
+          defs
+            `shouldBe` [ Location (filePathToUri fp)
+                                  (Range (toPos (8, 1)) (toPos (8, 29)))
+                       ]
+  it "find definition of parameterized data type"
+    $ runSession hieCommand fullCaps "test/testdata/gototest"
+    $ do
+        doc  <- openDoc "src/Lib.hs" "haskell"
+        defs <- getTypeDefinitions doc (toPos (40, 19))
+        liftIO $ do
+          fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
+          defs
+            `shouldBe` [ Location (filePathToUri fp)
+                                  (Range (toPos (37, 1)) (toPos (37, 31)))
+                       ]

--- a/test/functional/TypeDefinitionSpec.hs
+++ b/test/functional/TypeDefinitionSpec.hs
@@ -64,9 +64,7 @@ spec = describe "type definitions" $ do
   it "find local definition of type def"
     $ runSession hieCommand fullCaps "test/testdata/gototest"
     $ do
-        doc      <- openDoc "src/Lib2.hs" "haskell"
-        otherDoc <- openDoc "src/Lib.hs" "haskell"
-        closeDoc otherDoc
+        doc      <- openDoc "src/Lib.hs" "haskell"
         defs <- getTypeDefinitions doc (toPos (35, 16))
         liftIO $ do
           fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"
@@ -78,7 +76,9 @@ spec = describe "type definitions" $ do
   it "find type-definition of type def in component"
     $ runSession hieCommand fullCaps "test/testdata/gototest"
     $ do
-        doc  <- openDoc "src/Lib.hs" "haskell"
+        doc      <- openDoc "src/Lib2.hs" "haskell"
+        otherDoc <- openDoc "src/Lib.hs" "haskell"
+        closeDoc otherDoc
         defs <- getTypeDefinitions doc (toPos (13, 20))
         liftIO $ do
           fp <- canonicalizePath "test/testdata/gototest/src/Lib.hs"

--- a/test/testdata/gototest/src/Lib.hs
+++ b/test/testdata/gototest/src/Lib.hs
@@ -1,6 +1,35 @@
 module Lib
-    ( someFunc
-    ) where
+    
+    where
 
 someFunc :: IO ()
 someFunc = putStrLn "someFunc"
+
+data DataType = DataType Int
+
+dataTypeId :: DataType -> DataType
+dataTypeId dataType = dataType
+
+newtype NewType = NewType Int
+
+newTypeId :: NewType -> NewType
+newTypeId newType = newType
+
+data Enu = First | Second
+
+enuId :: Enu -> Enu
+enuId enu = enu
+
+toNum :: Enu -> Int
+toNum First = 1
+toNum Second = 2
+
+type MyInt = Int
+
+myIntId :: MyInt -> MyInt
+myIntId myInt = myInt
+
+type TypEnu = Enu
+
+typEnuId :: TypEnu -> TypEnu
+typEnuId enu = enu

--- a/test/testdata/gototest/src/Lib.hs
+++ b/test/testdata/gototest/src/Lib.hs
@@ -33,3 +33,8 @@ type TypEnu = Enu
 
 typEnuId :: TypEnu -> TypEnu
 typEnuId enu = enu
+
+data Parameter a = Parameter a
+
+parameterId :: Parameter a -> Parameter a
+parameterId pid = pid

--- a/test/testdata/gototest/src/Lib2.hs
+++ b/test/testdata/gototest/src/Lib2.hs
@@ -8,3 +8,6 @@ g = do
   where z = 1+2
         y = z+z
         x = y*z
+
+otherId :: DataType -> DataType
+otherId dataType = dataType

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -30,7 +30,7 @@ import           Test.Hspec
 -- ---------------------------------------------------------------------
 
 main :: IO ()
-main = hspec spec 
+main = hspec spec
 
 spec :: Spec
 spec = do

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -21,8 +21,8 @@ import           Language.Haskell.LSP.Types     ( Location(..)
 import           System.Directory
 import           System.FilePath
 import           TestUtils
+
 import           Test.Hspec
-import Test.Hspec.Runner
 
 -- ---------------------------------------------------------------------
 {-# ANN module ("hlint: ignore Eta reduce" :: String) #-}
@@ -30,10 +30,7 @@ import Test.Hspec.Runner
 -- ---------------------------------------------------------------------
 
 main :: IO ()
-main = do
-  setupStackFiles
-  config <- getHspecFormattedConfig "unit"
-  hspecWith config spec
+main = hspec spec 
 
 spec :: Spec
 spec = do
@@ -242,7 +239,11 @@ hareSpec = do
           lreq = setTypecheckedModule u
           req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (24, 7))
       r <- dispatchRequestPGoto $ lreq >> req
-      r `shouldBe` IdeResultOk [(Range (toPos (18, 1)) (toPos (18, 26)))]
+      r `shouldBe` IdeResultOk 
+        [ Location
+            (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs") 
+            (Range (toPos (18, 1)) (toPos (18, 26)))
+        ]
     it "can not find non-local definition of type def" $ do
       let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
           lreq = setTypecheckedModule u

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -270,6 +270,16 @@ hareSpec = do
             (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs")
             (Range (toPos (8, 1)) (toPos (8, 29)))
         ]
+    it "find definition of parameterized data type" $ do
+      let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
+          lreq = setTypecheckedModule u
+          req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (40, 19))
+      r <- dispatchRequestPGoto $ lreq >> req
+      r `shouldBe` IdeResultOk
+        [ Location
+            (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs")
+            (Range (toPos (37, 1)) (toPos (37, 31)))
+        ]
 
     -- ---------------------------------
 

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -21,8 +21,8 @@ import           Language.Haskell.LSP.Types     ( Location(..)
 import           System.Directory
 import           System.FilePath
 import           TestUtils
-
 import           Test.Hspec
+import Test.Hspec.Runner
 
 -- ---------------------------------------------------------------------
 {-# ANN module ("hlint: ignore Eta reduce" :: String) #-}
@@ -30,7 +30,10 @@ import           Test.Hspec
 -- ---------------------------------------------------------------------
 
 main :: IO ()
-main = hspec spec
+main = do
+  setupStackFiles
+  config <- getHspecFormattedConfig "unit"
+  hspecWith config spec
 
 spec :: Spec
 spec = do
@@ -199,12 +202,73 @@ hareSpec = do
           req = liftToGhc $ TestDeferM $ findDef u (toPos (7,11))
       r <- dispatchRequestPGoto $ lreq >> req
       r `shouldBe` IdeResultOk [Location (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib2.hs")
-                                           (Range (toPos (10,9)) (toPos (10,10)))]
+                                            (Range (toPos (10,9)) (toPos (10,10)))]
       let req2 = liftToGhc $ TestDeferM $ findDef u (toPos (10,13))
       r2 <- dispatchRequestPGoto $ lreq >> req2
       r2 `shouldBe` IdeResultOk [Location (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib2.hs")
                                             (Range (toPos (9,9)) (toPos (9,10)))]
-
+    it "finds local definition of record variable" $ do
+      let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
+          lreq = setTypecheckedModule u
+          req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (11, 23))
+      r <- dispatchRequestPGoto $ lreq >> req
+      r `shouldBe` IdeResultOk
+        [ Location
+            (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs")
+            (Range (toPos (8, 1)) (toPos (8, 29)))
+        ]
+    it "finds local definition of newtype variable" $ do
+      let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
+          lreq = setTypecheckedModule u
+          req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (16, 21))
+      r <- dispatchRequestPGoto $ lreq >> req
+      r `shouldBe` IdeResultOk
+        [ Location
+            (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs")
+            (Range (toPos (13, 1)) (toPos (13, 30)))
+        ]
+    it "finds local definition of sum type variable" $ do
+      let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
+          lreq = setTypecheckedModule u
+          req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (21, 13))
+      r <- dispatchRequestPGoto $ lreq >> req
+      r `shouldBe` IdeResultOk
+        [ Location
+            (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs")
+            (Range (toPos (18, 1)) (toPos (18, 26)))
+        ]
+    it "finds local definition of sum type contructor" $ do
+      let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
+          lreq = setTypecheckedModule u
+          req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (24, 7))
+      r <- dispatchRequestPGoto $ lreq >> req
+      r `shouldBe` IdeResultOk []
+    it "can not find non-local definition of type def" $ do
+      let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
+          lreq = setTypecheckedModule u
+          req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (30, 17))
+      r <- dispatchRequestPGoto $ lreq >> req
+      r `shouldBe` IdeResultOk []
+    it "find local definition of type def" $ do
+      let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
+          lreq = setTypecheckedModule u
+          req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (35, 16))
+      r <- dispatchRequestPGoto $ lreq >> req
+      r `shouldBe` IdeResultOk
+        [ Location
+            (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs")
+            (Range (toPos (18, 1)) (toPos (18, 26)))
+        ]
+    it "find type-definition of type def in component" $ do
+      let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib2.hs"
+          lreq = setTypecheckedModule u
+          req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (13, 20))
+      r <- dispatchRequestPGoto $ lreq >> req
+      r `shouldBe` IdeResultOk
+        [ Location
+            (filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs")
+            (Range (toPos (8, 1)) (toPos (8, 29)))
+        ]
 
     -- ---------------------------------
 

--- a/test/unit/HaRePluginSpec.hs
+++ b/test/unit/HaRePluginSpec.hs
@@ -242,7 +242,7 @@ hareSpec = do
           lreq = setTypecheckedModule u
           req  = liftToGhc $ TestDeferM $ findTypeDef u (toPos (24, 7))
       r <- dispatchRequestPGoto $ lreq >> req
-      r `shouldBe` IdeResultOk []
+      r `shouldBe` IdeResultOk [(Range (toPos (18, 1)) (toPos (18, 26)))]
     it "can not find non-local definition of type def" $ do
       let u    = filePathToUri $ cwd </> "test/testdata/gototest/src/Lib.hs"
           lreq = setTypecheckedModule u


### PR DESCRIPTION
Closes #1010 

Missing:
* [x] Unit-tests
* [x] Integration tests with lsp-test ~, see [#31](https://github.com/bubba/lsp-test/pull/31)~
* [x] Validating it actually does something

Works for variables and sum type values.
Implement tests for `data`, `newtype` and `type`.
For type defs, the original type definition will be found.
If the data type definition is not in scope, empty result will be sent.