### PR TITLE
Typemap reimplementation

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
@@ -10,7 +10,6 @@ import           GHC                               (TypecheckedModule)
 import qualified SrcLoc                            as GHC
 import qualified Var
 import qualified GhcMod.Gap                        as GM
-import           GhcMod.SrcUtils
 
 import           Language.Haskell.LSP.Types
 
@@ -32,15 +31,6 @@ genIntervalMap ts = foldr go IM.empty ts
     go (l,h,x) im = IM.insert (IM.Interval l h) x im
 
 -- ---------------------------------------------------------------------
-
-genTypeMap :: GHC.GhcMonad m => TypecheckedModule -> m TypeMap
-genTypeMap tm = do
-    ts <- collectAllSpansTypes True tm
-    return $ foldr go IM.empty ts
-  where
-    go (GHC.RealSrcSpan spn, typ) im =
-      IM.insert (rspToInt spn) typ im
-    go _ im = im
 
 -- | Generates a LocMap from a TypecheckedModule,
 -- which allows fast queries for all the symbols

--- a/hie-plugin-api/Haskell/Ide/Engine/Compat.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Compat.hs
@@ -7,6 +7,7 @@ import qualified GHC
 import qualified Type
 import qualified TcHsSyn
 import qualified TysWiredIn
+import qualified Var
 
 #if MIN_VERSION_filepath(1,4,2)
 #else
@@ -122,6 +123,17 @@ pattern HsMultiIfType t <-
 #else
     GHC.HsMultiIf t _
 #endif
+
+pattern FunBindType :: Type.Type -> GHC.HsBindLR GhcTc GhcTc
+pattern FunBindType t <-
+#if MIN_VERSION_ghc(8, 6, 0)
+    GHC.FunBind _ (GHC.L _ (Var.varType -> t)) _ _ _
+#elif MIN_VERSION_ghc(8, 4, 0)
+    GHC.FunBind (GHC.L _ (Var.varType -> t)) _ _ _ _
+#else
+    GHC.FunBind (GHC.L _ (Var.varType -> t)) _ _ _ _
+#endif
+
 
 #if MIN_VERSION_ghc(8, 6, 0)
 matchGroupType :: GHC.MatchGroupTc -> GHC.Type

--- a/hie-plugin-api/Haskell/Ide/Engine/Compat.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Compat.hs
@@ -1,5 +1,13 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
 module Haskell.Ide.Engine.Compat where
+
+
+import qualified GHC
+import qualified Type
+import qualified TcHsSyn
+import qualified TysWiredIn
 
 #if MIN_VERSION_filepath(1,4,2)
 #else
@@ -26,4 +34,36 @@ getProcessID = fromIntegral <$> P.getProcessID
 isExtensionOf :: String -> FilePath -> Bool
 isExtensionOf ext@('.':_) = isSuffixOf ext . takeExtensions
 isExtensionOf ext         = isSuffixOf ('.':ext) . takeExtensions
+#endif
+
+
+#if MIN_VERSION_ghc(8, 6, 0)
+
+pattern HsOverLitType :: Type.Type -> GHC.HsExpr GHC.GhcTc
+pattern HsOverLitType t <- GHC.HsOverLit _ (GHC.overLitType -> t)
+
+pattern HsLitType :: Type.Type -> GHC.HsExpr GHC.GhcTc
+pattern HsLitType t <- GHC.HsLit     _ (TcHsSyn.hsLitType -> t)
+
+pattern HsLamType :: Type.Type -> GHC.HsExpr GHC.GhcTc
+pattern HsLamType t <- GHC.HsLam _ ((\(GHC.MG { GHC.mg_ext = groupTy }) -> matchGroupType groupTy) -> t)
+
+pattern HsLamCaseType :: Type.Type -> GHC.HsExpr GHC.GhcTc
+pattern HsLamCaseType t <- GHC.HsLamCase _ ((\(GHC.MG { GHC.mg_ext = groupTy }) -> matchGroupType groupTy) -> t)
+
+pattern HsCaseType :: Type.Type -> GHC.HsExpr GHC.GhcTc
+pattern HsCaseType t <- GHC.HsCase _ _ ((\(GHC.MG { GHC.mg_ext = groupTy }) -> matchGroupType groupTy) -> t)
+
+pattern ExplicitListType :: Type.Type -> GHC.HsExpr GHC.GhcTc
+pattern ExplicitListType t <- GHC.ExplicitList (TysWiredIn.mkListTy -> t) _ _
+
+pattern ExplicitSumType :: Type.Type -> GHC.HsExpr GHC.GhcTc
+pattern ExplicitSumType t <- GHC.ExplicitSum (TysWiredIn.mkSumTy -> t) _ _ _
+
+pattern HsMultiIfType :: Type.Type -> GHC.HsExpr GHC.GhcTc
+pattern HsMultiIfType t <- GHC.HsMultiIf t _
+
+matchGroupType :: GHC.MatchGroupTc -> GHC.Type
+matchGroupType (GHC.MatchGroupTc args res) = Type.mkFunTys args res
+
 #endif

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -42,6 +42,7 @@ import qualified GhcMod.Utils  as GM
 import qualified GHC           as GHC
 
 import           Haskell.Ide.Engine.ArtifactMap
+import           Haskell.Ide.Engine.TypeMap
 import           Haskell.Ide.Engine.GhcModuleCache
 import           Haskell.Ide.Engine.MultiThreadState
 import           Haskell.Ide.Engine.PluginsIdeMonads

--- a/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
@@ -57,7 +57,7 @@ everythingInTypecheckedSourceM
   => (forall a . Data a => a -> IO TypeMap)
   -> x
   -> IO TypeMap
-everythingInTypecheckedSourceM f = everythingButTypeM @GHC.Name f
+everythingInTypecheckedSourceM f = everythingButTypeM @GHC.Id f
 
 -- | Combine two queries into one using alternative combinator.
 combineM

