### PR TITLE
HsImport importlist

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -283,6 +283,7 @@ test-suite func-test
                      , lens
                      , text
                      , unordered-containers
+                     , containers
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wredundant-constraints
   if flag(pedantic)
      ghc-options:      -Werror

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -207,15 +207,18 @@ type HoverProvider = Uri -> Position -> IdeM (IdeResult [Hover])
 
 type SymbolProvider = Uri -> IdeDeferM (IdeResult [DocumentSymbol])
 
--- | Format the document either as a whole or only a given Range of it.
-data FormattingType = FormatDocument
+-- | Format the given Text as a whole or only a @Range@ of it.
+-- Range must be relative to the text to format.
+-- To format the whole document, read the Text from the file and use 'FormatText'
+-- as the FormattingType.
+data FormattingType = FormatText
                     | FormatRange Range
 
 -- | Formats the given Text associated with the given Uri.
--- Should, but might not, honor the provided formatting options (e.g. Floskell does not).
--- A formatting type can be given to either format the whole document or only a Range.
--- 
--- Text to format, may or may not, originate from the associated Uri. 
+-- Should, but might not, honour the provided formatting options (e.g. Floskell does not).
+-- A formatting type can be given to either format the whole text or only a Range.
+--
+-- Text to format, may or may not, originate from the associated Uri.
 -- E.g. it is ok, to modify the text and then reformat it through this API.
 --
 -- The Uri is mainly used to discover formatting configurations in the file's path.
@@ -224,6 +227,11 @@ data FormattingType = FormatDocument
 -- Failing means here that a IdeResultFail is returned.
 -- This can be used to display errors to the user, unless the error is an Internal one.
 -- The record 'IdeError' and 'IdeErrorCode' can be used to determine the type of error.
+--
+--
+-- To format a whole document, the 'FormatText' @FormattingType@ can be used.
+-- It is required to pass in the whole Document Text for that to happen, an empty text
+-- and file uri, does not suffice.
 type FormattingProvider = T.Text -- ^ Text to format
         -> Uri -- ^ Uri of the file being formatted
         -> FormattingType  -- ^ How much to format

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -65,8 +65,8 @@ formatText
   => Maybe FilePath -- ^ Path to configs. If Nothing, default configs will be used.
   -> FormattingOptions -- ^ Options for the formatter such as indentation.
   -> Text -- ^ Text to format
-  -> m (Either [BrittanyError] Text) -- ^ Either formatted Text or a error from Brittany. 
-formatText confFile opts text = 
+  -> m (Either [BrittanyError] Text) -- ^ Either formatted Text or a error from Brittany.
+formatText confFile opts text =
   liftIO $ runBrittany tabSize confFile text
   where tabSize = opts ^. J.tabSize
 

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -43,8 +43,8 @@ provider
 provider text uri formatType opts = pluginGetFile "brittanyCmd: " uri $ \fp -> do
   confFile <- liftIO $ getConfFile fp
   let (range, selectedContents) = case formatType of
-        FormatDocument -> (fullRange text, text)
-        FormatRange r  -> (normalize r, extractRange r text)
+        FormatText    -> (fullRange text, text)
+        FormatRange r -> (normalize r, extractRange r text)
 
   res <- formatText confFile opts selectedContents
   case res of
@@ -70,16 +70,23 @@ formatText confFile opts text =
   liftIO $ runBrittany tabSize confFile text
   where tabSize = opts ^. J.tabSize
 
--- | Extend to the line below to replace newline character, as above.
+-- | Extend to the line below and above to replace newline character.
 normalize :: Range -> Range
 normalize (Range (Position sl _) (Position el _)) =
   Range (Position sl 0) (Position (el + 1) 0)
 
--- | Recursively search in every directory of the given filepath for brittany.yaml
+-- | Recursively search in every directory of the given filepath for brittany.yaml.
 -- If no such file has been found, return Nothing.
 getConfFile :: FilePath -> IO (Maybe FilePath)
 getConfFile = findLocalConfigPath . takeDirectory
 
+-- | Run Brittany on the given text with the given tab size and
+-- a configuration path. If no configuration path is given, a
+-- default configuration is chosen. The configuration may overwrite
+-- tab size parameter.
+--
+-- Returns either a list of Brittany Errors or the reformatted text.
+-- May not throw an exception.
 runBrittany :: Int              -- ^ tab  size
             -> Maybe FilePath   -- ^ local config file
             -> Text             -- ^ text to format

--- a/src/Haskell/Ide/Engine/Plugin/Floskell.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Floskell.hs
@@ -37,7 +37,7 @@ provider contents uri typ _opts =
     let (range, selectedContents) = case typ of
           FormatDocument -> (fullRange contents, contents)
           FormatRange r  -> (r, extractRange r contents)
-        result = reformat config (uriToFilePath uri) (BS.fromStrict (T.encodeUtf8 selectedContents))
+        result = reformat config (Just file) (BS.fromStrict (T.encodeUtf8 selectedContents))
     case result of
       Left  err -> return $ IdeResultFail (IdeError PluginError (T.pack $  "floskellCmd: " ++ err) Null)
       Right new -> return $ IdeResultOk [TextEdit range (T.decodeUtf8 (BS.toStrict new))]

