### PR TITLE
README Nix - replace old.postFixup -> postFixup

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ in
   packageOverrides = pkgs: rec {
 
     vscode = pkgs.vscode.overrideDerivation (old: {
-      postFixup = old.postFixup + ''
+      postFixup = ''
         wrapProgram $out/bin/code --prefix PATH : ${lib.makeBinPath [hie]}
       '';
     });


### PR DESCRIPTION
It's been removed in NixOS/nixpkgs@d9b1486#diff-0190490bb2285cd4e5839b08cda4b00f