--- a/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
@@ -113,7 +113,7 @@ everythingButM f x = do
 --
 -- See #16233<https://gitlab.haskell.org/ghc/ghc/issues/16233>
 getType
-  :: GHC.HscEnv -> GHC.LHsExpr GHC.GhcTc -> IO (Maybe (GHC.SrcSpan, Type.Type))
+  :: GHC.HscEnv -> GHC.LHsExpr GhcTc -> IO (Maybe (GHC.SrcSpan, Type.Type))
 getType hs_env e@(GHC.L spn e') =
   -- Some expression forms have their type immediately available
   let

--- a/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
@@ -97,19 +97,11 @@ everythingButM f x = do
       (everythingButM f)
       x
 
--- | This instance tries to construct 'HieAST' nodes which include the type of
--- the expression. It is not yet possible to do this efficiently for all
--- expression forms, so we skip filling in the type for those inputs.
+-- | Attempts to get the type for expressions in a lazy and cost saving way.
+-- Avoids costly desugaring of Expressions and only obtains the type at the leaf of an expression.
 --
--- 'HsApp', for example, doesn't have any type information available directly on
--- the node. Our next recourse would be to desugar it into a 'CoreExpr' then
--- query the type of that. Yet both the desugaring call and the type query both
--- involve recursive calls to the function and argument! This is particularly
--- problematic when you realize that the HIE traversal will eventually visit
--- those nodes too and ask for their types again.
---
--- Since the above is quite costly, we just skip cases where computing the
--- expression's type is going to be expensive.
+-- Implementation is taken from: HieAst.hs<https://gitlab.haskell.org/ghc/ghc/blob/1f5cc9dc8aeeafa439d6d12c3c4565ada524b926/compiler/hieFile/HieAst.hs>
+-- Slightly adapted to work for the supported GHC versions 8.2.1 - 8.6.4
 --
 -- See #16233<https://gitlab.haskell.org/ghc/ghc/issues/16233>
 getType

--- a/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE LambdaCase #-}
+module Haskell.Ide.Engine.TypeMap where
+
+import qualified Data.IntervalMap.FingerTree   as IM
+
+import qualified GHC
+import           GHC                            ( TypecheckedModule )
+import           GhcMod.SrcUtils
+
+import           Data.Data                     as Data
+import           Control.Monad.IO.Class
+import           Data.Maybe
+import qualified TcHsSyn
+import qualified TysWiredIn
+import qualified CoreUtils
+import qualified Type
+import qualified Desugar
+
+import           Haskell.Ide.Engine.ArtifactMap
+
+genTypeMap :: GHC.GhcMonad m => TypecheckedModule -> m TypeMap
+genTypeMap tm = do
+  let typecheckedSource = GHC.tm_typechecked_source tm
+  hs_env      <- GHC.getSession
+  liftIO $ types hs_env typecheckedSource
+
+collectAllSpansTypes'
+  :: GHC.GhcMonad m => Bool -> TypecheckedModule -> m [(GHC.SrcSpan, GHC.Type)]
+collectAllSpansTypes' = collectAllSpansTypes
+
+-- | Obtain details map for types.
+types :: GHC.HscEnv -> GHC.TypecheckedSource -> IO TypeMap
+types hs_env = everythingInTypecheckedSourceM (ty `combineM` fun)
+ where
+  ty :: forall a . Data a => a -> IO TypeMap
+  ty term = case cast term of
+    (Just lhsExprGhc@(GHC.L (GHC.RealSrcSpan spn) _)) ->
+      getType hs_env lhsExprGhc >>= \case 
+        Nothing -> return IM.empty
+        Just (_, typ) -> return (IM.singleton (rspToInt spn) typ)
+    _ -> return IM.empty
+
+  fun :: forall a . Data a => a -> IO TypeMap
+  fun term = case cast term of
+    (Just (GHC.L (GHC.RealSrcSpan spn) hsPatType)) ->
+      return (IM.singleton (rspToInt spn) (TcHsSyn.hsPatType hsPatType))
+    _ -> return IM.empty
+
+
+everythingInTypecheckedSourceM
+  :: Data x
+  => (forall a . Data a => a -> IO TypeMap)
+  -> x
+  -> IO TypeMap
+everythingInTypecheckedSourceM f = everythingButTypeM @GHC.Name f
+
+-- | Combine two queries into one using alternative combinator.
+combineM
+  :: (forall a. Data a => a -> IO TypeMap)
+  -> (forall a. Data a => a -> IO TypeMap)
+  -> (forall a. Data a => a -> IO TypeMap)
+combineM f g x = do 
+  a <- f x
+  b <- g x
+  return (a `IM.union` b)
+
+-- | Variation of "everything" that does not recurse into children of type t
+-- requires AllowAmbiguousTypes
+everythingButTypeM
+  :: forall t
+   . (Typeable t)
+  => (forall a . Data a => a -> IO TypeMap)
+  -> (forall a . Data a => a -> IO TypeMap)
+everythingButTypeM f = everythingButM $ (,) <$> f <*> isType @t
+
+-- | Returns true if a == t.
+-- requires AllowAmbiguousTypes
+isType :: forall a b . (Typeable a, Typeable b) => b -> Bool
+isType _ = isJust $ eqT @a @b
+
+-- | Variation of "everything" with an added stop condition
+-- Just like 'everything', this is stolen from SYB package.
+everythingButM
+  :: (forall a . Data a => a -> (IO TypeMap, Bool))
+  -> (forall a . Data a => a -> IO TypeMap)
+everythingButM f x = do
+  let (v, stop) = f x
+  if stop
+    then v
+    else Data.gmapQr
+      (\e acc -> do
+        e' <- e
+        a  <- acc
+        return (e' `IM.union` a)
+      )
+      v
+      (everythingButM f)
+      x
+
+-- | This instance tries to construct 'HieAST' nodes which include the type of
+-- the expression. It is not yet possible to do this efficiently for all
+-- expression forms, so we skip filling in the type for those inputs.
+--
+-- 'HsApp', for example, doesn't have any type information available directly on
+-- the node. Our next recourse would be to desugar it into a 'CoreExpr' then
+-- query the type of that. Yet both the desugaring call and the type query both
+-- involve recursive calls to the function and argument! This is particularly
+-- problematic when you realize that the HIE traversal will eventually visit
+-- those nodes too and ask for their types again.
+--
+-- Since the above is quite costly, we just skip cases where computing the
+-- expression's type is going to be expensive.
+--
+-- See #16233
+getType
+  :: GHC.HscEnv -> GHC.LHsExpr GHC.GhcTc -> IO (Maybe (GHC.SrcSpan, Type.Type))
+getType hs_env e@(GHC.L spn e') =
+  -- Some expression forms have their type immediately available
+  let
+    tyOpt = case e' of
+      GHC.HsLit     _ l -> Just (TcHsSyn.hsLitType l)
+      GHC.HsOverLit _ o -> Just (GHC.overLitType o)
+
+      GHC.HsLam _ GHC.MG { GHC.mg_ext = groupTy } ->
+        Just (matchGroupType groupTy)
+      GHC.HsLamCase _ GHC.MG { GHC.mg_ext = groupTy } ->
+        Just (matchGroupType groupTy)
+      GHC.HsCase _ _ GHC.MG { GHC.mg_ext = groupTy } ->
+        Just (GHC.mg_res_ty groupTy)
+
+      GHC.ExplicitList ty _ _  -> Just (TysWiredIn.mkListTy ty)
+      GHC.ExplicitSum ty _ _ _ -> Just (TysWiredIn.mkSumTy ty)
+      GHC.HsDo ty _ _          -> Just ty
+      GHC.HsMultiIf ty _       -> Just ty
+
+      _                        -> Nothing
+  in  case tyOpt of
+        _
+          | skipDesugaring e' -> pure Nothing
+          | otherwise -> do
+            (_, mbe) <- Desugar.deSugarExpr hs_env e
+            let res = (spn, ) . CoreUtils.exprType <$> mbe
+            pure res
+ where
+  matchGroupType :: GHC.MatchGroupTc -> GHC.Type
+  matchGroupType (GHC.MatchGroupTc args res) = Type.mkFunTys args res
+  -- | Skip desugaring of these expressions for performance reasons.
+  --
+  -- See impact on Haddock output (esp. missing type annotations or links)
+  -- before marking more things here as 'False'. See impact on Haddock
+  -- performance before marking more things as 'True'.
+  skipDesugaring :: GHC.HsExpr a -> Bool
+  skipDesugaring expression = case expression of
+    GHC.HsVar{}        -> False
+    GHC.HsUnboundVar{} -> False
+    GHC.HsConLikeOut{} -> False
+    GHC.HsRecFld{}     -> False
+    GHC.HsOverLabel{}  -> False
+    GHC.HsIPVar{}      -> False
+    GHC.HsWrap{}       -> False
+    _                  -> True

--- a/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
@@ -121,7 +121,8 @@ getType hs_env e@(GHC.L spn e') =
 
       _                        -> Nothing
   in  case tyOpt of
-        _
+        Just t -> return $ Just (spn ,t)
+        Nothing
           | skipDesugaring e' -> pure Nothing
           | otherwise -> do
             (_, mbe) <- Desugar.deSugarExpr hs_env e

--- a/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
@@ -18,7 +18,6 @@ import qualified TcHsSyn
 import qualified CoreUtils
 import qualified Type
 import qualified Desugar
-import qualified Var
 import           Haskell.Ide.Engine.Compat
 
 import           Haskell.Ide.Engine.ArtifactMap
@@ -57,8 +56,8 @@ types hs_env = everythingInTypecheckedSourceM (ty `combineM` fun `combineM` funB
 
   funBind :: forall a . Data a => a -> IO TypeMap
   funBind term = case cast term of
-    (Just (GHC.L (GHC.RealSrcSpan spn) ((GHC.FunBind _ (GHC.L _ (idp :: GHC.IdP GhcTc)) _ _ _) :: GHC.HsBindLR GhcTc GhcTc))) ->
-      return (IM.singleton (rspToInt spn) (Var.varType idp))
+    (Just (GHC.L (GHC.RealSrcSpan spn) (FunBindType t))) ->
+      return (IM.singleton (rspToInt spn) t)
     _ -> return IM.empty
 
 -- | Combine two queries into one using alternative combinator.

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -29,6 +29,7 @@ library
                        Haskell.Ide.Engine.MultiThreadState
                        Haskell.Ide.Engine.PluginsIdeMonads
                        Haskell.Ide.Engine.PluginUtils
+                       Haskell.Ide.Engine.TypeMap
   build-depends:       base >= 4.9 && < 5
                      , Diff
                      , aeson

--- a/test/testdata/Types.hs
+++ b/test/testdata/Types.hs
@@ -1,0 +1,28 @@
+module Types where
+
+import Control.Applicative
+
+foo :: Maybe Int -> Int
+foo (Just x) = x
+foo Nothing = 0
+
+bar :: Maybe Int -> Int
+bar x = case x of
+    Just y -> y + 1
+    Nothing -> 0
+
+maybeMonad :: Maybe Int -> Maybe Int
+maybeMonad x = do
+    y <- x
+    let z = return (y + 10)
+    b <- z
+    return (b + y)
+
+funcTest :: (a -> a) -> a -> a
+funcTest f a = f a
+
+compTest :: (b -> c) -> (a -> b) -> a -> c
+compTest f g = let h = f . g in h
+
+monadStuff :: (a -> b) -> IO a -> IO b
+monadStuff f action = f <$> action

--- a/test/testdata/Types.hs
+++ b/test/testdata/Types.hs
@@ -26,3 +26,8 @@ compTest f g = let h = f . g in h
 
 monadStuff :: (a -> b) -> IO a -> IO b
 monadStuff f action = f <$> action
+
+data Test
+    = TestC Int
+    | TestM String
+    deriving (Show, Eq, Ord)

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -91,8 +91,6 @@ ghcmodSpec =
           arg = TP False uri (toPos (5,9))
           res = IdeResultOk
             [(Range (toPos (5,9)) (toPos (5,10)), "Int")
-            ,(Range (toPos (5,9)) (toPos (5,14)), "Int")
-            ,(Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
             ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -110,8 +108,6 @@ ghcmodSpec =
         let arg = TP False uri (toPos (5,9))
         let res = IdeResultOk
               [(Range (toPos (5,9)) (toPos (5,10)), "Int")
-              ,(Range (toPos (5,9)) (toPos (5,14)), "Int")
-              ,(Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
               ]
         testCommand testPlugins act "ghcmod" "type" arg res
 

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -80,7 +80,7 @@ ghcmodSpec =
       -- ghc-mod tries to load the test file in the context of the hie project if we do not cd first.
       testCommand testPlugins act "ghcmod" "info" arg res
 
-    -- ---------------------------------
+-- ----------------------------------------------------------------------------
 
     it "runs the type command, find type" $ withCurrentDirectory "./test/testdata" $ do
       fp <- makeAbsolute "HaReRename.hs"
@@ -90,8 +90,10 @@ ghcmodSpec =
             liftToGhc $ newTypeCmd (toPos (5,9)) uri
           arg = TP False uri (toPos (5,9))
           res = IdeResultOk
-            [(Range (toPos (5,9)) (toPos (5,10)), "Int")
+            [ (Range (toPos (5,9)) (toPos (5,10)), "Int")
+            , (Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
             ]
+
       testCommand testPlugins act "ghcmod" "type" arg res
     it "runs the type command, find function type" $ withCurrentDirectory "./test/testdata" $ do
       fp <- makeAbsolute "HaReRename.hs"
@@ -101,7 +103,8 @@ ghcmodSpec =
             liftToGhc $ newTypeCmd (toPos (2,11)) uri
           arg = TP False uri (toPos (2,11))
           res = IdeResultOk
-            [(Range (toPos (2, 8)) (toPos (2,16)), "String -> IO ()")
+            [ (Range (toPos (2, 8)) (toPos (2,16)), "String -> IO ()")
+            , (Range (toPos (2, 1)) (toPos (2,24)), "IO ()")
             ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -115,7 +118,6 @@ ghcmodSpec =
           res = IdeResultOk []
       testCommand testPlugins act "ghcmod" "type" arg res
 
--- ----------------------------------------------------------------------------
     it "runs the type command, simple" $ withCurrentDirectory "./test/testdata" $ do
       fp <- makeAbsolute "Types.hs"
       let uri = filePathToUri fp
@@ -125,6 +127,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (6,16))
           res = IdeResultOk
               [ (Range (toPos (6, 16)) (toPos (6,17)), "Int")
+              , (Range (toPos (6, 1)) (toPos (7, 16)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -138,7 +141,7 @@ ghcmodSpec =
           res = IdeResultOk
               [ (Range (toPos (6, 6)) (toPos (6, 12)), "Maybe Int")
               , (Range (toPos (6, 5)) (toPos (6, 13)), "Maybe Int")
-              -- TODO: why is this happening?
+              , (Range (toPos (6, 1)) (toPos (7, 16)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -153,7 +156,7 @@ ghcmodSpec =
             [ (Range (toPos (6, 11)) (toPos (6, 12)), "Int")
             , (Range (toPos (6, 6)) (toPos (6, 12)), "Maybe Int")
             , (Range (toPos (6, 5)) (toPos (6, 13)), "Maybe Int")
-            -- TODO: why is this happening?
+            , (Range (toPos (6, 1)) (toPos (7, 16)), "Maybe Int -> Int")
             ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -166,6 +169,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (7,5))
           res = IdeResultOk
               [ (Range (toPos (7, 5)) (toPos (7, 12)), "Maybe Int")
+              , (Range (toPos (6, 1)) (toPos (7, 16)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -178,6 +182,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (7,15))
           res = IdeResultOk
               [ (Range (toPos (7, 15)) (toPos (7, 16)), "Int")
+              , (Range (toPos (6, 1)) (toPos (7, 16)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -190,6 +195,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (10,5))
           res = IdeResultOk
               [ (Range (toPos (10, 5)) (toPos (10, 6)), "Maybe Int")
+              , (Range (toPos (10, 1)) (toPos (12, 17)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -203,6 +209,7 @@ ghcmodSpec =
           res = IdeResultOk
               [ (Range (toPos (10, 14)) (toPos (10, 15)), "Maybe Int")
               , (Range (toPos (10, 9)) (toPos (12, 17)), "Maybe Int -> Int")
+              , (Range (toPos (10, 1)) (toPos (12, 17)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -216,6 +223,7 @@ ghcmodSpec =
           res = IdeResultOk
               [ (Range (toPos (11, 5)) (toPos (11, 11)), "Maybe Int")
               , (Range (toPos (10, 9)) (toPos (12, 17)), "Maybe Int -> Int")
+              , (Range (toPos (10, 1)) (toPos (12, 17)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -230,6 +238,7 @@ ghcmodSpec =
               [ (Range (toPos (11, 10)) (toPos (11, 11)), "Int")
               , (Range (toPos (11, 5)) (toPos (11, 11)), "Maybe Int")
               , (Range (toPos (10, 9)) (toPos (12, 17)), "Maybe Int -> Int")
+              , (Range (toPos (10, 1)) (toPos (12, 17)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -243,6 +252,7 @@ ghcmodSpec =
           res = IdeResultOk
               [ (Range (toPos (11, 17)) (toPos (11, 18)), "Int -> Int -> Int")
               , (Range (toPos (10, 9)) (toPos (12, 17)), "Maybe Int -> Int")
+              , (Range (toPos (10, 1)) (toPos (12, 17)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -256,6 +266,7 @@ ghcmodSpec =
           res = IdeResultOk
               [ (Range (toPos (12, 5)) (toPos (12, 12)), "Maybe Int")
               , (Range (toPos (10, 9)) (toPos (12, 17)), "Maybe Int -> Int")
+              , (Range (toPos (10, 1)) (toPos (12, 17)), "Maybe Int -> Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -268,6 +279,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (16,5))
           res = IdeResultOk
               [ (Range (toPos (16, 5)) (toPos (16, 6)), "Int")
+              , (Range (toPos (15, 1)) (toPos (19, 19)), "Maybe Int -> Maybe Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -280,6 +292,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (16,10))
           res = IdeResultOk
               [ (Range (toPos (16, 10)) (toPos (16, 11)), "Maybe Int")
+              , (Range (toPos (15, 1)) (toPos (19, 19)), "Maybe Int -> Maybe Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -292,6 +305,8 @@ ghcmodSpec =
           arg = TP False uri (toPos (17,13))
           res = IdeResultOk
               [ (Range (toPos (17, 13)) (toPos (17, 19)), "Int -> Maybe Int")
+              , (Range (toPos (17, 9)) (toPos (17, 28)), "Maybe Int")
+              , (Range (toPos (15, 1)) (toPos (19, 19)), "Maybe Int -> Maybe Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -304,6 +319,8 @@ ghcmodSpec =
           arg = TP False uri (toPos (17,21))
           res = IdeResultOk
               [ (Range (toPos (17, 21)) (toPos (17, 22)), "Int")
+              , (Range (toPos (17, 9)) (toPos (17, 28)), "Maybe Int")
+              , (Range (toPos (15, 1)) (toPos (19, 19)), "Maybe Int -> Maybe Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -314,9 +331,10 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (17,9)) uri
           arg = TP False uri (toPos (17,9))
-          res = IdeResultOk []
-            -- TODO: do we want this?
-            -- (Range (toPos (17, 9)) (toPos (17, 10)), "Maybe Int")
+          res = IdeResultOk
+              [ (Range (toPos (17, 9)) (toPos (17, 28)), "Maybe Int")
+              , (Range (toPos (15, 1)) (toPos (19, 19)), "Maybe Int -> Maybe Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, do expr, function type" $ withCurrentDirectory "./test/testdata" $ do
@@ -328,6 +346,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (18,10))
           res = IdeResultOk
               [ (Range (toPos (18, 10)) (toPos (18, 11)), "Maybe Int")
+              , (Range (toPos (15, 1)) (toPos (19, 19)), "Maybe Int -> Maybe Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -340,6 +359,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (18,5))
           res = IdeResultOk
               [ (Range (toPos (18, 5)) (toPos (18, 6)), "Int")
+              , (Range (toPos (15, 1)) (toPos (19, 19)), "Maybe Int -> Maybe Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -350,20 +370,8 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (15,5)) uri
           arg = TP False uri (toPos (15,5))
-          res = IdeResultOk []
-            -- TODO: the type is known, why not in the map?
-            -- [(Range (toPos (15, 1)) (toPos (14, 11)), "Maybe Int -> Maybe Int")]
-      testCommand testPlugins act "ghcmod" "type" arg res
-
-    it "runs the type command, function parameter" $ withCurrentDirectory "./test/testdata" $ do
-      fp <- makeAbsolute "Types.hs"
-      let uri = filePathToUri fp
-          act = do
-            _ <- setTypecheckedModule uri
-            liftToGhc $ newTypeCmd (toPos (22,10)) uri
-          arg = TP False uri (toPos (22,10))
           res = IdeResultOk
-              [ (Range (toPos (22, 10)) (toPos (22, 11)), "a -> a")
+              [ (Range (toPos (15, 1)) (toPos (19, 19)), "Maybe Int -> Maybe Int")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -376,6 +384,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (22,10))
           res = IdeResultOk
               [ (Range (toPos (22, 10)) (toPos (22, 11)), "a -> a")
+              , (Range (toPos (22, 1)) (toPos (22, 19)), "(a -> a) -> a -> a")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -388,6 +397,8 @@ ghcmodSpec =
           arg = TP False uri (toPos (25,26))
           res = IdeResultOk
               [ (Range (toPos (25, 26)) (toPos (25, 27)), "(b -> c) -> (a -> b) -> a -> c")
+              , (Range (toPos (25, 20)) (toPos (25, 29)), "a -> c")
+              , (Range (toPos (25, 1)) (toPos (25, 34)), "(b -> c) -> (a -> b) -> a -> c")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -398,9 +409,10 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (25,20)) uri
           arg = TP False uri (toPos (25,20))
-          res = IdeResultOk []
-              -- TODO: do we want this?
-              --(Range (toPos (25, 20)) (toPos (25, 21)), "a -> c")
+          res = IdeResultOk
+              [ (Range (toPos (25, 20)) (toPos (25, 29)), "a -> c")
+              , (Range (toPos (25, 1)) (toPos (25, 34)), "(b -> c) -> (a -> b) -> a -> c")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, let binding, type of function" $ withCurrentDirectory "./test/testdata" $ do
@@ -412,6 +424,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (25,33))
           res = IdeResultOk
               [ (Range (toPos (25, 33)) (toPos (25, 34)), "a -> c")
+              , (Range (toPos (25, 1)) (toPos (25, 34)), "(b -> c) -> (a -> b) -> a -> c")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -422,9 +435,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (25,5)) uri
           arg = TP False uri (toPos (25,5))
-          res = IdeResultOk []
-            -- TODO: the type is known, why not in the map?
-            -- (Range (toPos (25, 1)) (toPos (25, 9)), "(b -> c) -> (a -> b) -> a -> c")
+          res = IdeResultOk
+              [ (Range (toPos (25, 1)) (toPos (25, 34)), "(b -> c) -> (a -> b) -> a -> c")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, infix operator" $ withCurrentDirectory "./test/testdata" $ do
@@ -436,6 +449,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (28,25))
           res = IdeResultOk
               [ (Range (toPos (28, 25)) (toPos (28, 28)), "(a -> b) -> IO a -> IO b")
+              , (Range (toPos (28, 1)) (toPos (28, 35)), "(a -> b) -> IO a -> IO b")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -463,6 +477,7 @@ ghcmodSpec =
               , (Range (toPos (33, 15)) (toPos (33, 19)), "Int -> Test -> ShowS")
               , (Range (toPos (33, 15)) (toPos (33, 19)), "Test -> String")
               , (Range (toPos (33, 15)) (toPos (33, 19)), "[Test] -> ShowS")
+              , (Range (toPos (33, 15)) (toPos (33, 19)), "Int -> Test -> ShowS")
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -475,6 +490,7 @@ ghcmodSpec =
           arg = TP False uri (toPos (33,21))
           res = IdeResultOk
               [ (Range (toPos (33, 21)) (toPos (33, 23)), "(Test -> Test -> Bool) -> (Test -> Test -> Bool) -> Eq Test")
+              , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
               ]
@@ -495,6 +511,7 @@ ghcmodSpec =
         let arg = TP False uri (toPos (5,9))
         let res = IdeResultOk
               [(Range (toPos (5,9)) (toPos (5,10)), "Int")
+              , (Range (toPos (5,1)) (toPos (5,14)), "Int -> Int")
               ]
         testCommand testPlugins act "ghcmod" "type" arg res
 

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -115,6 +115,292 @@ ghcmodSpec =
           res = IdeResultOk []
       testCommand testPlugins act "ghcmod" "type" arg res
 
+-- ----------------------------------------------------------------------------
+    it "runs the type command, simple" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (6,16)) uri
+          arg = TP False uri (toPos (6,16))
+          res = IdeResultOk [(Range (toPos (6, 16)) (toPos (6,17)), "Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, sum type pattern match, just" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (6,6)) uri
+          arg = TP False uri (toPos (6, 6))
+          res = IdeResultOk
+              [ (Range (toPos (6, 6)) (toPos (6, 12)), "Maybe Int")
+              , (Range (toPos (6, 5)) (toPos (6, 13)), "Maybe Int")
+              -- TODO: why is this happening?
+              ]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, sum type pattern match, just value" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (6,11)) uri
+          arg = TP False uri (toPos (6, 11))
+          res = IdeResultOk
+            [ (Range (toPos (6, 11)) (toPos (6, 12)), "Int")
+            , (Range (toPos (6, 6)) (toPos (6, 12)), "Maybe Int")
+            , (Range (toPos (6, 5)) (toPos (6, 13)), "Maybe Int")
+            -- TODO: why is this happening?
+            ]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, sum type pattern match, nothing" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (7,5)) uri
+          arg = TP False uri (toPos (7,5))
+          res = IdeResultOk [(Range (toPos (7, 5)) (toPos (7, 12)), "Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, sum type pattern match, nothing, literal" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (7,15)) uri
+          arg = TP False uri (toPos (7,15))
+          res = IdeResultOk []
+            -- TODO: do we want this?
+            --(Range (toPos (7, 15)) (toPos (7, 16)), "Int")
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, variable matching" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (10,5)) uri
+          arg = TP False uri (toPos (10,5))
+          res = IdeResultOk [(Range (toPos (10, 5)) (toPos (10, 6)), "Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, case expr" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (10,14)) uri
+          arg = TP False uri (toPos (10,14))
+          res = IdeResultOk [(Range (toPos (10, 14)) (toPos (10, 15)), "Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, case expr match, just" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (11,5)) uri
+          arg = TP False uri (toPos (11,5))
+          res = IdeResultOk [(Range (toPos (11, 5)) (toPos (11, 11)), "Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, case expr match, just value" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (11,10)) uri
+          arg = TP False uri (toPos (11,10))
+          res = IdeResultOk
+              [ (Range (toPos (11, 10)) (toPos (11, 11)), "Int")
+              , (Range (toPos (11, 5)) (toPos (11, 11)), "Maybe Int")
+              ]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, infix operator" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (11,17)) uri
+          arg = TP False uri (toPos (11,17))
+          res = IdeResultOk
+              [ (Range (toPos (11, 17)) (toPos (11, 18)), "Int -> Int -> Int")
+              ]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, case expr match, nothing" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (12,5)) uri
+          arg = TP False uri (toPos (12,5))
+          res = IdeResultOk [(Range (toPos (12, 5)) (toPos (12, 12)), "Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, do bind expr result " $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (16,5)) uri
+          arg = TP False uri (toPos (16,5))
+          res = IdeResultOk [(Range (toPos (16, 5)) (toPos (16, 6)), "Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+    it "runs the type command, do bind expr" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (16,10)) uri
+          arg = TP False uri (toPos (16,10))
+          res = IdeResultOk [(Range (toPos (16, 10)) (toPos (16, 11)), "Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, let binding function, return func" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (17,13)) uri
+          arg = TP False uri (toPos (17,13))
+          res = IdeResultOk [(Range (toPos (17, 13)) (toPos (17, 19)), "Int -> Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, let binding function, return param" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (17,21)) uri
+          arg = TP False uri (toPos (17,21))
+          res = IdeResultOk [(Range (toPos (17, 21)) (toPos (17, 22)), "Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, let binding function, function type" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (17,9)) uri
+          arg = TP False uri (toPos (17,9))
+          res = IdeResultOk []
+            -- TODO: do we want this?
+            -- (Range (toPos (17, 9)) (toPos (17, 10)), "Maybe Int")
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, do expr, function type" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (18,10)) uri
+          arg = TP False uri (toPos (18,10))
+          res = IdeResultOk [(Range (toPos (18, 10)) (toPos (18, 11)), "Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, let binding function, do expr bind for local func" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (18,5)) uri
+          arg = TP False uri (toPos (18,5))
+          res = IdeResultOk [(Range (toPos (18, 5)) (toPos (18, 6)), "Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, function type" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (15,5)) uri
+          arg = TP False uri (toPos (15,5))
+          res = IdeResultOk []
+            -- TODO: the type is known, why not in the map?
+            -- [(Range (toPos (15, 1)) (toPos (14, 11)), "Maybe Int -> Maybe Int")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, function parameter" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (22,10)) uri
+          arg = TP False uri (toPos (22,10))
+          res = IdeResultOk [(Range (toPos (22, 10)) (toPos (22, 11)), "a -> a")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, function parameter" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (22,10)) uri
+          arg = TP False uri (toPos (22,10))
+          res = IdeResultOk [(Range (toPos (22, 10)) (toPos (22, 11)), "a -> a")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, function composition" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (25,26)) uri
+          arg = TP False uri (toPos (25,26))
+          res = IdeResultOk
+              [ (Range (toPos (25, 26)) (toPos (25, 27)), "(b -> c) -> (a -> b) -> a -> c")
+              ]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, let binding, function composition" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (25,20)) uri
+          arg = TP False uri (toPos (25,20))
+          res = IdeResultOk []
+              -- TODO: do we want this?
+              --(Range (toPos (25, 20)) (toPos (25, 21)), "a -> c")
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, let binding, type of function" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (25,33)) uri
+          arg = TP False uri (toPos (25,33))
+          res = IdeResultOk [(Range (toPos (25, 33)) (toPos (25, 34)), "a -> c")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, function type composition" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (25,5)) uri
+          arg = TP False uri (toPos (25,5))
+          res = IdeResultOk []
+            -- TODO: the type is known, why not in the map?
+            -- (Range (toPos (25, 1)) (toPos (25, 9)), "(b -> c) -> (a -> b) -> a -> c")
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, infix operator" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "Types.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (28,25)) uri
+          arg = TP False uri (toPos (28,25))
+          res = IdeResultOk [(Range (toPos (28, 25)) (toPos (28, 28)), "(a -> b) -> IO a -> IO b")]
+      testCommand testPlugins act "ghcmod" "type" arg res
+-- ----------------------------------------------------------------------------
     it "runs the type command with an absolute path from another folder, correct params" $ do
       fp <- makeAbsolute "./test/testdata/HaReRename.hs"
       cd <- getCurrentDirectory

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -123,7 +123,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (6,16)) uri
           arg = TP False uri (toPos (6,16))
-          res = IdeResultOk [(Range (toPos (6, 16)) (toPos (6,17)), "Int")]
+          res = IdeResultOk
+              [ (Range (toPos (6, 16)) (toPos (6,17)), "Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, sum type pattern match, just" $ withCurrentDirectory "./test/testdata" $ do
@@ -162,7 +164,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (7,5)) uri
           arg = TP False uri (toPos (7,5))
-          res = IdeResultOk [(Range (toPos (7, 5)) (toPos (7, 12)), "Maybe Int")]
+          res = IdeResultOk
+              [ (Range (toPos (7, 5)) (toPos (7, 12)), "Maybe Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, sum type pattern match, nothing, literal" $ withCurrentDirectory "./test/testdata" $ do
@@ -172,7 +176,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (7,15)) uri
           arg = TP False uri (toPos (7,15))
-          res = IdeResultOk [(Range (toPos (7, 15)) (toPos (7, 16)), "Int")]
+          res = IdeResultOk
+              [ (Range (toPos (7, 15)) (toPos (7, 16)), "Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, variable matching" $ withCurrentDirectory "./test/testdata" $ do
@@ -182,7 +188,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (10,5)) uri
           arg = TP False uri (toPos (10,5))
-          res = IdeResultOk [(Range (toPos (10, 5)) (toPos (10, 6)), "Maybe Int")]
+          res = IdeResultOk
+              [ (Range (toPos (10, 5)) (toPos (10, 6)), "Maybe Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, case expr" $ withCurrentDirectory "./test/testdata" $ do
@@ -258,7 +266,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (16,5)) uri
           arg = TP False uri (toPos (16,5))
-          res = IdeResultOk [(Range (toPos (16, 5)) (toPos (16, 6)), "Int")]
+          res = IdeResultOk
+              [ (Range (toPos (16, 5)) (toPos (16, 6)), "Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, do bind expr" $ withCurrentDirectory "./test/testdata" $ do
@@ -268,7 +278,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (16,10)) uri
           arg = TP False uri (toPos (16,10))
-          res = IdeResultOk [(Range (toPos (16, 10)) (toPos (16, 11)), "Maybe Int")]
+          res = IdeResultOk
+              [ (Range (toPos (16, 10)) (toPos (16, 11)), "Maybe Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, let binding function, return func" $ withCurrentDirectory "./test/testdata" $ do
@@ -278,7 +290,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (17,13)) uri
           arg = TP False uri (toPos (17,13))
-          res = IdeResultOk [(Range (toPos (17, 13)) (toPos (17, 19)), "Int -> Maybe Int")]
+          res = IdeResultOk
+              [ (Range (toPos (17, 13)) (toPos (17, 19)), "Int -> Maybe Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, let binding function, return param" $ withCurrentDirectory "./test/testdata" $ do
@@ -288,7 +302,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (17,21)) uri
           arg = TP False uri (toPos (17,21))
-          res = IdeResultOk [(Range (toPos (17, 21)) (toPos (17, 22)), "Int")]
+          res = IdeResultOk
+              [ (Range (toPos (17, 21)) (toPos (17, 22)), "Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, let binding function, function type" $ withCurrentDirectory "./test/testdata" $ do
@@ -310,7 +326,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (18,10)) uri
           arg = TP False uri (toPos (18,10))
-          res = IdeResultOk [(Range (toPos (18, 10)) (toPos (18, 11)), "Maybe Int")]
+          res = IdeResultOk
+              [ (Range (toPos (18, 10)) (toPos (18, 11)), "Maybe Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, let binding function, do expr bind for local func" $ withCurrentDirectory "./test/testdata" $ do
@@ -320,7 +338,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (18,5)) uri
           arg = TP False uri (toPos (18,5))
-          res = IdeResultOk [(Range (toPos (18, 5)) (toPos (18, 6)), "Int")]
+          res = IdeResultOk
+              [ (Range (toPos (18, 5)) (toPos (18, 6)), "Int")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, function type" $ withCurrentDirectory "./test/testdata" $ do
@@ -342,7 +362,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (22,10)) uri
           arg = TP False uri (toPos (22,10))
-          res = IdeResultOk [(Range (toPos (22, 10)) (toPos (22, 11)), "a -> a")]
+          res = IdeResultOk
+              [ (Range (toPos (22, 10)) (toPos (22, 11)), "a -> a")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, function parameter" $ withCurrentDirectory "./test/testdata" $ do
@@ -352,7 +374,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (22,10)) uri
           arg = TP False uri (toPos (22,10))
-          res = IdeResultOk [(Range (toPos (22, 10)) (toPos (22, 11)), "a -> a")]
+          res = IdeResultOk
+              [ (Range (toPos (22, 10)) (toPos (22, 11)), "a -> a")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, function composition" $ withCurrentDirectory "./test/testdata" $ do
@@ -386,7 +410,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (25,33)) uri
           arg = TP False uri (toPos (25,33))
-          res = IdeResultOk [(Range (toPos (25, 33)) (toPos (25, 34)), "a -> c")]
+          res = IdeResultOk
+              [ (Range (toPos (25, 33)) (toPos (25, 34)), "a -> c")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, function type composition" $ withCurrentDirectory "./test/testdata" $ do
@@ -408,7 +434,9 @@ ghcmodSpec =
             _ <- setTypecheckedModule uri
             liftToGhc $ newTypeCmd (toPos (28,25)) uri
           arg = TP False uri (toPos (28,25))
-          res = IdeResultOk [(Range (toPos (28, 25)) (toPos (28, 28)), "(a -> b) -> IO a -> IO b")]
+          res = IdeResultOk
+              [ (Range (toPos (28, 25)) (toPos (28, 28)), "(a -> b) -> IO a -> IO b")
+              ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command, constructor" $ withCurrentDirectory "./test/testdata" $ do

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -478,6 +478,10 @@ ghcmodSpec =
               , (Range (toPos (33, 15)) (toPos (33, 19)), "Test -> String")
               , (Range (toPos (33, 15)) (toPos (33, 19)), "[Test] -> ShowS")
               , (Range (toPos (33, 15)) (toPos (33, 19)), "Int -> Test -> ShowS")
+#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,0,0)))
+#else
+              , (Range (toPos (33, 15)) (toPos (33, 19)), "[Test] -> ShowS")
+#endif
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 
@@ -493,6 +497,10 @@ ghcmodSpec =
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
+#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,0,0)))
+#else
+              , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
+#endif
               ]
       testCommand testPlugins act "ghcmod" "type" arg res
 

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -82,7 +82,7 @@ ghcmodSpec =
 
     -- ---------------------------------
 
-    it "runs the type command" $ withCurrentDirectory "./test/testdata" $ do
+    it "runs the type command, find type" $ withCurrentDirectory "./test/testdata" $ do
       fp <- makeAbsolute "HaReRename.hs"
       let uri = filePathToUri fp
           act = do
@@ -92,6 +92,27 @@ ghcmodSpec =
           res = IdeResultOk
             [(Range (toPos (5,9)) (toPos (5,10)), "Int")
             ]
+      testCommand testPlugins act "ghcmod" "type" arg res
+    it "runs the type command, find function type" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "HaReRename.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (2,11)) uri
+          arg = TP False uri (toPos (2,11))
+          res = IdeResultOk
+            [(Range (toPos (2, 8)) (toPos (2,16)), "String -> IO ()")
+            ]
+      testCommand testPlugins act "ghcmod" "type" arg res
+
+    it "runs the type command, no type at location" $ withCurrentDirectory "./test/testdata" $ do
+      fp <- makeAbsolute "HaReRename.hs"
+      let uri = filePathToUri fp
+          act = do
+            _ <- setTypecheckedModule uri
+            liftToGhc $ newTypeCmd (toPos (1,1)) uri
+          arg = TP False uri (toPos (1,1))
+          res = IdeResultOk []
       testCommand testPlugins act "ghcmod" "type" arg res
 
     it "runs the type command with an absolute path from another folder, correct params" $ do


### PR DESCRIPTION
Under the orchestration of @mpickering, reimplements the `genTypeMap` function in a new module.
A Typechecked module is only traveresed once.
This reimplementation should have a lower memory footprint but is likely to increase the first startup time of modules.
Some parts may no longer have a type on hover.

Implementation has already been merged into #1126. There it is said to be working!

* [x] More Documentation
* [x] Way more tests

Closes #1156