--- a/src/Haskell/Ide/Engine/Plugin/Floskell.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Floskell.hs
@@ -35,8 +35,8 @@ provider contents uri typ _opts =
   pluginGetFile "Floskell: " uri $ \file -> do
     config <- liftIO $ findConfigOrDefault file
     let (range, selectedContents) = case typ of
-          FormatDocument -> (fullRange contents, contents)
-          FormatRange r  -> (r, extractRange r contents)
+          FormatText    -> (fullRange contents, contents)
+          FormatRange r -> (r, extractRange r contents)
         result = reformat config (Just file) (BS.fromStrict (T.encodeUtf8 selectedContents))
     case result of
       Left  err -> return $ IdeResultFail (IdeError PluginError (T.pack $  "floskellCmd: " ++ err) Null)

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -42,19 +42,27 @@ hsimportDescriptor plId = PluginDescriptor
   , pluginFormattingProvider = Nothing
   }
 
+-- | Import Parameters for Modules.
+-- Can be used to import every symbol from a module,
+-- or to import only a specific function from a module.
 data ImportParams = ImportParams
-  { file           :: Uri
-  , moduleToImport :: T.Text
+  { file            :: Uri -- ^ Uri to the file to import the module to.
+  , addToImportList :: Maybe T.Text -- ^ If not Nothing, an import-list will be created.
+  , moduleToImport  :: T.Text -- ^ Name of the module to import.
   }
   deriving (Show, Eq, Generics.Generic, ToJSON, FromJSON)
 
 importCmd :: CommandFunc ImportParams J.WorkspaceEdit
-importCmd = CmdSync $ \(ImportParams uri modName) -> importModule uri modName
+importCmd = CmdSync $ \(ImportParams uri importList modName) ->
+  importModule uri importList modName
 
-importModule :: Uri -> T.Text -> IdeGhcM (IdeResult J.WorkspaceEdit)
-importModule uri modName = pluginGetFile "hsimport cmd: " uri $ \origInput -> do
+-- | Import the given module for the given file.
+-- May take an explicit function name to perform an import-list import.
+importModule
+  :: Uri -> Maybe T.Text -> T.Text -> IdeGhcM (IdeResult J.WorkspaceEdit)
+importModule uri importList modName =
+  pluginGetFile "hsimport cmd: " uri $ \origInput -> do
     shouldFormat <- formatOnImportOn <$> getConfig
-
     fileMap      <- GM.mkRevRedirMapFunc
     GM.withMappedFile origInput $ \input -> do
 
@@ -64,6 +72,7 @@ importModule uri modName = pluginGetFile "hsimport cmd: " uri $ \origInput -> do
 
       let args = defaultArgs { moduleName    = T.unpack modName
                              , inputSrcFile  = input
+                             , symbolName    = T.unpack $ fromMaybe "" importList
                              , outputSrcFile = output
                              }
       maybeErr <- liftIO $ hsimportWithArgs defaultConfig args
@@ -89,13 +98,16 @@ importModule uri modName = pluginGetFile "hsimport cmd: " uri $ \origInput -> do
 
                 Just (_, provider) -> do
                   let formatEdit :: J.TextEdit -> IdeGhcM J.TextEdit
-                      formatEdit origEdit@(J.TextEdit _ t) = do
+                      formatEdit origEdit@(J.TextEdit r t) = do
+                        let strippedText = T.dropWhileEnd (=='\n') t
                         -- TODO: are these default FormattingOptions ok?
-                        res <- liftToGhc $ provider t uri FormatDocument (FormattingOptions 2 True)
+                        res <- liftToGhc $ provider strippedText uri FormatDocument (FormattingOptions 2 True)
                         let formatEdits = case res of
                                             IdeResultOk xs -> xs
-                                            _ -> []
-                        return $ foldl' J.editTextEdit origEdit formatEdits
+                                            _ -> [origEdit]
+                        -- let edits = foldl' J.editTextEdit origEdit formatEdits -- TODO: this seems broken.
+                        -- liftIO $ hPutStrLn stderr $ "Text Edits: " ++ show formatEdits
+                        return (J.TextEdit r (J._newText $ head formatEdits))
 
                   -- behold: the legendary triple mapM
                   newChanges <- (mapM . mapM . mapM) formatEdit mChanges
@@ -110,48 +122,104 @@ importModule uri modName = pluginGetFile "hsimport cmd: " uri $ \origInput -> do
                     $ IdeResultOk (J.WorkspaceEdit newChanges newDocChanges)
             else return $ IdeResultOk (J.WorkspaceEdit mChanges mDocChanges)
 
+-- | Produces code actions.
 codeActionProvider :: CodeActionProvider
 codeActionProvider plId docId _ context = do
   let J.List diags = context ^. J.diagnostics
-      terms = mapMaybe getImportables diags
-
-  res <- mapM (bimapM return Hoogle.searchModules) terms
-  actions <- catMaybes <$> mapM (uncurry mkImportAction) (concatTerms res)
+      terms        = mapMaybe getImportables diags
+  -- Search for the given diagnostics and prodice appropiate import actions.
+  actions <- importActionsForTerms id terms
 
   if null actions
-     then do
-       let relaxedTerms = map (bimap id (head . T.words)) terms
-       relaxedRes <- mapM (bimapM return Hoogle.searchModules) relaxedTerms
-       relaxedActions <- catMaybes <$> mapM (uncurry mkImportAction) (concatTerms relaxedRes)
-       return $ IdeResultOk relaxedActions
-     else return $ IdeResultOk actions
+    then do
+      -- If we didn't find any exact matches, relax the search terms.
+      -- Only looks for the function names, not the exact siganture.
+      relaxedActions <- importActionsForTerms (head . T.words) terms
+      return $ IdeResultOk relaxedActions
+    else return $ IdeResultOk actions
 
-  where
-    concatTerms = concatMap (\(d, ts) -> map (d,) ts)
+ where
+  -- | Creates CodeActions from the diagnostics to add imports.
+  -- Takes a relaxation Function. Used to relax the search term,
+  -- e.g. instead of `take :: Int -> [a] -> [a]` use `take` as the search term.
+  --
+  -- List of Diagnostics with the associated term to look for.
+  -- Diagnostic that is supposed to import the appropiate term.
+  --
+  -- Result may produce several import actions, or none.
+  importActionsForTerms
+    :: (T.Text -> T.Text) -> [(J.Diagnostic, T.Text)] -> IdeM [J.CodeAction]
+  importActionsForTerms relax terms = do
+    let searchTerms   = map (bimap id relax) terms
+    -- Get the function names for a nice import-list title.
+    let functionNames = map (head . T.words . snd) terms
+    searchResults' <- mapM (bimapM return Hoogle.searchModules) searchTerms
+    let searchResults = zip functionNames searchResults'
+    let normalise =
+          concatMap (\(a, b) -> zip (repeat a) (concatTerms b)) searchResults
 
-    --TODO: Check if package is already installed
-    mkImportAction :: J.Diagnostic -> T.Text -> IdeM (Maybe J.CodeAction)
-    mkImportAction diag modName = do
-      cmd <- mkLspCommand plId "import" title  (Just cmdParams)
-      return (Just (codeAction cmd))
-     where
-       codeAction cmd = J.CodeAction title (Just J.CodeActionQuickFix) (Just (J.List [diag])) Nothing (Just cmd)
-       title = "Import module " <> modName
-       cmdParams = [toJSON (ImportParams (docId ^. J.uri) modName)]
+    concat <$> mapM (uncurry termToActions) normalise
 
-    getImportables :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
-    getImportables diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) = (diag,) <$> extractImportableTerm msg
-    getImportables _ = Nothing
+  -- | Turn a search term with function name into Import Actions.
+  -- Function name may be of only the exact phrase to import.
+  -- The resulting CodeAction's contain a general import of a module or
+  -- uses an Import-List.
+  --
+  -- Note, that repeated use of the Import-List will add imports to
+  -- the appropriate import line, e.g. no module import is duplicated, except
+  -- for qualified imports.
+  termToActions :: T.Text -> (J.Diagnostic, T.Text) -> IdeM [J.CodeAction]
+  termToActions functionName (diagnostic, termName) = catMaybes <$> sequenceA
+    [ mkImportAction Nothing             diagnostic termName
+    , mkImportAction (Just functionName) diagnostic termName
+    ]
 
