### PR TITLE
Extra argument causes cabal-build-doc to fail

### DIFF
--- a/install.hs
+++ b/install.hs
@@ -222,7 +222,7 @@ cabalInstallHie versionNumber = do
 
 cabalBuildDoc :: Action ()
 cabalBuildDoc = do
-  execCabal_ ["new-build", "hoogle", "generate"]
+  execCabal_ ["new-build", "hoogle"]
   execCabal_ ["new-exec", "hoogle", "generate"]
 
 cabalTest :: VersionNumber -> Action ()


### PR DESCRIPTION
`stack install.hs cabal-build-doc`

was failing with:
```
cabal: Cannot build the package generate, it is not in this project (either directly or indirectly). If you want to add it to the project then edit the cabal.project file.
```

Looking at commit 8fd5cba63213736e8720799a57afab32c8ef544b it looks like a cut/paste error in `cabalBuildDoc` which this PR corrects.