### PR TITLE
Adapting to new haskell-lsp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,9 @@
 	# url = https://github.com/bubba/ghc-mod.git
 	url = https://github.com/alanz/ghc-mod.git
 
+[submodule "submodules/haskell-lsp"]
+	path = submodules/haskell-lsp
+	url = https://github.com/alanz/haskell-lsp.git
+[submodule "submodules/lsp-test"]
+	path = submodules/lsp-test
+	url = https://github.com/alanz/lsp-test.git

--- a/cabal.project
+++ b/cabal.project
@@ -8,5 +8,8 @@ packages:
          ./submodules/ghc-mod/
          ./submodules/ghc-mod/core/
          ./submodules/ghc-mod/ghc-project-types
+         ./submodules/haskell-lsp
+         ./submodules/haskell-lsp/haskell-lsp-types
+         ./submodules/lsp-test
 
 tests: true

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -70,8 +70,8 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp == 0.11.*
-                     , haskell-lsp-types == 0.11.*
+                     , haskell-lsp == 0.12.*
+                     , haskell-lsp-types == 0.12.*
                      , haskell-src-exts
                      , hie-plugin-api
                      , hlint >= 2.0.11
@@ -86,6 +86,7 @@ library
                      , optparse-simple >= 0.0.3
                      , parsec
                      , process
+                     , rope-utf16-splay
                      , safe
                      , sorted-list >= 0.2.1.0
                      , stm
@@ -95,7 +96,6 @@ library
                      , unordered-containers
                      , vector
                      , yaml >= 0.8.31
-                     , yi-rope
   ghc-options:         -Wall -Wredundant-constraints
   if flag(pedantic)
      ghc-options:      -Werror
@@ -278,8 +278,8 @@ test-suite func-test
                      , filepath
                      , lsp-test >= 0.5.2
                      , haskell-ide-engine
-                     , haskell-lsp-types == 0.11.*
-                     , haskell-lsp == 0.11.*
+                     , haskell-lsp-types == 0.12.*
+                     , haskell-lsp == 0.12.*
                      , hie-test-utils
                      , hie-plugin-api
                      , hspec

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -86,7 +86,7 @@ library
                      , optparse-simple >= 0.0.3
                      , parsec
                      , process
-                     , rope-utf16-splay
+                     , rope-utf16-splay >= 0.3.1.0
                      , safe
                      , sorted-list >= 0.2.1.0
                      , stm

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -32,7 +32,6 @@ module Haskell.Ide.Engine.PluginUtils
   , readVFS
   , getRangeFromVFS
   , rangeLinesFromVfs
-  , splitAtLine
   ) where
 
 import           Control.Monad.IO.Class
@@ -285,12 +284,5 @@ getRangeFromVFS uri rg = do
   case mvf of
     Just vfs -> return $ Just $ rangeLinesFromVfs vfs rg
     Nothing  -> return Nothing
-
--- rangeLinesFromVfs :: VirtualFile -> Range -> T.Text
--- rangeLinesFromVfs (VirtualFile _ yitext _) (Range (Position lf _cf) (Position lt _ct)) = r
---   where
---     (_ ,s1) = splitAtLine lf yitext
---     (s2, _) = splitAtLine (lt - lf) s1
---     r = Rope.toText s2
 
 -- ---------------------------------------------------------------------

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -32,6 +32,7 @@ module Haskell.Ide.Engine.PluginUtils
   , readVFS
   , getRangeFromVFS
   , rangeLinesFromVfs
+  , splitAtLine
   ) where
 
 import           Control.Monad.IO.Class
@@ -57,7 +58,7 @@ import           Prelude                               hiding (log)
 import           SrcLoc
 import           System.Directory
 import           System.FilePath
-import qualified Yi.Rope as Yi
+import qualified Data.Rope.UTF16 as Rope
 
 -- ---------------------------------------------------------------------
 
@@ -275,7 +276,7 @@ readVFS :: (MonadIde m, MonadIO m) => Uri -> m (Maybe T.Text)
 readVFS uri = do
   mvf <- getVirtualFile uri
   case mvf of