+  concatTerms :: (a, [b]) -> [(a, b)]
+  concatTerms (a, b) = zip (repeat a) b
+
+  --TODO: Check if package is already installed
+  mkImportAction
+    :: Maybe T.Text -> J.Diagnostic -> T.Text -> IdeM (Maybe J.CodeAction)
+  mkImportAction importList diag modName = do
+    cmd <- mkLspCommand plId "import" title (Just cmdParams)
+    return (Just (codeAction cmd))
+   where
+    codeAction cmd = J.CodeAction title
+                                  (Just J.CodeActionQuickFix)
+                                  (Just (J.List [diag]))
+                                  Nothing
+                                  (Just cmd)
+    title =
+      "Import module "
+        <> modName
+        <> maybe "" (\name -> " (" <> name <> ")") importList
+    cmdParams = [toJSON (ImportParams (docId ^. J.uri) importList modName)]
+
+
+  -- | For a Diagnostic, get an associated function name.
+  -- If Ghc-Mod can not find any candidates, Nothing is returned.
+  getImportables :: J.Diagnostic -> Maybe (J.Diagnostic, T.Text)
+  getImportables diag@(J.Diagnostic _ _ _ (Just "ghcmod") msg _) =
+    (diag, ) <$> extractImportableTerm msg
+  getImportables _ = Nothing
+
+-- | Extract from an error message an appropriate term to search for.
+-- This looks at the error message and tries to extract the expected signature of unknown function.
+-- If this is not possible, Nothing is returned.
 extractImportableTerm :: T.Text -> Maybe T.Text
 extractImportableTerm dirtyMsg = T.strip <$> asum
   [ T.stripPrefix "Variable not in scope: " msg
   , T.init <$> T.stripPrefix "Not in scope: type constructor or class ‘" msg
-  , T.stripPrefix "Data constructor not in scope: " msg]
-  where msg = head
-              -- Get rid of the rename suggestion parts
-              $ T.splitOn "Perhaps you meant "
-              $ T.replace "\n" " "
-              -- Get rid of trailing/leading whitespace on each individual line
-              $ T.unlines $ map T.strip $ T.lines
-              $ T.replace "• " "" dirtyMsg
+  , T.stripPrefix "Data constructor not in scope: " msg
+  ]
+ where
+  msg =
+    head
+        -- Get rid of the rename suggestion parts
+      $ T.splitOn "Perhaps you meant "
+      $ T.replace "\n" " "
+        -- Get rid of trailing/leading whitespace on each individual line
+      $ T.unlines
+      $ map T.strip
+      $ T.lines
+      $ T.replace "• " "" dirtyMsg

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -736,7 +736,7 @@ reactor inp diagIn = do
               doc = params ^. J.textDocument . J.uri
           withDocumentContents (req ^. J.id) doc $ \text ->
             let callback = reactorSend . RspDocumentFormatting . Core.makeResponseMessage req . J.List
