### PR TITLE
hie sends invalid message on hover

### DIFF
--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -555,6 +555,7 @@ reactor inp diagIn = do
                 let hs = concat hhs
                     h = case mconcat ((map (^. J.contents) hs) :: [J.HoverContents]) of
                       J.HoverContentsMS (List []) -> Nothing
+                      J.HoverContentsEmpty        -> Nothing
                       hh                          -> Just $ J.Hover hh r
                     r = listToMaybe $ mapMaybe (^. J.range) hs
                 in reactorSend $ RspHover $ Core.makeResponseMessage req h


### PR DESCRIPTION
When there is no information available against a hover request, hie returns a response like

```json
{"result":{"contents":null},"jsonrpc":"2.0","id":1}
```

which does not respect the Language Server Protocol in which `contents` cannot be `null`:

```typescript
interface Hover {
    contents: MarkedString | MarkedString[] | MarkupContent;
    range?: Range;
}
```

This PR includes a temporal measure for this problem.
It would be better to fix `haskell-lsp` so as not to allow `null` in `HoverContents`.
I've opened the [issue](https://github.com/alanz/haskell-lsp/issues/162) on `haskell-lsp` too.
