### PR TITLE
Use LSP MarkupContent for generated documentation

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,4 +8,3 @@ packages:
          ./submodules/floskell
          ./submodules/ghc-mod/
          ./submodules/ghc-mod/core/
-         ./submodules/lsp-test

--- a/cabal.project
+++ b/cabal.project
@@ -8,3 +8,4 @@ packages:
          ./submodules/floskell
          ./submodules/ghc-mod/
          ./submodules/ghc-mod/core/
+         ./submodules/lsp-test

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -70,8 +70,8 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp >= 0.8.2
-                     , haskell-lsp-types >= 0.8.2
+                     , haskell-lsp == 0.9.*
+                     , haskell-lsp-types == 0.9.*
                      , haskell-src-exts
                      , hie-plugin-api
                      , hlint >= 2.0.11
@@ -275,7 +275,7 @@ test-suite func-test
                      , data-default
                      , directory
                      , filepath
-                     , lsp-test == 0.5.*
+                     , lsp-test >= 0.5.1.1 && < 0.5.2
                      , haskell-ide-engine
                      , haskell-lsp-types >= 0.4
                      , hie-test-utils

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -41,7 +41,7 @@ library
                      , free
                      , ghc
                      , ghc-mod-core >= 5.9.0.0
-                     , haskell-lsp >= 0.8
+                     , haskell-lsp == 0.9.*
                      , hslogger
                      , monad-control
                      , mtl

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -594,17 +594,17 @@ hoverProvider doc pos = runIdeResultT $ do
         ((r,typ):_) ->
           case find ((r ==) . fst) names of
             Nothing ->
-              (Just $ LSP.CodeString $ LSP.LanguageString "haskell" $ "_ :: " <> typ, Just r)
+              (Just $ LSP.markedUpContent "haskell" $ "_ :: " <> typ, Just r)
             Just (_,name)
               | nnames == 1 ->
-                (Just $ LSP.CodeString $ LSP.LanguageString "haskell" $ Hie.showName name <> " :: " <> typ, Just r)
+                (Just $ LSP.markedUpContent "haskell" $ Hie.showName name <> " :: " <> typ, Just r)
               | otherwise ->
-                (Just $ LSP.CodeString $ LSP.LanguageString "haskell" $ "_ :: " <> typ, Just r)
+                (Just $ LSP.markedUpContent "haskell" $ "_ :: " <> typ, Just r)
         [] -> case names of
           [] -> (Nothing, Nothing)
           ((r,_):_) -> (Nothing, Just r)
   return $ case mrange of
-    Just r -> [LSP.Hover (LSP.List $ catMaybes [info]) (Just r)]
+    Just r -> [LSP.Hover (LSP.HoverContents $ mconcat $ catMaybes [info]) (Just r)]
     Nothing -> []
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Plugin/Haddock.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Haddock.hs
@@ -223,7 +223,7 @@ hoverProvider doc pos = pluginGetFile "haddock:hoverProvider" doc $ \fp ->
           return $ case mdocu of
             Nothing -> mname <> minfo
             Just docu -> docu <> "\n\n" <> minfo
-    return [J.Hover (J.List $ fmap J.PlainString docs) Nothing]
+    return [J.Hover (J.HoverContents $ J.MarkupContent J.MkMarkdown (T.intercalate J.sectionSeparator docs)) Nothing]
   where
     pickName [] = Nothing
     pickName [x] = Just x

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -60,12 +60,12 @@ instance ExtensionClass HoogleDb where
 -- | Initialise the Hoogle Database.
 -- Search for the Hoogle Database and set it in the global config if found.
 -- Looks first into custom hoogle database locations, then in the default location.
--- Note, that the FilePath must be an absolute path, otherwise Hoogle can not 
+-- Note, that the FilePath must be an absolute path, otherwise Hoogle can not
 -- find the database.
--- 
+--
 -- If no hoogle database has been found, Nothing is returned
 -- and we will have no access to the hoogle database.
--- However, it is still safe to use the hoogle API, 
+-- However, it is still safe to use the hoogle API,
 -- e.g. either error or default values are returned.
 initializeHoogleDb :: IdeGhcM (Maybe FilePath)
 initializeHoogleDb = do