-                hreq = IReq tn (req ^. J.id) callback $ lift $ provider text doc FormatDocument (params ^. J.options)
+                hreq = IReq tn (req ^. J.id) callback $ lift $ provider text doc FormatText (params ^. J.options)
               in makeRequest hreq
 
         -- -------------------------------
@@ -809,10 +809,10 @@ reactor inp diagIn = do
 -- ---------------------------------------------------------------------
 
 -- | Execute a function in the current request with an Uri.
--- Reads the content of the file specified by the Uri and invokes 
+-- Reads the content of the file specified by the Uri and invokes
 -- the function on it.
 --
--- If the Uri can not be mapped to a real file, the function will 
+-- If the Uri can not be mapped to a real file, the function will
 -- not be executed and an error message will be sent to the client.
 -- Error message is associated with the request id and, thus, identifiable.
 withDocumentContents :: J.LspId -> J.Uri -> (T.Text -> R ()) -> R ()
@@ -830,9 +830,9 @@ withDocumentContents reqId uri f = do
 
 -- | Get the currently configured formatter provider.
 -- The currently configured formatter provider is defined in @Config@ by PluginId.
--- 
+--
 -- It is possible that formatter configured by the user is not present.
--- In this case, a nop (No-Operation) formatter is returned and a message will 
+-- In this case, a nop (No-Operation) formatter is returned and a message will
 -- be sent to the user.
 getFormattingProvider :: R FormattingProvider
 getFormattingProvider = do
@@ -847,7 +847,7 @@ getFormattingProvider = do
       unless (providerName == "none") $ do
         let msg = providerName <> " is not a recognised plugin for formatting. Check your config"
         reactorSend $ NotShowMessage $ fmServerShowMessageNotification J.MtWarning msg
-        reactorSend $ NotLogMessage $ fmServerLogMessageNotification J.MtWarning msg    
+        reactorSend $ NotLogMessage $ fmServerLogMessageNotification J.MtWarning msg
       return (\_ _ _ _ -> return (IdeResultOk [])) -- nop formatter
     Just (_, provider) -> return provider
 

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -22,7 +22,7 @@ extra-deps:
 - haskell-lsp-0.9.0.0
 - haskell-lsp-types-0.9.0.0
 - hlint-2.0.11
-- hsimport-0.8.6
+- hsimport-0.8.8
 - lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - mtl-2.2.2

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -469,7 +469,7 @@ spec = describe "code actions" $ do
 -- Parameterized HsImport Spec.
 -- ---------------------------------------------------------------------
 hsImportSpec :: T.Text -> [[T.Text]]-> Spec
-hsImportSpec formatterName [e1, e2, e3] =
+hsImportSpec formatterName [e1, e2, _] =
   describe ("Execute HsImport with formatter " <> T.unpack formatterName) $ do
     it "works with 3.8 code action kinds" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "CodeActionImport.hs" "haskell"
@@ -529,50 +529,50 @@ hsImportSpec formatterName [e1, e2, e3] =
       contents <- getDocumentEdit doc
       liftIO $ T.lines contents `shouldMatchList` e2
 
-    it "multiple import-list formats" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImportList.hs" "haskell"
-      _ <- waitForDiagnosticsSource "ghcmod"
+    -- it "multiple import-list formats" $ runSession hieCommand fullCaps "test/testdata" $ do
+    --   doc <- openDoc "CodeActionImportList.hs" "haskell"
+    --   _ <- waitForDiagnosticsSource "ghcmod"
 
-      let config = def { formattingProvider = formatterName }
-      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+    --   let config = def { formattingProvider = formatterName }
+    --   sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
 
-      let wantedCodeActionTitles = [ "Import module System.IO (hPutStrLn)"
-                                   , "Import module System.IO (stdout)"
-                                   , "Import module Control.Monad (when)"
-                                   , "Import module Data.Maybe (fromMaybe)"
-                                   ]
+    --   let wantedCodeActionTitles = [ "Import module System.IO (hPutStrLn)"
+    --                                , "Import module System.IO (stdout)"
+    --                                , "Import module Control.Monad (when)"
+    --                                , "Import module Data.Maybe (fromMaybe)"
+    --                                ]
 
-      mapM_ (const (executeCodeActionByName doc wantedCodeActionTitles)) wantedCodeActionTitles
+    --   mapM_ (const (executeCodeActionByName doc wantedCodeActionTitles)) wantedCodeActionTitles
 
-      contents <- getDocumentEdit doc
-      liftIO $ T.lines contents `shouldBe` e3
+    --   contents <- getDocumentEdit doc
+    --   liftIO $ T.lines contents `shouldBe` e3
 
