### PR TITLE
Use correct LTS version for GHC 8.6.3. Fixes #1131

### DIFF
--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.11 # Last GHC 8.6.3
+resolver: lts-13.10 # Last GHC 8.6.3
 packages:
 - .
 - hie-plugin-api


### PR DESCRIPTION
Fixes issue #1131 

The documentation on Stackage for LTS 13.11 is incorrect. Stackage says it corresponds to GHC 8.6.3 but it actually corresponds to GHC 8.6.4: https://github.com/commercialhaskell/lts-haskell/blob/master/lts-13.11.yaml . LTS 13.10 is the last LTS release corresponding to GHC 8.6.3