@@ -100,9 +100,9 @@ infoCmd' expr = do
 -- If documentation can be found for it, the result will be rendered
 -- in markdown for the lsp-client. If multiple results have been found,
 -- only the first result will be shown.
--- 
--- If no result can be found for the identifier, a hoogle error is returned 
--- that can be shown to the client by converting it 
+--
+-- If no result can be found for the identifier, a hoogle error is returned
+-- that can be shown to the client by converting it
 -- to an IdeError with 'hoogleErrorToIdeError'.
 infoCmdFancyRender :: T.Text -> IdeM (Either HoogleError T.Text)
 infoCmdFancyRender expr = do
@@ -116,7 +116,8 @@ infoCmdFancyRender expr = do
 -- | Render the target in valid markdown.
 -- Transform haddock documentation into markdown.
 renderTarget :: Target -> T.Text
-renderTarget t = T.intercalate "\n\n" $
+-- renderTarget t = T.intercalate "\n\n" $
+renderTarget t = T.intercalate "\n" $
      ["```haskell\n" <> unHTML (T.pack $ targetItem t) <> "```"]
   ++ [T.pack $ unwords mdl | not $ null mdl]
   ++ [renderDocs $ targetDocs t]
@@ -154,8 +155,8 @@ searchPackages :: T.Text -> IdeM [T.Text]
 searchPackages = fmap (nub . take 5) . searchTargets (fmap (T.pack . fst) . targetPackage)
 
 -- | Search for Targets that fit to the given Text and satisfy the given predicate.
--- Limits the amount of matches to at most ten. 
--- Applies the predicate to the first ten matches. May also return zero matches, 
+-- Limits the amount of matches to at most ten.
+-- Applies the predicate to the first ten matches. May also return zero matches,
 -- although there are matches, if none of the first ten matches
 -- satisfies the predicate.
 --
@@ -192,7 +193,7 @@ lookupCmd' n term = do
 
 ------------------------------------------------------------------------
 
--- | Run a query for Hoogle on the given Hoogle database. 
+-- | Run a query for Hoogle on the given Hoogle database.
 -- If no Database is given, no search is executed.
 -- If the Database cannot be found at the given location, an IOException will be thrown.
 -- Note, that the database file must be an absolute path.
@@ -201,15 +202,15 @@ lookupCmd' n term = do
 -- Found targets can be consumed with the given callback function.
 -- You can limit the amount of results, by taking only the first ten results.
 -- Example call:
--- 
--- @ 
---   runHoogleQuery 
---    (Just "/home/user/.hoogle/default-haskell-5.0.17.hoo") 
---    (Data.Text.pack "take :: Int -> [a] -> [a]") 
+--
+-- @
+--   runHoogleQuery
+--    (Just "/home/user/.hoogle/default-haskell-5.0.17.hoo")
+--    (Data.Text.pack "take :: Int -> [a] -> [a]")
 --    (Right . Prelude.take 10)
 -- @
 -- This limits the results to ten and looks for a function `take` that has the given signature.
--- 
+--
 -- HoogleError's can be translated to IdeErrors with @hoogleErrorToIdeError@
 -- and shown to the client.
 runHoogleQuery :: Maybe FilePath -> T.Text -> ([Target] -> Either HoogleError a) -> IO (Either HoogleError a)
@@ -219,7 +220,7 @@ runHoogleQuery (Just db) quer f = do
   return (f res)
 
 
--- | Run a query for Hoogle on the given Hoogle database. 
+-- | Run a query for Hoogle on the given Hoogle database.
 -- If the database can not be found, an IOException is thrown.
 -- The target may be of the form: `take`, `take :: Int -> [a] -> [a]`
 searchHoogle :: FilePath -> T.Text -> IO [Target]

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -258,8 +258,8 @@ hoverProvider uri pos =
                 ls    = getThingsAtPos info pos perrs
             hs <- forM ls $ \(r,LE _s _e msg) -> do
               let msgs = T.splitOn "\\n" msg