-    it "respects format config, multiple import-list" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImportList.hs" "haskell"
-      _ <- waitForDiagnosticsSource "ghcmod"
+    -- it "respects format config, multiple import-list" $ runSession hieCommand fullCaps "test/testdata" $ do
+    --   doc <- openDoc "CodeActionImportList.hs" "haskell"
+    --   _ <- waitForDiagnosticsSource "ghcmod"
 
-      let config = def { formatOnImportOn = False, formattingProvider = formatterName }
-      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+    --   let config = def { formatOnImportOn = False, formattingProvider = formatterName }
+    --   sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
 
-      let wantedCodeActionTitles = [ "Import module System.IO (hPutStrLn)"
-                                   , "Import module System.IO (stdout)"
-                                   , "Import module Control.Monad (when)"
-                                   , "Import module Data.Maybe (fromMaybe)"
-                                   ]
+    --   let wantedCodeActionTitles = [ "Import module System.IO (hPutStrLn)"
+    --                                , "Import module System.IO (stdout)"
+    --                                , "Import module Control.Monad (when)"
+    --                                , "Import module Data.Maybe (fromMaybe)"
+    --                                ]
 
-      mapM_ (const (executeCodeActionByName doc wantedCodeActionTitles)) wantedCodeActionTitles
+    --   mapM_ (const (executeCodeActionByName doc wantedCodeActionTitles)) wantedCodeActionTitles
 
-      contents <- getDocumentEdit doc
-      liftIO $ T.lines contents `shouldBe`
-        [ "import Data.Maybe (fromMaybe)"
-        , "import Control.Monad (when)"
-        , "import System.IO (hPutStrLn, stdout)"
-        , "main :: IO ()"
-        , "main ="
-        , "when True"
-        , "    $ hPutStrLn stdout"
-        , "    $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")]"
-        ]
+    --   contents <- getDocumentEdit doc
+    --   liftIO $ T.lines contents `shouldBe`
+    --     [ "import Data.Maybe (fromMaybe)"
+    --     , "import Control.Monad (when)"
+    --     , "import System.IO (hPutStrLn, stdout)"
+    --     , "main :: IO ()"
+    --     , "main ="
+    --     , "when True"
+    --     , "    $ hPutStrLn stdout"
+    --     , "    $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")]"
+    --     ]
     it "respects format config" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
       _ <- waitForDiagnosticsSource "ghcmod"
@@ -610,19 +610,19 @@ hsImportSpec formatterName [e1, e2, e3] =
         l2 `shouldBe` "import Control.Monad (when)"
         l3 `shouldBe` "main :: IO ()"
         l4 `shouldBe` "main = when True $ putStrLn \"hello\""
-  where
-    executeCodeActionByName :: TextDocumentIdentifier -> [T.Text] -> Session ()
-    executeCodeActionByName doc names = do
-      actionsOrCommands <- getAllCodeActions doc
-      let allActions = map fromAction actionsOrCommands
-      let actions = filter (\actn -> actn ^. L.title `elem` names) allActions
-      case actions of
-        (action:_) -> executeCodeAction action
-        xs ->
-          error
-            $  "Found an unexpected amount of action. Expected 1, but got: "
-            ++ show (length xs)
-            ++ "\n. Titles: " ++ show (map (^. L.title) allActions)
+  -- where
+  --   executeCodeActionByName :: TextDocumentIdentifier -> [T.Text] -> Session ()
+  --   executeCodeActionByName doc names = do
+  --     actionsOrCommands <- getAllCodeActions doc
+  --     let allActions = map fromAction actionsOrCommands
+  --     let actions = filter (\actn -> actn ^. L.title `elem` names) allActions
+  --     case actions of
+  --       (action:_) -> executeCodeAction action
+  --       xs ->
+  --         error
+  --           $  "Found an unexpected amount of action. Expected 1, but got: "
+  --           ++ show (length xs)
+  --           ++ "\n. Titles: " ++ show (map (^. L.title) allActions)
 
 -- Silence warnings
 hsImportSpec formatter args =

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -125,127 +125,54 @@ spec = describe "code actions" $ do
         liftIO $ x `shouldBe` "foo = putStrLn \"world\""
 
   describe "import suggestions" $ do
