### PR TITLE
Remove redundant shake.yaml

### DIFF
--- a/install.hs
+++ b/install.hs
@@ -1,8 +1,7 @@
 #!/usr/bin/env stack
 {- stack
-  --stack-yaml shake.yaml
-  --install-ghc
-  runghc
+  script
+  --resolver nightly-2018-12-17
   --package shake
   --package directory
 -}

--- a/install.hs
+++ b/install.hs
@@ -1,7 +1,7 @@
 #!/usr/bin/env stack
 {- stack
   script
-  --resolver nightly-2018-12-17
+  --resolver nightly-2018-12-15
   --package shake
   --package directory
 -}


### PR DESCRIPTION
As of #1136 we no longer need the nix config in `shake.yaml`.