### PR TITLE
update the snippet for .spacemacs/user-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,8 +458,9 @@ and then activate [`lsp-haskell`](https://github.com/emacs-lsp/lsp-haskell) in y
 ```lisp
 (defun dotspacemacs/user-config ()
   "..."
+  (setq lsp-haskell-process-path-hie "hie-wrapper")
   (require 'lsp-haskell)
-  (add-hook 'haskell-mode-hook #'lsp-haskell-enable)
+  (add-hook 'haskell-mode-hook #'lsp)
   )
 ```
 


### PR DESCRIPTION
The function `lsp-haskell-enable` does not seem to exist anymore.

Per https://github.com/emacs-lsp/lsp-haskell the lsp-haskell mode should be enabled with `   (add-hook 'haskell-mode-hook #'lsp)`