### PR TITLE
Add Nix cabal-helper fix to troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ we talk to clients.__
       - [Is \<package\> base-x?](#is-package-base-x)
       - [Is there a hash (#) after \<package\>?](#is-there-a-hash--after-package)
       - [Otherwise](#otherwise)
+    - [Nix: cabal-helper, No such file or directory](#nix-cabal-helper-no-such-file-or-directory)
 
 ## Features
 
@@ -597,3 +598,16 @@ Delete any `.ghc.environment*` files in your project root and try again. (At the
 
 #### Otherwise
 Try running `cabal update`.
+
+### Nix: cabal-helper, No such file or directory
+
+An error on stderr like
+
+```
+cabal-helper-wrapper: /home/<...>/.cache/cabal-helper/cabal-helper<...>: createProcess: runInteractiveProcess:
+  exec: does not exist (No such file or directory)
+```
+
+can happen because cabal-helper compiles and runs above executable at runtime without using nix-build, which means a Nix garbage collection can delete the paths it depends on. Delete ~/.cache/cabal-helper and restart HIE to fix this.
+
+


### PR DESCRIPTION
I noticed this error because I just upgraded my NixOS.

```
$ ~/.cache/cabal-helper/cabal-helper0.9.0.0-Cabal2.4.1.0
zsh: no such file or directory: /home/infinisil/.cache/cabal-helper/cabal-helper0.9.0.0-Cabal2.4.1.0
$ patchelf --print-interpreter ~/.cache/cabal-helper/cabal-helper0.9.0.0-Cabal2.4.1.0
/nix/store/sw54ph775lw7b9g4hlfvpx6fmlvdy8qi-glibc-2.27/lib/ld-linux-x86-64.so.2
$ stat /nix/store/sw54ph775lw7b9g4hlfvpx6fmlvdy8qi-glibc-2.27/lib/ld-linux-x86-64.so.2
stat: cannot stat '/nix/store/sw54ph775lw7b9g4hlfvpx6fmlvdy8qi-glibc-2.27/lib/ld-linux-x86-64.so.2': No such file or directory
```