### PR TITLE
Prevent hie crash if apply-refact crashes

### DIFF
--- a/test/testdata/ApplyRefactError.hs
+++ b/test/testdata/ApplyRefactError.hs
@@ -1,2 +1,2 @@
-hoge :: forall a. (a -> a) -> a -> a
-hoge f x = f $ x
+foo :: forall a. (a -> a) -> a -> a
+foo f x = f $ x

--- a/test/testdata/ApplyRefactError.hs
+++ b/test/testdata/ApplyRefactError.hs
@@ -1,0 +1,2 @@
+hoge :: forall a. (a -> a) -> a -> a
+hoge f x = f $ x

--- a/test/unit/ApplyRefactPluginSpec.hs
+++ b/test/unit/ApplyRefactPluginSpec.hs
@@ -4,6 +4,7 @@
 module ApplyRefactPluginSpec where
 
 import qualified Data.HashMap.Strict                   as H
+import qualified Data.Text                             as T
 import           Haskell.Ide.Engine.Plugin.ApplyRefact
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils
@@ -153,3 +154,15 @@ applyRefactSpec = do
             , _diagnostics = List []
             }
            ))
+
+    -- ---------------------------------
+
+    it "reports error without crash" $ do
+      filePath  <- filePathToUri <$> makeAbsolute "./test/testdata/ApplyRefactError.hs"
+
+      let req = applyAllCmd' filePath
+          isExpectedError (IdeResultFail (IdeError PluginError err _)) =
+              "Illegal symbol '.' in type" `T.isInfixOf` err
+          isExpectedError _ = False
+      r <- withCurrentDirectory "./test/testdata" $ runIGM testPlugins req
+      r `shouldSatisfy` isExpectedError


### PR DESCRIPTION
Fixes #451

Note: We need to catch `SomeException` because `applyRefactorings` throw an error by `error`.