-                  msg' = J.CodeString (J.LanguageString "haskell" (T.unlines msgs))
-              return $ J.Hover (J.List [msg']) (Just r)
+                  msgm = J.markedUpContent "haskell" (T.unlines msgs)
+              return $ J.Hover (J.HoverContents msgm) (Just r)
             return (IdeResultOk hs)
 
 -- ---------------------------------------------------------------------

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -553,9 +553,9 @@ reactor inp diagIn = do
                 -- TODO: maybe only have provider give MarkedString and
                 -- work out range here?
                 let hs = concat hhs
-                    h = case (fold (map (^. J.contents) hs) :: List J.MarkedString) of
-                      List [] -> Nothing
-                      hh -> Just $ J.Hover hh r
+                    h = case mconcat ((map (^. J.contents) hs) :: [J.HoverContents]) of
+                      J.HoverContentsMS (List []) -> Nothing
+                      hh                          -> Just $ J.Hover hh r
                     r = listToMaybe $ mapMaybe (^. J.range) hs
                 in reactorSend $ RspHover $ Core.makeResponseMessage req h
 

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -4,12 +4,12 @@ packages:
 - hie-plugin-api
 
 extra-deps:
-- ./submodules/brittany
 - ./submodules/HaRe
-- ./submodules/ghc-mod
-- ./submodules/ghc-mod/core
+- ./submodules/brittany
 - ./submodules/cabal-helper
 - ./submodules/floskell
+- ./submodules/ghc-mod
+- ./submodules/ghc-mod/core
 
 # - brittany-0.11.0.0
 - butcher-1.3.1.1
@@ -19,11 +19,11 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - hlint-2.0.11
 - hsimport-0.8.6
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - mtl-2.2.2
 - pretty-show-1.8.2

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -4,12 +4,12 @@ packages:
 - hie-plugin-api
 
 extra-deps:
-- ./submodules/brittany
 - ./submodules/HaRe
-- ./submodules/ghc-mod
-- ./submodules/ghc-mod/core
+- ./submodules/brittany
 - ./submodules/cabal-helper
 - ./submodules/floskell
+- ./submodules/ghc-mod
+- ./submodules/ghc-mod/core
 
 # - brittany-0.11.0.0
 - butcher-1.3.1.1
@@ -20,14 +20,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - sorted-list-0.2.1.0

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -4,12 +4,12 @@ packages:
 - hie-plugin-api
 
 extra-deps:
-- ./submodules/brittany
 - ./submodules/HaRe
-- ./submodules/ghc-mod
-- ./submodules/ghc-mod/core
+- ./submodules/brittany
 - ./submodules/cabal-helper
 - ./submodules/floskell
+- ./submodules/ghc-mod
+- ./submodules/ghc-mod/core
 
 # - brittany-0.11.0.0
 - base-compat-0.9.3
@@ -18,14 +18,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - syz-0.2.0.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -4,12 +4,12 @@ packages:
 - hie-plugin-api
 
 extra-deps:
-- ./submodules/brittany
 - ./submodules/HaRe
-- ./submodules/ghc-mod
-- ./submodules/ghc-mod/core
+- ./submodules/brittany
 - ./submodules/cabal-helper
 - ./submodules/floskell
+- ./submodules/ghc-mod
+- ./submodules/ghc-mod/core
 
 - base-compat-0.9.3
 - cabal-plan-0.3.0.0
@@ -17,14 +17,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - syz-0.2.0.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -4,12 +4,12 @@ packages:
 - hie-plugin-api
 
 extra-deps:
-- ./submodules/brittany
 - ./submodules/HaRe
-- ./submodules/ghc-mod
-- ./submodules/ghc-mod/core
+- ./submodules/brittany
 - ./submodules/cabal-helper
 - ./submodules/floskell
+- ./submodules/ghc-mod
+- ./submodules/ghc-mod/core
 
 # - brittany-0.11.0.0
 - cabal-plan-0.4.0.0
@@ -17,14 +17,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - optparse-simple-0.1.0
 - pretty-show-1.9.5

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -7,9 +7,9 @@ extra-deps:
 - ./submodules/HaRe
 - ./submodules/brittany
 - ./submodules/cabal-helper
+- ./submodules/floskell
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
-- ./submodules/floskell
 
 - apply-refact-0.6.0.0
 - butcher-1.3.2.1
@@ -19,14 +19,14 @@ extra-deps:
 - czipwith-1.0.1.1
 - data-tree-print-0.1.0.2
 - haddock-api-2.21.0
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - monoid-subclasses-0.4.6.1

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -7,22 +7,22 @@ extra-deps:
 - ./submodules/HaRe
 - ./submodules/brittany
 - ./submodules/cabal-helper
+- ./submodules/floskell
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
-- ./submodules/floskell
 
 - butcher-1.3.2.1
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.21.0
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -7,22 +7,22 @@ extra-deps:
 - ./submodules/HaRe
 - ./submodules/brittany
 - ./submodules/cabal-helper
+- ./submodules/floskell
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
-- ./submodules/floskell
 
 - butcher-1.3.2.1
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.21.0
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -7,22 +7,22 @@ extra-deps:
 - ./submodules/HaRe
 - ./submodules/brittany
 - ./submodules/cabal-helper
+- ./submodules/floskell
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
-- ./submodules/floskell
 
 - butcher-1.3.2.1
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
 - haddock-api-2.22.0
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,9 +7,9 @@ extra-deps:
 - ./submodules/HaRe
 - ./submodules/brittany
 - ./submodules/cabal-helper
+- ./submodules/floskell
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
-- ./submodules/floskell
 
 - ansi-terminal-0.8.2
 - butcher-1.3.2.1
@@ -18,12 +18,12 @@ extra-deps:
 - deque-0.2.7
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.22.0
-- haskell-lsp-0.8.2.0
-- haskell-lsp-types-0.8.2.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.16
 - hsimport-0.8.8
-- lsp-test-0.5.1.0
+- lsp-test-0.5.1.1
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/test/functional/DeferredSpec.hs
+++ b/test/functional/DeferredSpec.hs
@@ -29,7 +29,7 @@ spec = do
 
       skipMany anyNotification
       hoverRsp <- message :: Session HoverResponse
-      liftIO $ hoverRsp ^? result . _Just . _Just . contents `shouldBe` Nothing
+      liftIO $ hoverRsp ^? result . _Just . _Just . contents `shouldBe` (Just HoverContentsEmpty)
       liftIO $ hoverRsp ^. LSP.id `shouldBe` responseId id1
 
       id2 <- sendRequest TextDocumentDocumentSymbol (DocumentSymbolParams doc)
@@ -40,7 +40,7 @@ spec = do
       hoverRsp2 <- skipManyTill anyNotification message :: Session HoverResponse
       liftIO $ hoverRsp2 ^. LSP.id `shouldBe` responseId id3
 
-      let (Just (List contents2)) = hoverRsp2 ^? result . _Just . _Just . contents
+      let contents2 = hoverRsp2 ^? result . _Just . _Just . contents
       liftIO $ contents2 `shouldNotSatisfy` null
 
       -- Now that we have cache the following request should be instant

--- a/test/functional/HoverSpec.hs
+++ b/test/functional/HoverSpec.hs
@@ -19,12 +19,16 @@ spec = describe "hover" $
     Just h <- getHover doc (Position 1 19)
     liftIO $ do
       h ^. range `shouldBe` Just (Range (Position 1 16) (Position 1 19))
-      let hasType (CodeString (LanguageString "haskell" "sum :: [Int] -> Int")) = True
+      let
+          hasType (HoverContents (MarkupContent MkMarkdown s))
+            = "```haskell\nsum :: [Int] -> Int\n```" `T.isPrefixOf`s
           hasType _ = False
 
           sumDoc = "The `sum` function computes the sum of the numbers of a structure."
 
-          hasDoc (PlainString s) = sumDoc `T.isInfixOf` s
+          hasDoc (HoverContents (MarkupContent MkMarkdown s))
+            = sumDoc `T.isInfixOf` s
           hasDoc _               = False
-      h ^. contents `shouldSatisfy` any hasType
-      h ^. contents `shouldSatisfy` any hasDoc
+
+      h ^. contents `shouldSatisfy` hasType
+      h ^. contents `shouldSatisfy` hasDoc


### PR DESCRIPTION
The affects the `HoverReply` message.

All documentation is now returned in markdown, and it renders much better in `emacs-lsp`.