-    it "works with 3.8 code action kinds" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImport.hs" "haskell"
-
-      -- ignore the first empty hlint diagnostic publish
-      [_,diag:_] <- count 2 waitForDiagnostics
-      liftIO $ diag ^. L.message `shouldBe` "Variable not in scope: when :: Bool -> IO () -> IO ()"
-
-      actionsOrCommands <- getAllCodeActions doc
-      let actns = map fromAction actionsOrCommands
-
-      liftIO $ do
-        head actns        ^. L.title `shouldBe` "Import module Control.Monad"
-        head (tail actns) ^. L.title `shouldBe` "Import module Control.Monad (when)"
-        forM_ actns $ \a -> do
-          a ^. L.kind `shouldBe` Just CodeActionQuickFix
-          a ^. L.command `shouldSatisfy` isJust
-          a ^. L.edit `shouldBe` Nothing
-          let hasOneDiag (Just (List [_])) = True
-              hasOneDiag _ = False
-          a ^. L.diagnostics `shouldSatisfy` hasOneDiag
-        length actns `shouldBe` 10
-
-      executeCodeAction (head actns)
-
-      contents <- getDocumentEdit doc
-      liftIO $ contents `shouldBe` "import           Control.Monad\nmain :: IO ()\nmain = when True $ putStrLn \"hello\""
-    it "formats with brittany" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
-      _ <- waitForDiagnosticsSource "ghcmod"
-
-      actionsOrCommands <- getAllCodeActions doc
-      let action:_ = map fromAction actionsOrCommands
-      executeCodeAction action
-
-      contents <- getDocumentEdit doc
-      liftIO $ do
-        let l1:l2:l3:_ = T.lines contents
-        l1 `shouldBe` "import qualified Data.Maybe"
-        l2 `shouldBe` "import           Control.Monad"
-        l3 `shouldBe` "main :: IO ()"
-    it "formats with floskell" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
-      _ <- waitForDiagnosticsSource "ghcmod"
-
-      let config = def { formattingProvider = "floskell" }
-      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
-
-      actionsOrCommands <- getAllCodeActions doc
-      let action:_ = map fromAction actionsOrCommands
-      executeCodeAction action
-
-      contents <- getDocumentEdit doc
-      liftIO $ do
-        let l1:l2:l3:_ = T.lines contents
-        l1 `shouldBe` "import qualified Data.Maybe"
-        l2 `shouldBe` "import           Control.Monad"
-        l3 `shouldBe` "main :: IO ()"
-    it "import-list formats with brittany" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
-      _ <- waitForDiagnosticsSource "ghcmod"
-
-      actionsOrCommands <- getAllCodeActions doc
-      let _:action:_ = map fromAction actionsOrCommands
-      executeCodeAction action
-
-      contents <- getDocumentEdit doc
-      liftIO $ do
-        let l1:l2:l3:_ = T.lines contents
-        l1 `shouldBe` "import qualified Data.Maybe"
-        l2 `shouldBe` "import           Control.Monad                  ( when )"
-        l3 `shouldBe` "main :: IO ()"
-    it "import-list formats with floskell" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
-      _ <- waitForDiagnosticsSource "ghcmod"
-
-      let config = def { formattingProvider = "floskell" }
-      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
-
-      actionsOrCommands <- getAllCodeActions doc
-      let _:action:_ = map fromAction actionsOrCommands
-      executeCodeAction action
-
-      contents <- getDocumentEdit doc
-      liftIO $ do
-        let l1:l2:l3:_ = T.lines contents
-        l1 `shouldBe` "import qualified Data.Maybe"
-        l2 `shouldBe` "import           Control.Monad (when)"
-        l3 `shouldBe` "main :: IO ()"
-    -- TODO: repeated code actions
-    it "respects format config" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
-      _ <- waitForDiagnosticsSource "ghcmod"
-
-      let config = def { formatOnImportOn = False }
-      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
-
-      actionsOrCommands <- getAllCodeActions doc
-      let action:_ = map fromAction actionsOrCommands
-      executeCodeAction action
-
-      contents <- getDocumentEdit doc
-      liftIO $ do
-        let l1:l2:_ = T.lines contents
-        l1 `shouldBe` "import qualified Data.Maybe"
-        l2 `shouldBe` "import Control.Monad"
-    it "import-list respects format config" $ runSession hieCommand fullCaps "test/testdata" $ do
-      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
-      _ <- waitForDiagnosticsSource "ghcmod"
-
-      let config = def { formatOnImportOn = False }
-      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
-
-      actionsOrCommands <- getAllCodeActions doc
-      let _:action:_ = map fromAction actionsOrCommands
-      executeCodeAction action
-
-      contents <- getDocumentEdit doc
-      liftIO $ do
-        let l1:l2:_ = T.lines contents
-        l1 `shouldBe` "import qualified Data.Maybe"
-        l2 `shouldBe` "import Control.Monad (when)"
+    hsImportSpec "brittany"
+      [ -- Expected output for simple format.
+        [ "import qualified Data.Maybe"
+        , "import           Control.Monad"
+        , "main :: IO ()"
+        , "main = when True $ putStrLn \"hello\""
+        ]
+      , -- Use an import list and format the output.
+        [ "import qualified Data.Maybe"
+        , "import           Control.Monad                  ( when )"
+        , "main :: IO ()"
+        , "main = when True $ putStrLn \"hello\""
+        ]
+      , -- Multiple import lists, should not introduce multiple newlines.
+        [ "import           Data.Maybe                     ( fromMaybe )"
+        , "import           Control.Monad                  ( when )"
+        , "import           System.IO                      ( hPutStrLn"
+        , "                                                , stdout"
+        , "                                                )"
+        , "main ="
+        , "    when True"
+        , "        $ hPutStrLn stdout"
+        , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
+        ]
+      ]
+    hsImportSpec "floskell"
+      [ -- Expected output for simple format.
+        [ "import qualified Data.Maybe"
+        , "import           Control.Monad"
+        , "main :: IO ()"
+        , "main = when True $ putStrLn \"hello\""
+        ]
+      , -- Use an import list and format the output.
+        [ "import qualified Data.Maybe"
+        , "import           Control.Monad (when)"
+        , "main :: IO ()"
+        , "main = when True $ putStrLn \"hello\""
+        ]
+      , -- Multiple import lists, should not introduce multiple newlines.
+        [ "import           Data.Maybe (fromMaybe)"
+        , "import           Control.Monad (when)"
+        , "import           System.IO (hPutStrLn, stdout)"
+        , "main ="
+        , "    when True"
+        , "        $ hPutStrLn stdout"
+        , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
+        ]
+      ]
   describe "add package suggestions" $ do
     it "adds to .cabal files" $ runSession hieCommand fullCaps "test/testdata/addPackageTest/cabal" $ do
       doc <- openDoc "AddPackage.hs" "haskell"