-    Just (VirtualFile _ txt) -> return $ Just (Yi.toText txt)
+    Just (VirtualFile _ txt _) -> return $ Just (Rope.toText txt)
     Nothing -> return Nothing
 
 getRangeFromVFS :: (MonadIde m, MonadIO m) => Uri -> Range -> m (Maybe T.Text)
@@ -285,9 +286,11 @@ getRangeFromVFS uri rg = do
     Just vfs -> return $ Just $ rangeLinesFromVfs vfs rg
     Nothing  -> return Nothing
 
-rangeLinesFromVfs :: VirtualFile -> Range -> T.Text
-rangeLinesFromVfs (VirtualFile _ yitext) (Range (Position lf _cf) (Position lt _ct)) = r
-  where
-    (_ ,s1) = Yi.splitAtLine lf yitext
-    (s2, _) = Yi.splitAtLine (lt - lf) s1
-    r = Yi.toText s2
+-- rangeLinesFromVfs :: VirtualFile -> Range -> T.Text
+-- rangeLinesFromVfs (VirtualFile _ yitext _) (Range (Position lf _cf) (Position lt _ct)) = r
+--   where
+--     (_ ,s1) = splitAtLine lf yitext
+--     (s2, _) = splitAtLine (lt - lf) s1
+--     r = Rope.toText s2
+
+-- ---------------------------------------------------------------------

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -49,7 +49,7 @@ library
                      , hslogger
                      , monad-control
                      , mtl
-                     , rope-utf16-splay == 0.2.*
+                     , rope-utf16-splay >= 0.3.1.0
                      , stm
                      , syb
                      , text

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -45,16 +45,16 @@ library
                      , ghc
                      , ghc-mod-core >= 5.9.0.0
                      , ghc-project-types >= 5.9.0.0
-                     , haskell-lsp == 0.11.*
+                     , haskell-lsp == 0.12.*
                      , hslogger
                      , monad-control
                      , mtl
+                     , rope-utf16-splay == 0.2.*
                      , stm
                      , syb
                      , text
                      , transformers
                      , unordered-containers
-                     , yi-rope
   if os(windows)
     build-depends:     Win32
   else

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -189,24 +189,6 @@ safeTyThingId _                           = Nothing
 -- Associates a module's qualifier with its members
 type QualCompls = Map.Map T.Text [CompItem]
 
