### PR TITLE
Add an explicit stack file for GHC 8.6.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,11 @@ jobs:
       - STACK_FILE: "stack-8.6.4.yaml"
     <<: *defaults
 
+  ghc-8.6.5:
+    environment:
+      - STACK_FILE: "stack-8.6.5.yaml"
+    <<: *defaults
+
   ghc-nightly:
     environment:
       - STACK_FILE: "stack.yaml"
@@ -196,7 +201,8 @@ workflows:
       - ghc-8.4.4
       - ghc-8.6.1
       - ghc-8.6.2
-      - ghc-8.6.3
+      # - ghc-8.6.3
       - ghc-8.6.4
+      - ghc-8.6.5
       - ghc-nightly
       - cabal

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,0 +1,44 @@
+resolver: nightly-2019-04-30 # First GHC 8.6.5
+packages:
+- .
+- hie-plugin-api
+
+extra-deps:
+- ./submodules/HaRe
+- ./submodules/brittany
+- ./submodules/cabal-helper
+- ./submodules/floskell
+- ./submodules/ghc-mod
+- ./submodules/ghc-mod/core
+
+- ansi-terminal-0.8.2
+- butcher-1.3.2.1
+- cabal-plan-0.4.0.0
+- constrained-dynamic-0.1.0.0
+- deque-0.2.7
+- ghc-exactprint-0.5.8.2
+- haddock-api-2.22.0
+- haskell-lsp-0.9.0.0
+- haskell-lsp-types-0.9.0.0
+- hlint-2.1.17
+- hsimport-0.8.8
+- lsp-test-0.5.1.1
+- monad-dijkstra-0.1.1.2@rev:1
+- monad-memo-0.4.1
+- multistate-0.8.0.1
+- syz-0.2.0.0
+- temporary-1.2.1.1
+- yaml-0.8.32
+
+flags:
+  haskell-ide-engine:
+    pedantic: true
+  hie-plugin-api:
+    pedantic: true
+
+# allow-newer: true
+
+nix:
+  packages: [ icu libcxx zlib ]
+
+concurrent-tests: false


### PR DESCRIPTION
And schedule circle CI for it, even though it is a repeat of the
nightly one.

Very pleasantly surprised to see that `install.hs` needs no change to
pick this up.