### PR TITLE
Change resolver to achieve idempotent builds

### DIFF
--- a/shake.yaml
+++ b/shake.yaml
@@ -1,5 +1,5 @@
 # Used to provide a different environment for the shake build script
-resolver: nightly-2018-12-17 # GHC 8.6.2
+resolver: nightly-2018-12-15 # GHC 8.6.2
 packages:
 - .
 


### PR DESCRIPTION
Closes #1116.
Changes the resolver to avoid unregistering extra dep packages.

Pro:
Builds should now be idempotent, e.g. repeated invocation of `./install.hs build` should not build anything twice.

Con: 
Additional snapshot must be downloaded. 