### PR TITLE
remove installation of Cabal by cabal

### DIFF
--- a/install.hs
+++ b/install.hs
@@ -248,8 +248,6 @@ installCabal = do
   when (isNothing cabalExe) $
     execStackShake_ ["install", "cabal-install"]
   execCabal_ ["update"]
-  ghc <- getStackGhcPathShake
-  execCabal_ ["install", "Cabal-2.4.1.0", "--with-compiler=" ++ ghc]
 
 
 checkStack :: Action ()


### PR DESCRIPTION
The `install.hs` calls `cabal install Cabal-X`. This command was copied from the `Makefile` several months ago.

I have done exhaustive tests on different machies (linux only) and have not seen any effect of this line and `hie` works even without this command. This PR removes this command from the installation process.

Comments on this change and tests on MacOS and Windows are welcome!