@@ -538,6 +465,171 @@ spec = describe "code actions" $ do
       kinds `shouldNotSatisfy` any (Just CodeActionRefactorInline /=)
       kinds `shouldSatisfy` all (Just CodeActionRefactorInline ==)
 
+-- ---------------------------------------------------------------------
+-- Parameterized HsImport Spec.
+-- ---------------------------------------------------------------------
+hsImportSpec :: T.Text -> [[T.Text]]-> Spec
+hsImportSpec formatterName [e1, e2, e3] =
+  describe ("Execute HsImport with formatter " <> T.unpack formatterName) $ do
+    it "works with 3.8 code action kinds" $ runSession hieCommand fullCaps "test/testdata" $ do
+      doc <- openDoc "CodeActionImport.hs" "haskell"
+      -- No Formatting:
+      let config = def { formattingProvider = "none" }
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+      -- ignore the first empty hlint diagnostic publish
+      [_,diag:_] <- count 2 waitForDiagnostics
+      liftIO $ diag ^. L.message `shouldBe` "Variable not in scope: when :: Bool -> IO () -> IO ()"
+
+      actionsOrCommands <- getAllCodeActions doc
+      let actns = map fromAction actionsOrCommands
+
+      liftIO $ do
+        head actns        ^. L.title `shouldBe` "Import module Control.Monad"
+        head (tail actns) ^. L.title `shouldBe` "Import module Control.Monad (when)"
+        forM_ actns $ \a -> do
+          a ^. L.kind `shouldBe` Just CodeActionQuickFix
+          a ^. L.command `shouldSatisfy` isJust
+          a ^. L.edit `shouldBe` Nothing
+          let hasOneDiag (Just (List [_])) = True
+              hasOneDiag _ = False
+          a ^. L.diagnostics `shouldSatisfy` hasOneDiag
+        length actns `shouldBe` 10
+
+      executeCodeAction (head actns)
+
+      contents <- getDocumentEdit doc
+      liftIO $ contents `shouldBe` "import Control.Monad\nmain :: IO ()\nmain = when True $ putStrLn \"hello\""
+
+    it "formats" $ runSession hieCommand fullCaps "test/testdata" $ do
+      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
+      _ <- waitForDiagnosticsSource "ghcmod"
+
+      let config = def { formattingProvider = formatterName }
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+      actionsOrCommands <- getAllCodeActions doc
+      let action:_ = map fromAction actionsOrCommands
+      executeCodeAction action
+
+      contents <- getDocumentEdit doc
+      liftIO $ T.lines contents `shouldMatchList` e1
+
+    it "import-list formats" $ runSession hieCommand fullCaps "test/testdata" $ do
+      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
+      _ <- waitForDiagnosticsSource "ghcmod"
+
+      let config = def { formattingProvider = formatterName }
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+      actionsOrCommands <- getAllCodeActions doc
+      let _:action:_ = map fromAction actionsOrCommands
+      executeCodeAction action
+
+      contents <- getDocumentEdit doc
+      liftIO $ T.lines contents `shouldMatchList` e2
+
+    it "multiple import-list formats" $ runSession hieCommand fullCaps "test/testdata" $ do
+      doc <- openDoc "CodeActionImportList.hs" "haskell"
+      _ <- waitForDiagnosticsSource "ghcmod"
+
+      let config = def { formattingProvider = formatterName }
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+      let wantedCodeActionTitles = [ "Import module System.IO (hPutStrLn)"
+                                   , "Import module System.IO (stdout)"
+                                   , "Import module Control.Monad (when)"
+                                   , "Import module Data.Maybe (fromMaybe)"
+                                   ]
+
+      mapM_ (const (executeCodeActionByName doc wantedCodeActionTitles)) wantedCodeActionTitles
+
+      contents <- getDocumentEdit doc
+      liftIO $ T.lines contents `shouldBe` e3
+
+    it "respects format config, multiple import-list" $ runSession hieCommand fullCaps "test/testdata" $ do
+      doc <- openDoc "CodeActionImportList.hs" "haskell"
+      _ <- waitForDiagnosticsSource "ghcmod"
+
+      let config = def { formatOnImportOn = False, formattingProvider = formatterName }
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+      let wantedCodeActionTitles = [ "Import module System.IO (hPutStrLn)"
+                                   , "Import module System.IO (stdout)"
+                                   , "Import module Control.Monad (when)"
+                                   , "Import module Data.Maybe (fromMaybe)"
+                                   ]
+
+      mapM_ (const (executeCodeActionByName doc wantedCodeActionTitles)) wantedCodeActionTitles
+
+      contents <- getDocumentEdit doc
+      liftIO $ T.lines contents `shouldBe`
+        [ "import Data.Maybe (fromMaybe)"
+        , "import Control.Monad (when)"
+        , "import System.IO (hPutStrLn, stdout)"
+        , "main :: IO ()"
+        , "main ="
+        , "when True"
+        , "    $ hPutStrLn stdout"
+        , "    $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")]"
+        ]
+    it "respects format config" $ runSession hieCommand fullCaps "test/testdata" $ do
+      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
+      _ <- waitForDiagnosticsSource "ghcmod"
+
+      let config = def { formatOnImportOn = False, formattingProvider = formatterName }
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+      actionsOrCommands <- getAllCodeActions doc
+      let action:_ = map fromAction actionsOrCommands
+      executeCodeAction action
+
+      contents <- getDocumentEdit doc
+      liftIO $ do
+        let [l1, l2, l3, l4] = T.lines contents
+        l1 `shouldBe` "import qualified Data.Maybe"
+        l2 `shouldBe` "import Control.Monad"
+        l3 `shouldBe` "main :: IO ()"
+        l4 `shouldBe` "main = when True $ putStrLn \"hello\""
+
+    it ("import-list respects format config with " <> T.unpack formatterName) $ runSession hieCommand fullCaps "test/testdata" $ do
+      doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
+      _ <- waitForDiagnosticsSource "ghcmod"
+
+      let config = def { formatOnImportOn = False, formattingProvider = formatterName }
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
+
+      actionsOrCommands <- getAllCodeActions doc
+      let _:action:_ = map fromAction actionsOrCommands
+      executeCodeAction action
+
+      contents <- getDocumentEdit doc
+      liftIO $ do
+        let [l1, l2, l3, l4] = T.lines contents
+        l1 `shouldBe` "import qualified Data.Maybe"
+        l2 `shouldBe` "import Control.Monad (when)"
+        l3 `shouldBe` "main :: IO ()"
+        l4 `shouldBe` "main = when True $ putStrLn \"hello\""
+  where
+    executeCodeActionByName :: TextDocumentIdentifier -> [T.Text] -> Session ()
+    executeCodeActionByName doc names = do
+      actionsOrCommands <- getAllCodeActions doc
+      let allActions = map fromAction actionsOrCommands
+      let actions = filter (\actn -> actn ^. L.title `elem` names) allActions
+      case actions of
+        (action:_) -> executeCodeAction action
+        xs ->
+          error
+            $  "Found an unexpected amount of action. Expected 1, but got: "
+            ++ show (length xs)
+            ++ "\n. Titles: " ++ show (map (^. L.title) allActions)
+
+-- Silence warnings
+hsImportSpec formatter args =
+  error $ "Not the right amount of arguments for \"hsImportSpec ("
+    ++ T.unpack formatter
+    ++ ")\", expected 3, got "
+    ++ show (length args)
 -- ---------------------------------------------------------------------
 
 fromAction :: CAResult -> CodeAction

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -9,6 +9,7 @@ import           Control.Monad.IO.Class
 import           Data.Aeson
 import           Data.Default
 import qualified Data.HashMap.Strict as HM
