### PR TITLE
fix version of lsp-test

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -275,7 +275,7 @@ test-suite func-test
                      , data-default
                      , directory
                      , filepath
-                     , lsp-test >= 0.5.1.1 && < 0.5.2
+                     , lsp-test == 0.5.1.1
                      , haskell-ide-engine
                      , haskell-lsp-types >= 0.4
                      , hie-test-utils


### PR DESCRIPTION
closes #1210 for now. This fixes the version of `lsp-test` to `0.5.1.1` instead of allowing `0.5.1.3`, which cause several errors.

In the long term, it will be necessary to upgrade `haskell-lsp` to version `0.10`, but this will be a longer process.