### PR TITLE
Build simplifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ then it means you have the command in PATH.
 
 On Linux you will need install a couple of extra libraries (for Unicode ([ICU](http://site.icu-project.org/)) and [NCURSES](https://www.gnu.org/software/ncurses/)):
 
-**Debian/Ubuntu**: 
+**Debian/Ubuntu**:
 
 ```bash
 sudo apt install libicu-dev libtinfo-dev libgmp-dev
@@ -194,7 +194,7 @@ Available commands can be seen with:
 stack ./install.hs help
 ```
 
-Remember, this will take time to download a Stackage-LTS and an appropriate GHC. However, afterwards all commands should work as expected. 
+Remember, this will take time to download a Stackage-LTS and an appropriate GHC. However, afterwards all commands should work as expected.
 
 ##### Install specific GHC Version
 
@@ -202,14 +202,14 @@ Install **Nightly** (and hoogle docs):
 
 ```bash
 stack ./install.hs hie-8.6.4
-stack ./install.hs build-doc-8.6.4
+stack ./install.hs build-docs
 ```
 
 Install **LTS** (and hoogle docs):
 
 ```bash
 stack ./install.hs hie-8.4.4
-stack ./install.hs build-doc-8.4.4
+stack ./install.hs build-docs
 ```
 
 The Haskell IDE Engine can also be built with `cabal new-build` instead of `stack build`.
@@ -237,7 +237,7 @@ If your desired ghc has been found, you use it to install Haskell IDE Engine.
 
 ```bash
 stack install.hs cabal-hie-8.4.4
-stack install.hs cabal-build-doc-8.4.4
+stack install.hs cabal-build-docs
 ```
 
 To install HIE for all GHC versions that are present on your system, use:
@@ -589,11 +589,11 @@ These builds have a dependency on [homebrew](https://brew.sh)'s `gmp` library. I
 
 ### cannot satisfy -package-id \<package\>
 
-#### Is \<package\> base-x? 
+#### Is \<package\> base-x?
 Make sure that you are running the correct version of hie for your version of ghc, or check out hie-wrapper.
 
 #### Is there a hash (#) after \<package\>?
 Delete any `.ghc.environment*` files in your project root and try again. (At the time of writing, cabal new-style projects are not supported with ghc-mod)
 
 #### Otherwise
-Try running `cabal update`. 
+Try running `cabal update`.

--- a/install.hs
+++ b/install.hs
@@ -34,6 +34,7 @@ import           Data.Maybe                               ( isNothing
 import           Data.List                                ( dropWhileEnd
                                                           , intersperse
                                                           , intercalate
+                                                          , sort
                                                           )
 import qualified Data.Text as T
 import           Data.Char                                ( isSpace )
@@ -63,6 +64,7 @@ getHieVersions = do
         & map T.unpack
         -- the following line excludes `8.6.3` on windows systems
         & filter (\p -> not isWindowsSystem || p /= "8.6.3")
+        & sort
   return hieVersions
 
 -- | Most recent version of hie.
@@ -319,7 +321,7 @@ shortHelpMessage = do
     , stackBuildAllTarget
     -- , stackHieTarget mostRecentHieVersion
     , stackBuildDocTarget
-    , stackHieTarget "8.4.4"
+    , stackHieTarget (last hieVersions)
     , emptyTarget
     , ( "cabal-ghcs"
       , "Show all GHC versions that can be installed via `cabal-build` and `cabal-build-all`."
@@ -328,7 +330,7 @@ shortHelpMessage = do
     , cabalBuildAllTarget
     -- , cabalHieTarget mostRecentHieVersion
     , cabalBuildDocTarget
-    , cabalHieTarget "8.4.4"
+    , cabalHieTarget (last hieVersions)
     ]
 
 

--- a/install.hs
+++ b/install.hs
@@ -232,7 +232,7 @@ installCabal = do
   when (isNothing cabalExe) $
     execStack_ ["install", "--stack-yaml=shake.yaml", "cabal-install"]
   execCabal_ ["update"]
-  ghc <- getStackGhcPath mostRecentHieVersion
+  ghc <- getStackGhcPathShake
   execCabal_ ["install", "Cabal-2.4.1.0", "--with-compiler=" ++ ghc]
 
 
@@ -472,6 +472,11 @@ isWindowsSystem = os `elem` ["mingw32", "win32"]
 getStackGhcPath :: VersionNumber -> Action GhcPath
 getStackGhcPath ghcVersion = do
   Stdout ghc <- execStackWithYaml ghcVersion ["path", "--compiler-exe"]
+  return $ trim ghc
+
+getStackGhcPathShake :: Action GhcPath
+getStackGhcPathShake = do
+  Stdout ghc <- execStack ["--stack-yaml=shake.yaml", "path", "--compiler-exe"]
   return $ trim ghc
 
 -- |Get the path to a GHC that has the version specified by `VersionNumber`

--- a/install.hs
+++ b/install.hs
@@ -244,8 +244,8 @@ checkStack = do
         stackVersion & trim & readP_to_S parseVersion & filter
           (("" ==) . snd)
   unless (parsedVersion >= makeVersion [1, 9, 3]) $ do
-    liftIO $ putStrLn $ embedInStars stackExeIsOldFailMsg
-    error stackExeIsOldFailMsg
+    liftIO $ putStrLn $ embedInStars $ stackExeIsOldFailMsg stackVersion
+    error $ stackExeIsOldFailMsg stackVersion
 
 
 stackBuildHie :: VersionNumber -> Action ()
@@ -561,7 +561,8 @@ cabalInstallNotSuportedFailMsg =
     ++ "If this system has been falsely identified, please open an issue at:\n\thttps://github.com/haskell/haskell-ide-engine\n"
 
 -- | Error message when the `stack` binary is an older version
-stackExeIsOldFailMsg :: String
-stackExeIsOldFailMsg =
+stackExeIsOldFailMsg :: String -> String
+stackExeIsOldFailMsg stackVersion =
   "The `stack` executable is outdated.\n"
+    ++ "found version is `" ++ stackVersion ++ "`.\n"
     ++ "Please run `stack upgrade` to upgrade your stack installation"

--- a/install.hs
+++ b/install.hs
@@ -41,7 +41,7 @@ import           Text.ParserCombinators.ReadP             ( readP_to_S )
 type VersionNumber = String
 type GhcPath = String
 
--- |Defines all different hie versions that are buildable.
+-- | Defines all different hie versions that are buildable.
 -- If they are edited, make sure to maintain the order of the versions.
 hieVersions :: [VersionNumber]
 hieVersions =
@@ -56,7 +56,7 @@ hieVersions =
   , "8.6.4"
   ]
 
--- |Most recent version of hie.
+-- | Most recent version of hie.
 -- Shown in the more concise help message.
 mostRecentHieVersion :: VersionNumber
 mostRecentHieVersion = last hieVersions
@@ -155,7 +155,7 @@ buildIcuMacosFix version = execStackWithGhc_
   , "--extra-include-dirs=/usr/local/opt/icu4c/include"
   ]
 
--- |update the submodules that the project is in the state as required by the `stack.yaml` files
+-- | update the submodules that the project is in the state as required by the `stack.yaml` files
 updateSubmodules :: Action ()
 updateSubmodules = do
   command_ [] "git" ["submodule", "sync", "--recursive"]
@@ -376,25 +376,25 @@ helpMessage = do
 emptyTarget :: (String, String)
 emptyTarget = ("", "")
 
--- |Number of spaces the target name including whitespace should have.
+-- | Number of spaces the target name including whitespace should have.
 -- At least twenty, maybe more if target names are long. At most the length of the longest target plus five.
 space :: [(String, String)] -> Int
 space phonyTargets = maximum (20 : map ((+ 5) . length . fst) phonyTargets)
 
--- |Show a target.
+-- | Show a target.
 -- Concatenates the target with its help message and inserts whitespace between them.
 showTarget :: Int -> (String, String) -> String
 showTarget spaces (target, msg) =
   target ++ replicate (spaces - length target) ' ' ++ msg
 
--- |Target for a specific ghc version
+-- | Target for a specific ghc version
 stackHieTarget :: String -> (String, String)
 stackHieTarget version =
   ( "hie-" ++ version
   , "Builds hie for GHC version " ++ version ++ " only with stack"
   )
 
--- |Target for a specific ghc version
+-- | Target for a specific ghc version
 cabalHieTarget :: String -> (String, String)
 cabalHieTarget version =
   ( "cabal-hie-" ++ version
@@ -438,24 +438,24 @@ allVersionMessage wordList = case wordList of
 
 -- RUN EXECUTABLES
 
--- |Execute a stack command for a specified ghc, discarding the output
+-- | Execute a stack command for a specified ghc, discarding the output
 execStackWithGhc_ :: VersionNumber -> [String] -> Action ()
 execStackWithGhc_ versionNumber args = do
   let stackFile = "stack-" ++ versionNumber ++ ".yaml"
   command_ [] "stack" (("--stack-yaml=" ++ stackFile) : args)
 
--- |Execute a stack command for a specified ghc
+-- | Execute a stack command for a specified ghc
 execStackWithGhc :: CmdResult r => VersionNumber -> [String] -> Action r
 execStackWithGhc versionNumber args = do
   let stackFile = "stack-" ++ versionNumber ++ ".yaml"
   command [] "stack" (("--stack-yaml=" ++ stackFile) : args)
 
--- |Execute a stack command with the same resolver as the build script
+-- | Execute a stack command with the same resolver as the build script
 execStackShake :: CmdResult r => [String] -> Action r
 execStackShake args =
   command [] "stack" ("--stack-yaml=shake.yaml" : args)
 
--- |Execute a stack command with the same resolver as the build script, discarding the output
+-- | Execute a stack command with the same resolver as the build script, discarding the output
 execStackShake_ :: [String] -> Action ()
 execStackShake_ args =
   command_ [] "stack" ("--stack-yaml=shake.yaml" : args)
@@ -477,7 +477,7 @@ existsExecutable executable = liftIO $ isJust <$> findExecutable executable
 isWindowsSystem :: Bool
 isWindowsSystem = os `elem` ["mingw32", "win32"]
 
--- |Get the path to the GHC compiler executable linked to the local `stack-$GHCVER.yaml`.
+-- | Get the path to the GHC compiler executable linked to the local `stack-$GHCVER.yaml`.
 -- Equal to the command `stack path --stack-yaml $stack-yaml --compiler-exe`.
 -- This might install a GHC if it is not already installed, thus, might fail if stack fails to install the GHC.
 getStackGhcPath :: VersionNumber -> Action GhcPath
@@ -490,7 +490,7 @@ getStackGhcPathShake = do
   Stdout ghc <- execStackShake ["path", "--compiler-exe"]
   return $ trim ghc
 
--- |Get the path to a GHC that has the version specified by `VersionNumber`
+-- | Get the path to a GHC that has the version specified by `VersionNumber`
 -- If no such GHC can be found, Nothing is returned.
 -- First, it is checked whether there is a GHC with the name `ghc-$VersionNumber`.
 -- If this yields no result, it is checked, whether the numeric-version of the `ghc`
@@ -506,7 +506,7 @@ getGhcPath ghcVersion = liftIO $
           if ghcVersion == trim version then return $ Just p else return Nothing
     p -> return p
 
--- |Read the local install root of the stack project specified by the VersionNumber
+-- | Read the local install root of the stack project specified by the VersionNumber
 -- Returns the filepath of the local install root.
 -- Equal to the command `stack path --local-install-root`
 getLocalInstallRoot :: VersionNumber -> Action FilePath
@@ -516,7 +516,7 @@ getLocalInstallRoot hieVersion = do
     ["path", "--local-install-root"]
   return $ trim localInstallRoot'
 
--- |Get the local binary path of stack.
+-- | Get the local binary path of stack.
 -- Equal to the command `stack path --local-bin`
 getLocalBin :: Action FilePath
 getLocalBin = do
@@ -524,11 +524,11 @@ getLocalBin = do
     ["path", "--local-bin"]
   return $ trim stackLocalDir'
 
--- |Trim the end of a string
+-- | Trim the end of a string
 trim :: String -> String
 trim = dropWhileEnd isSpace
 
--- |Embed a string within two lines of stars to improve perceivability and, thus, readability.
+-- | Embed a string within two lines of stars to improve perceivability and, thus, readability.
 embedInStars :: String -> String
 embedInStars str =
   let starsLine
@@ -544,7 +544,7 @@ stackBuildFailMsg =
     ++ "If this does not work, open an issue at \n"
     ++ "\thttps://github.com/haskell/haskell-ide-engine"
 
--- |No suitable ghc version has been found. Show a message.
+-- | No suitable ghc version has been found. Show a message.
 ghcVersionNotFoundFailMsg :: VersionNumber -> String
 ghcVersionNotFoundFailMsg versionNumber =
   "No GHC with version "
@@ -560,7 +560,7 @@ cabalInstallNotSuportedFailMsg =
     ++ "Please use one of the stack-based targets.\n\n"
     ++ "If this system has been falsely identified, please open an issue at:\n\thttps://github.com/haskell/haskell-ide-engine\n"
 
--- | Error message when a windows system tries to install HIE via `cabal new-install`
+-- | Error message when the `stack` binary is an older version
 stackExeIsOldFailMsg :: String
 stackExeIsOldFailMsg =
   "The `stack` executable is outdated.\n"

--- a/install.hs
+++ b/install.hs
@@ -161,6 +161,7 @@ updateSubmodules = do
   command_ [] "git" ["submodule", "sync", "--recursive"]
   command_ [] "git" ["submodule", "update", "--init", "--recursive"]
 
+-- TODO: this restriction will be gone in the next release of cabal
 validateCabalNewInstallIsSupported :: Action ()
 validateCabalNewInstallIsSupported = when isWindowsSystem $ do
   liftIO $ putStrLn $ embedInStars cabalInstallNotSuportedFailMsg

--- a/install.hs
+++ b/install.hs
@@ -34,6 +34,7 @@ import           Data.List                                ( dropWhileEnd
 import           Data.Char                                ( isSpace )
 import           Data.Version                             ( parseVersion
                                                           , makeVersion
+                                                          , showVersion
                                                           )
 import           Data.Function                            ( (&) )
 import           Text.ParserCombinators.ReadP             ( readP_to_S )
@@ -243,9 +244,9 @@ checkStack = do
   let (parsedVersion, "") : _ =
         stackVersion & trim & readP_to_S parseVersion & filter
           (("" ==) . snd)
-  unless (parsedVersion >= makeVersion [1, 9, 3]) $ do
-    liftIO $ putStrLn $ embedInStars $ stackExeIsOldFailMsg stackVersion
-    error $ stackExeIsOldFailMsg stackVersion
+  unless (parsedVersion >= makeVersion requiredStackVersion) $ do
+    liftIO $ putStrLn $ embedInStars $ stackExeIsOldFailMsg $ trim stackVersion
+    error $ stackExeIsOldFailMsg $ trim stackVersion
 
 
 stackBuildHie :: VersionNumber -> Action ()
@@ -565,4 +566,8 @@ stackExeIsOldFailMsg :: String -> String
 stackExeIsOldFailMsg stackVersion =
   "The `stack` executable is outdated.\n"
     ++ "found version is `" ++ stackVersion ++ "`.\n"
+    ++ "required version is `" ++ showVersion (makeVersion requiredStackVersion) ++ "`.\n"
     ++ "Please run `stack upgrade` to upgrade your stack installation"
+
+requiredStackVersion :: [Int]
+requiredStackVersion = [1, 9, 3]

--- a/install.hs
+++ b/install.hs
@@ -156,7 +156,7 @@ validateCabalNewInstallIsSupported = when (os `elem` ["mingw32", "win32"]) $ do
 configureCabal :: VersionNumber -> Action ()
 configureCabal versionNumber = do
   ghcPath <- getGhcPath versionNumber >>= \case
-    Nothing -> do -- TODO: this is better written using a monad-transformer
+    Nothing -> do
       liftIO $ putStrLn $ embedInStars (ghcVersionNotFound versionNumber)
       error (ghcVersionNotFound versionNumber)
     Just p -> return p
@@ -170,7 +170,7 @@ findInstalledGhcs = mapMaybeM
       Nothing -> return Nothing
       Just p  -> return $ Just (version, p)
   )
-  hieVersions
+  (reverse hieVersions)
 
 cabalBuildHie :: VersionNumber -> Action ()
 cabalBuildHie versionNumber = do
@@ -345,7 +345,7 @@ emptyTarget :: (String, String)
 emptyTarget = ("", "")
 
 -- |Number of spaces the target name including whitespace should have.
--- At least twenty, maybe more if target names are long and at least the length of the longest target plus five.
+-- At least twenty, maybe more if target names are long. At most the length of the longest target plus five.
 space :: [(String, String)] -> Int
 space phonyTargets = maximum (20 : map ((+ 5) . length . fst) phonyTargets)
 


### PR DESCRIPTION
This pull-request is the result of my review of the `install.hs` file.

Following improvements were made:
* hoogle-database is only generated once. The same file was generated every time.
* `cabal-install` is not installed via `stack` if the executable `cabal` can already be found.

A review from @fendor has been conducted and the suggestions have been included.