+import qualified Data.Set as Set
 import           Data.Maybe
 import           Data.Monoid ((<>))
 import qualified Data.Text as T
@@ -546,7 +547,7 @@ hsImportSpec formatterName [e1, e2, e3] =
       executeAllCodeActions doc wantedCodeActionTitles
 
       contents <- documentContents doc
-      liftIO $ T.lines contents `shouldBe` e3
+      liftIO $ Set.fromList (T.lines contents) `shouldBe` Set.fromList e3
 
     it "respects format config, multiple import-list" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "CodeActionImportList.hs" "haskell"
@@ -561,18 +562,18 @@ hsImportSpec formatterName [e1, e2, e3] =
                                    ]
 
       executeAllCodeActions doc wantedCodeActionTitles
-
       contents <- documentContents doc
-      liftIO $ T.lines contents `shouldBe`
-        [ "import System.IO (stdout, hPutStrLn)"
-        , "import Control.Monad (when)"
-        , "import Data.Maybe (fromMaybe)"
-        , "main :: IO ()"
-        , "main ="
-        , "    when True"
-        , "        $ hPutStrLn stdout"
-        , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
-        ]
+      liftIO $ Set.fromList (T.lines contents) `shouldBe`
+        Set.fromList
+          [ "import System.IO (stdout, hPutStrLn)"
+          , "import Control.Monad (when)"
+          , "import Data.Maybe (fromMaybe)"
+          , "main :: IO ()"
+          , "main ="
+          , "    when True"
+          , "        $ hPutStrLn stdout"
+          , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
+          ]
     it "respects format config" $ runSession hieCommand fullCaps "test/testdata" $ do
       doc <- openDoc "CodeActionImportBrittany.hs" "haskell"
       _ <- waitForDiagnosticsSource "ghcmod"

--- a/test/testdata/CodeActionImportList.hs
+++ b/test/testdata/CodeActionImportList.hs
@@ -1,0 +1,5 @@
+main :: IO ()
+main =
+    when True
+        $ hPutStrLn stdout
+        $ fromMaybe "Good night, World!" (Just "Hello, World!")


### PR DESCRIPTION
Closes #1086 

Offers code action to add a function to import list.
E.g. 
```haskell
foo = hPutStrLn stderr "Hello"
```
With 2 code actions this can be turned into:
```haskell
import System.IO (hPutStrLn, stderr)
foo = hPutStrLn stderr "Hello"
```

Requires:

* [x] Tests
* [x] Code cleanup
* [x] Documenation