--- -- | Describes the line at the current cursor position
--- data PosPrefixInfo = PosPrefixInfo
---   { fullLine :: T.Text
---     -- ^ The full contents of the line the cursor is at
-
---   , prefixModule :: T.Text
---     -- ^ If any, the module name that was typed right before the cursor position.
---     --  For example, if the user has typed "Data.Maybe.from", then this property
---     --  will be "Data.Maybe"
-
---   , prefixText :: T.Text
---     -- ^ The word right before the cursor position, after removing the module part.
---     -- For example if the user has typed "Data.Maybe.from",
---     -- then this property will be "from"
---   , cursorPos :: J.Position
---     -- ^ The cursor position
---   }
-
 data CachedCompletions = CC
   { allModNamesAsNS :: [T.Text]
   , unqualCompls :: [CompItem]

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -27,7 +27,6 @@ import           Control.Monad.STM
 import           Data.Aeson ( (.=) )
 import qualified Data.Aeson as J
 import qualified Data.ByteString.Lazy as BL
--- import           Data.Char (isUpper, isAlphaNum)
 import           Data.Coerce (coerce)
 import           Data.Default
 import           Data.Foldable
@@ -203,33 +202,6 @@ getPrefixAtPos :: (MonadIO m, MonadReader REnv m)
 getPrefixAtPos uri pos = do
   mvf <- liftIO =<< asksLspFuncs Core.getVirtualFileFunc <*> pure uri
   case mvf of
-    -- Just (VFS.VirtualFile _ yitext) ->
-    --   return $ Just $ fromMaybe (Hie.PosPrefixInfo "" "" "" pos) $ do
-    --     let headMaybe [] = Nothing
-    --         headMaybe (x:_) = Just x
-    --         lastMaybe [] = Nothing
-    --         lastMaybe xs = Just $ last xs
-    --     -- curLine <- headMaybe $ Yi.lines $ snd $ Yi.splitAtLine l yitext
-    --     -- let beforePos = Yi.take c curLine
-    --     -- curWord <- case Yi.last beforePos of
-    --     --              Just ' ' -> Just "" -- don't count abc as the curword in 'abc '
-    --     --              _ -> Yi.toText <$> lastMaybe (Yi.words beforePos)
-
-    --     curLine <- headMaybe $ Yi.lines $ snd $ splitAtLine l yitext
-    --     let beforePos = Yi.take c curLine
-    --     curWord <- case Yi.last beforePos of
-    --                  Just ' ' -> Just "" -- don't count abc as the curword in 'abc '
-    --                  _ -> Yi.toText <$> lastMaybe (Yi.words beforePos)
-
-    --     let parts = T.split (=='.')
-    --                   $ T.takeWhileEnd (\x -> isAlphaNum x || x `elem` ("._'"::String)) curWord
-    --     case reverse parts of
-    --       [] -> Nothing
-    --       (x:xs) -> do
-    --         let modParts = dropWhile (not . isUpper . T.head)
-    --                             $ reverse $ filter (not .T.null) xs
-    --             modName = T.intercalate "." modParts
-    --         return $ Hie.PosPrefixInfo (Yi.toText curLine) modName x pos
     Just vf -> VFS.getCompletionPrefix pos vf
     Nothing -> return Nothing
 

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -27,7 +27,7 @@ import           Control.Monad.STM
 import           Data.Aeson ( (.=) )
 import qualified Data.Aeson as J
 import qualified Data.ByteString.Lazy as BL
-import           Data.Char (isUpper, isAlphaNum)
+-- import           Data.Char (isUpper, isAlphaNum)
 import           Data.Coerce (coerce)
 import           Data.Default
 import           Data.Foldable
@@ -65,8 +65,8 @@ import qualified Language.Haskell.LSP.Types.Lens         as J
 import qualified Language.Haskell.LSP.Utility            as U
 import qualified Language.Haskell.LSP.VFS                as VFS
 import           System.Exit
-import qualified System.Log.Logger as L
-import qualified Yi.Rope as Yi
+import qualified System.Log.Logger                       as L
+import qualified Data.Rope.UTF16                         as Rope
 
 -- ---------------------------------------------------------------------
 {-# ANN module ("hlint: ignore Eta reduce" :: String) #-}
@@ -200,29 +200,37 @@ configVal field = field <$> getClientConfig
 
 getPrefixAtPos :: (MonadIO m, MonadReader REnv m)
   => Uri -> Position -> m (Maybe Hie.PosPrefixInfo)
-getPrefixAtPos uri pos@(Position l c) = do
+getPrefixAtPos uri pos = do
   mvf <- liftIO =<< asksLspFuncs Core.getVirtualFileFunc <*> pure uri
   case mvf of
-    Just (VFS.VirtualFile _ yitext) ->
-      return $ Just $ fromMaybe (Hie.PosPrefixInfo "" "" "" pos) $ do
-        let headMaybe [] = Nothing
-            headMaybe (x:_) = Just x
-            lastMaybe [] = Nothing
-            lastMaybe xs = Just $ last xs
-        curLine <- headMaybe $ Yi.lines $ snd $ Yi.splitAtLine l yitext
-        let beforePos = Yi.take c curLine
-        curWord <- case Yi.last beforePos of
-                     Just ' ' -> Just "" -- don't count abc as the curword in 'abc '
-                     _ -> Yi.toText <$> lastMaybe (Yi.words beforePos)
-        let parts = T.split (=='.')
-                      $ T.takeWhileEnd (\x -> isAlphaNum x || x `elem` ("._'"::String)) curWord
-        case reverse parts of
-          [] -> Nothing
-          (x:xs) -> do
-            let modParts = dropWhile (not . isUpper . T.head)
-                                $ reverse $ filter (not .T.null) xs
-                modName = T.intercalate "." modParts
-            return $ Hie.PosPrefixInfo (Yi.toText curLine) modName x pos
+    -- Just (VFS.VirtualFile _ yitext) ->
+    --   return $ Just $ fromMaybe (Hie.PosPrefixInfo "" "" "" pos) $ do
+    --     let headMaybe [] = Nothing
+    --         headMaybe (x:_) = Just x
+    --         lastMaybe [] = Nothing
+    --         lastMaybe xs = Just $ last xs
+    --     -- curLine <- headMaybe $ Yi.lines $ snd $ Yi.splitAtLine l yitext
+    --     -- let beforePos = Yi.take c curLine
+    --     -- curWord <- case Yi.last beforePos of
+    --     --              Just ' ' -> Just "" -- don't count abc as the curword in 'abc '
+    --     --              _ -> Yi.toText <$> lastMaybe (Yi.words beforePos)
+
+    --     curLine <- headMaybe $ Yi.lines $ snd $ splitAtLine l yitext
+    --     let beforePos = Yi.take c curLine
+    --     curWord <- case Yi.last beforePos of
+    --                  Just ' ' -> Just "" -- don't count abc as the curword in 'abc '
+    --                  _ -> Yi.toText <$> lastMaybe (Yi.words beforePos)
+
+    --     let parts = T.split (=='.')
+    --                   $ T.takeWhileEnd (\x -> isAlphaNum x || x `elem` ("._'"::String)) curWord
+    --     case reverse parts of
+    --       [] -> Nothing
+    --       (x:xs) -> do
+    --         let modParts = dropWhile (not . isUpper . T.head)
+    --                             $ reverse $ filter (not .T.null) xs
+    --             modName = T.intercalate "." modParts
+    --         return $ Hie.PosPrefixInfo (Yi.toText curLine) modName x pos
+    Just vf -> VFS.getCompletionPrefix pos vf
     Nothing -> return Nothing
 
 -- ---------------------------------------------------------------------
@@ -237,8 +245,8 @@ mapFileFromVfs tn vtdi = do
   vfsFunc <- asksLspFuncs Core.getVirtualFileFunc
   mvf <- liftIO $ vfsFunc uri
   case (mvf, uriToFilePath uri) of
-    (Just (VFS.VirtualFile _ yitext), Just fp) -> do
-      let text' = Yi.toString yitext
+    (Just (VFS.VirtualFile _ yitext _), Just fp) -> do
+      let text' = Rope.toString yitext
           -- text = "{-# LINE 1 \"" ++ fp ++ "\"#-}\n" <> text'
       let req = GReq tn (Just uri) Nothing Nothing (const $ return ())
                   $ IdeResultOk <$> do
@@ -826,7 +834,7 @@ withDocumentContents reqId uri f = do
         (J.responseId reqId)
         J.InvalidRequest
         "Document was not open"
-    Just (VFS.VirtualFile _ txt) -> f (Yi.toText txt)
+    Just (VFS.VirtualFile _ txt _) -> f (Rope.toText txt)
 
 -- | Get the currently configured formatter provider.
 -- The currently configured formatter provider is defined in @Config@ by PluginId.

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -31,6 +31,7 @@ extra-deps:
 - monad-dijkstra-0.1.1.2
 - mtl-2.2.2
 - pretty-show-1.8.2
+- rope-utf16-splay-0.3.1.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 - yaml-0.8.32

--- a/stack-8.2.1.yaml
+++ b/stack-8.2.1.yaml
@@ -10,6 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 # - brittany-0.11.0.0
 - butcher-1.3.1.1
@@ -20,11 +23,11 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - hlint-2.0.11
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - mtl-2.2.2
 - pretty-show-1.8.2

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -10,6 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 # - brittany-0.11.0.0
 - butcher-1.3.1.1
@@ -21,14 +24,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - sorted-list-0.2.1.0

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -34,6 +34,7 @@ extra-deps:
 # - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
+- rope-utf16-splay-0.3.1.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
 

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -32,6 +32,7 @@ extra-deps:
 # - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - windns-0.1.0.0

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -10,6 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 # - brittany-0.11.0.0
 - base-compat-0.9.3
@@ -19,14 +22,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - syz-0.2.0.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -31,6 +31,7 @@ extra-deps:
 # - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -10,6 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 - base-compat-0.9.3
 - cabal-plan-0.3.0.0
@@ -18,14 +21,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - syz-0.2.0.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -10,6 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 # - brittany-0.11.0.0
 - cabal-plan-0.4.0.0
@@ -18,14 +21,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - optparse-simple-0.1.0
 - pretty-show-1.9.5

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -32,6 +32,7 @@ extra-deps:
 - monad-dijkstra-0.1.1.2
 - optparse-simple-0.1.0
 - pretty-show-1.9.5
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -37,6 +37,7 @@ extra-deps:
 - multistate-0.8.0.1
 - primes-0.2.1.0
 - resolv-0.1.1.2
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -10,6 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 - apply-refact-0.6.0.0
 - butcher-1.3.2.1
@@ -20,14 +23,14 @@ extra-deps:
 - data-tree-print-0.1.0.2
 - floskell-0.10.0
 - haddock-api-2.21.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - monoid-subclasses-0.4.6.1

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -30,6 +30,7 @@ extra-deps:
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -10,20 +10,23 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 - butcher-1.3.2.1
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.0
 - haddock-api-2.21.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -31,6 +31,7 @@ extra-deps:
 - monad-memo-0.4.1
 - multistate-0.8.0.1
 - optparse-simple-0.1.0
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -10,20 +10,23 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 - butcher-1.3.2.1
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.0
 - haddock-api-2.21.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -29,6 +29,7 @@ extra-deps:
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -10,19 +10,22 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 - butcher-1.3.2.1
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.0
 - haddock-api-2.22.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - haskell-src-exts-1.21.0
 - hlint-2.1.17
 - hoogle-5.0.17.6
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -30,6 +30,7 @@ extra-deps:
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -10,6 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 - ansi-terminal-0.8.2
 - butcher-1.3.2.1
@@ -19,11 +22,11 @@ extra-deps:
 - floskell-0.10.0
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.22.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - hlint-2.1.17
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,6 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
+- ../lsp-test
+- ../haskell-lsp
+- ../haskell-lsp/haskell-lsp-types
 
 - ansi-terminal-0.8.2
 - butcher-1.3.2.1
@@ -19,11 +22,11 @@ extra-deps:
 - floskell-0.10.0
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.22.0
-- haskell-lsp-0.11.0.0
-- haskell-lsp-types-0.11.0.0
+# - haskell-lsp-0.12.1.0
+# - haskell-lsp-types-0.12.1.0
 - hlint-2.1.17
 - hsimport-0.8.8
-- lsp-test-0.5.2.0
+# - lsp-test-0.5.2.1
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,9 +10,9 @@ extra-deps:
 - ./submodules/ghc-mod
 - ./submodules/ghc-mod/core
 - ./submodules/ghc-mod/ghc-project-types
-- ../lsp-test
-- ../haskell-lsp
-- ../haskell-lsp/haskell-lsp-types
+- ./submodules/haskell-lsp
+- ./submodules/haskell-lsp/haskell-lsp-types
+- ./submodules/lsp-test
 
 - ansi-terminal-0.8.2
 - butcher-1.3.2.1
@@ -30,6 +30,7 @@ extra-deps:
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1
+- rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - yaml-0.8.32


### PR DESCRIPTION
- It uses `rope-utf16-splay` instead of `yi-rope`
- Moving some functionality and types from `haskell-ide-engine` to `haskell-lsp`, to benefit other LSP servers based on it
- It is a step toward bringing in the `hie-bios` being worked on by @mpickering 

This is WIP pending merges of 
- https://github.com/alanz/haskell-lsp/pull/164
- https://github.com/alanz/lsp-test/tree/az-hie-bios