### PR TITLE
Narrow ghc mod core

### DIFF
--- a/app/HieWrapper.hs
+++ b/app/HieWrapper.hs
@@ -10,6 +10,7 @@ import           Data.List
 import           Data.Foldable
 import           Data.Version                          (showVersion)
 import qualified GhcMod.Monad                          as GM
+import qualified GhcMod.Monad.Types                    as GM
 import qualified GhcMod.Types                          as GM
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.Options

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -107,7 +107,6 @@ executable hie
   other-modules:       Paths_haskell_ide_engine
   build-depends:       base
                      , directory
-                     , ghc-mod-core
                      , haskell-ide-engine
                      , haskell-lsp
                      , hie-plugin-api

--- a/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
@@ -9,7 +9,6 @@ import qualified GHC
 import           GHC                               (TypecheckedModule)
 import qualified SrcLoc                            as GHC
 import qualified Var
--- import qualified GhcMod.Gap                        as GM ( GhcRn, GhcTc, GhcPs )
 import qualified GhcModCore                        as GM ( GhcRn, GhcTc, GhcPs )
 
 import           Language.Haskell.LSP.Types

--- a/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
@@ -9,7 +9,8 @@ import qualified GHC
 import           GHC                               (TypecheckedModule)
 import qualified SrcLoc                            as GHC
 import qualified Var
-import qualified GhcMod.Gap                        as GM ( GhcRn, GhcTc, GhcPs )
+-- import qualified GhcMod.Gap                        as GM ( GhcRn, GhcTc, GhcPs )
+import qualified GhcModCore                        as GM ( GhcRn, GhcTc, GhcPs )
 
 import           Language.Haskell.LSP.Types
 

--- a/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ArtifactMap.hs
@@ -9,7 +9,7 @@ import qualified GHC
 import           GHC                               (TypecheckedModule)
 import qualified SrcLoc                            as GHC
 import qualified Var
-import qualified GhcMod.Gap                        as GM
+import qualified GhcMod.Gap                        as GM ( GhcRn, GhcTc, GhcPs )
 
 import           Language.Haskell.LSP.Types
 

--- a/hie-plugin-api/Haskell/Ide/Engine/Context.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Context.hs
@@ -3,7 +3,6 @@ module Haskell.Ide.Engine.Context where
 import Data.Generics
 import Language.Haskell.LSP.Types
 import GHC
--- import qualified GhcMod.Gap as GM (GhcPs) -- for GHC 8.2.2
 import qualified GhcModCore as GM (GhcPs) -- for GHC 8.2.2
 import Haskell.Ide.Engine.PluginUtils
 

--- a/hie-plugin-api/Haskell/Ide/Engine/Context.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Context.hs
@@ -3,7 +3,8 @@ module Haskell.Ide.Engine.Context where
 import Data.Generics
 import Language.Haskell.LSP.Types
 import GHC
-import GhcMod.Gap (GhcPs) -- for GHC 8.2.2
+-- import qualified GhcMod.Gap as GM (GhcPs) -- for GHC 8.2.2
+import qualified GhcModCore as GM (GhcPs) -- for GHC 8.2.2
 import Haskell.Ide.Engine.PluginUtils
 
 -- | A context of a declaration in the program
@@ -20,7 +21,7 @@ data Context = TypeContext
 getContext :: Position -> ParsedModule -> Maybe Context
 getContext pos pm = everything join (Nothing `mkQ` go `extQ` goInline) decl
   where decl = hsmodDecls $ unLoc $ pm_parsed_source pm
-        go :: LHsDecl GhcPs -> Maybe Context
+        go :: LHsDecl GM.GhcPs -> Maybe Context
         go (L (RealSrcSpan r) (SigD {}))
           | pos `isInsideRange` r = Just TypeContext
           | otherwise = Nothing
@@ -28,7 +29,7 @@ getContext pos pm = everything join (Nothing `mkQ` go `extQ` goInline) decl
           | pos `isInsideRange` r = Just ValueContext
           | otherwise = Nothing
         go _ = Nothing
-        goInline :: GHC.LHsType GhcPs -> Maybe Context
+        goInline :: GHC.LHsType GM.GhcPs -> Maybe Context
         goInline (GHC.L (GHC.RealSrcSpan r) _)
           | pos `isInsideRange` r = Just TypeContext
           | otherwise = Nothing

--- a/hie-plugin-api/Haskell/Ide/Engine/Ghc.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Ghc.hs
@@ -21,18 +21,18 @@ import           Bag
 import           Control.Monad.IO.Class
 import           Data.IORef
 import qualified Data.Map.Strict                   as Map
+import           Data.Monoid ((<>))
 import qualified Data.Set                          as Set
 import qualified Data.Text                         as T
 import           ErrUtils
-import qualified GhcMod.DynFlags                   as GM
-import qualified GhcMod.Error                      as GM
-import qualified GhcMod.Gap                        as GM
-import qualified GhcMod.ModuleLoader               as GM
-import qualified GhcMod.Monad                      as GM
-import           Data.Monoid ((<>))
-import qualified GhcMod.Target                     as GM
-import qualified GhcMod.Types                      as GM
-import qualified GhcMod.Utils                      as GM
+import qualified GhcMod.DynFlags                   as GM ( withDynFlags )
+import qualified GhcMod.Error                      as GM ( gcatches, GHandler(..), ghcExceptionDoc )
+import qualified GhcMod.Gap                        as GM ( mkErrStyle', renderGm )
+import qualified GhcMod.ModuleLoader               as GM ( getModulesGhc' )
+import qualified GhcMod.Monad                      as GM ( GmlT(..), getMMappedFiles, GmState(..), GhcModT, cradle )
+import qualified GhcMod.Target                     as GM ( cabalResolvedComponents )
+import qualified GhcMod.Types                      as GM ( IOish, GhcModError(..), GmGhcSession(..), GhcModState(..), GmModuleGraph(..), Cradle(..), gmcHomeModuleGraph )
+import qualified GhcMod.Utils                      as GM ( mkRevRedirMapFunc )
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils

--- a/hie-plugin-api/Haskell/Ide/Engine/Ghc.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Ghc.hs
@@ -26,15 +26,6 @@ import qualified Data.Set                          as Set
 import qualified Data.Text                         as T
 import           ErrUtils
 
--- import qualified GhcMod.DynFlags                   as GM ( withDynFlags )
--- import qualified GhcMod.Error                      as GM ( gcatches, GHandler(..), ghcExceptionDoc )
--- import qualified GhcMod.Gap                        as GM ( mkErrStyle', renderGm )
--- import qualified GhcMod.ModuleLoader               as GM ( getModulesGhc' )
--- import qualified GhcMod.Monad                      as GM ( GmlT(..), getMMappedFiles, GmState(..), GhcModT, cradle )
--- import qualified GhcMod.Target                     as GM ( cabalResolvedComponents )
--- import qualified GhcMod.Types                      as GM ( IOish, GhcModError(..), GmGhcSession(..), GhcModState(..), GmModuleGraph(..), Cradle(..), gmcHomeModuleGraph )
--- import qualified GhcMod.Utils                      as GM ( mkRevRedirMapFunc )
-
 import qualified GhcModCore                   as GM ( withDynFlags
                                                     , gcatches, GHandler(..), ghcExceptionDoc
                                                     , mkErrStyle', renderGm

--- a/hie-plugin-api/Haskell/Ide/Engine/Ghc.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Ghc.hs
@@ -25,14 +25,25 @@ import           Data.Monoid ((<>))
 import qualified Data.Set                          as Set
 import qualified Data.Text                         as T
 import           ErrUtils
-import qualified GhcMod.DynFlags                   as GM ( withDynFlags )
-import qualified GhcMod.Error                      as GM ( gcatches, GHandler(..), ghcExceptionDoc )
-import qualified GhcMod.Gap                        as GM ( mkErrStyle', renderGm )
-import qualified GhcMod.ModuleLoader               as GM ( getModulesGhc' )
-import qualified GhcMod.Monad                      as GM ( GmlT(..), getMMappedFiles, GmState(..), GhcModT, cradle )
-import qualified GhcMod.Target                     as GM ( cabalResolvedComponents )
-import qualified GhcMod.Types                      as GM ( IOish, GhcModError(..), GmGhcSession(..), GhcModState(..), GmModuleGraph(..), Cradle(..), gmcHomeModuleGraph )
-import qualified GhcMod.Utils                      as GM ( mkRevRedirMapFunc )
+
+-- import qualified GhcMod.DynFlags                   as GM ( withDynFlags )
+-- import qualified GhcMod.Error                      as GM ( gcatches, GHandler(..), ghcExceptionDoc )
+-- import qualified GhcMod.Gap                        as GM ( mkErrStyle', renderGm )
+-- import qualified GhcMod.ModuleLoader               as GM ( getModulesGhc' )
+-- import qualified GhcMod.Monad                      as GM ( GmlT(..), getMMappedFiles, GmState(..), GhcModT, cradle )
+-- import qualified GhcMod.Target                     as GM ( cabalResolvedComponents )
+-- import qualified GhcMod.Types                      as GM ( IOish, GhcModError(..), GmGhcSession(..), GhcModState(..), GmModuleGraph(..), Cradle(..), gmcHomeModuleGraph )
+-- import qualified GhcMod.Utils                      as GM ( mkRevRedirMapFunc )
+
+import qualified GhcModCore                   as GM ( withDynFlags
+                                                    , gcatches, GHandler(..), ghcExceptionDoc
+                                                    , mkErrStyle', renderGm
+                                                    , getModulesGhc'
+                                                    , GmlT(..), getMMappedFiles, GmState(..), GhcModT, cradle
+                                                    , cabalResolvedComponents
+                                                    , IOish, GhcModError(..), GmGhcSession(..), GhcModState(..), GmModuleGraph(..), Cradle(..), gmcHomeModuleGraph
+                                                    , mkRevRedirMapFunc )
+
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils

--- a/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
@@ -8,7 +8,8 @@ import qualified Data.Map as Map
 import           Data.Dynamic (Dynamic)
 import           Data.Typeable (TypeRep)
 
-import qualified GhcMod.Types                      as GM ( Cradle(..) )
+-- import qualified GhcMod.Types                      as GM ( Cradle(..) )
+import qualified GhcModCore                      as GM ( Cradle(..) )
 
 import           GHC                               (TypecheckedModule, ParsedModule)
 

--- a/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
@@ -8,7 +8,6 @@ import qualified Data.Map as Map
 import           Data.Dynamic (Dynamic)
 import           Data.Typeable (TypeRep)
 
--- import qualified GhcMod.Types                      as GM ( Cradle(..) )
 import qualified GhcModCore                      as GM ( Cradle(..) )
 
 import           GHC                               (TypecheckedModule, ParsedModule)

--- a/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
@@ -8,7 +8,7 @@ import qualified Data.Map as Map
 import           Data.Dynamic (Dynamic)
 import           Data.Typeable (TypeRep)
 
-import qualified GhcMod.Types                      as GM
+import qualified GhcMod.Types                      as GM ( Cradle(..) )
 
 import           GHC                               (TypecheckedModule, ParsedModule)
 

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -35,10 +35,16 @@ import           Exception (ExceptionMonad)
 import           System.Directory
 import           System.FilePath
 
-import qualified GhcMod.Cradle as GM ( findCradle' )
-import qualified GhcMod.Monad  as GM ( GmEnv(..), GmLog(..), GmlT(..), GmOut(..), cradle, options )
-import qualified GhcMod.Types  as GM ( Cradle(..), GhcModEnv(..), MonadIO(..), Options(..) )
-import qualified GhcMod.Utils  as GM ( mkRevRedirMapFunc )
+-- import qualified GhcMod.Cradle as GM ( findCradle' )
+-- import qualified GhcMod.Monad  as GM ( GmEnv(..), GmLog(..), GmlT(..), GmOut(..), cradle, options )
+-- import qualified GhcMod.Types  as GM ( Cradle(..), GhcModEnv(..), MonadIO(..), Options(..) )
+-- import qualified GhcMod.Utils  as GM ( mkRevRedirMapFunc )
+
+import qualified GhcModCore as GM ( findCradle'
+                                  , GmEnv(..), GmLog(..), GmlT(..), GmOut(..), cradle, options
+                                  , Cradle(..), GhcModEnv(..), MonadIO(..), Options(..)
+                                  , mkRevRedirMapFunc )
+
 import qualified GHC           as GHC
 
 import           Haskell.Ide.Engine.ArtifactMap

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -35,11 +35,6 @@ import           Exception (ExceptionMonad)
 import           System.Directory
 import           System.FilePath
 
--- import qualified GhcMod.Cradle as GM ( findCradle' )
--- import qualified GhcMod.Monad  as GM ( GmEnv(..), GmLog(..), GmlT(..), GmOut(..), cradle, options )
--- import qualified GhcMod.Types  as GM ( Cradle(..), GhcModEnv(..), MonadIO(..), Options(..) )
--- import qualified GhcMod.Utils  as GM ( mkRevRedirMapFunc )
-
 import qualified GhcModCore as GM ( findCradle'
                                   , GmEnv(..), GmLog(..), GmlT(..), GmOut(..), cradle, options
                                   , Cradle(..), GhcModEnv(..), MonadIO(..), Options(..)

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -35,10 +35,10 @@ import           Exception (ExceptionMonad)
 import           System.Directory
 import           System.FilePath
 
-import qualified GhcMod.Cradle as GM
-import qualified GhcMod.Monad  as GM
-import qualified GhcMod.Types  as GM
-import qualified GhcMod.Utils  as GM
+import qualified GhcMod.Cradle as GM ( findCradle' )
+import qualified GhcMod.Monad  as GM ( GmEnv(..), GmLog(..), GmlT(..), GmOut(..), cradle, options )
+import qualified GhcMod.Types  as GM ( Cradle(..), GhcModEnv(..), MonadIO(..), Options(..) )
+import qualified GhcMod.Utils  as GM ( mkRevRedirMapFunc )
 import qualified GHC           as GHC
 
 import           Haskell.Ide.Engine.ArtifactMap

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -45,7 +45,7 @@ import           Data.Monoid
 import qualified Data.Text                             as T
 import qualified Data.Text.IO                          as T
 import           Data.Maybe
-import qualified GhcMod.Utils                          as GM
+import qualified GhcMod.Utils                          as GM ( makeAbsolute' )
 import           FastString
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.MonadFunctions

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -45,7 +45,6 @@ import           Data.Monoid
 import qualified Data.Text                             as T
 import qualified Data.Text.IO                          as T
 import           Data.Maybe
--- import qualified GhcMod.Utils                          as GM ( makeAbsolute' )
 import qualified GhcModCore                          as GM ( makeAbsolute' )
 import           FastString
 import           Haskell.Ide.Engine.MonadTypes

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -45,7 +45,8 @@ import           Data.Monoid
 import qualified Data.Text                             as T
 import qualified Data.Text.IO                          as T
 import           Data.Maybe
-import qualified GhcMod.Utils                          as GM ( makeAbsolute' )
+-- import qualified GhcMod.Utils                          as GM ( makeAbsolute' )
+import qualified GhcModCore                          as GM ( makeAbsolute' )
 import           FastString
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.MonadFunctions

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -117,8 +117,12 @@ import           Data.Typeable                  ( TypeRep
                                                 , Typeable
                                                 )
 
-import qualified GhcMod.Monad                  as GM ( GhcModT, runGhcModT, GmlT(..), gmlGetSession, gmlSetSession )
-import qualified GhcMod.Types                  as GM ( MonadIO(..), GmLogLevel(..), Options(..), defaultOptions, OutputOpts(..) )
+-- import qualified GhcMod.Monad                  as GM ( GhcModT, runGhcModT, GmlT(..), gmlGetSession, gmlSetSession )
+-- import qualified GhcMod.Types                  as GM ( MonadIO(..), GmLogLevel(..), Options(..), defaultOptions, OutputOpts(..) )
+
+import qualified GhcModCore                  as GM ( GhcModT, runGhcModT, GmlT(..), gmlGetSession, gmlSetSession
+                                                   , MonadIO(..), GmLogLevel(..), Options(..), defaultOptions, OutputOpts(..) )
+
 import           GHC.Generics
 import           GHC                            ( HscEnv )
 import qualified DynFlags      as GHC

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -117,8 +117,8 @@ import           Data.Typeable                  ( TypeRep
                                                 , Typeable
                                                 )
 
-import qualified GhcMod.Monad                  as GM
-import qualified GhcMod.Types                  as GM
+import qualified GhcMod.Monad                  as GM ( GhcModT, runGhcModT, GmlT(..), gmlGetSession, gmlSetSession )
+import qualified GhcMod.Types                  as GM ( MonadIO(..), GmLogLevel(..), Options(..), defaultOptions, OutputOpts(..) )
 import           GHC.Generics
 import           GHC                            ( HscEnv )
 import qualified DynFlags      as GHC

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -117,9 +117,6 @@ import           Data.Typeable                  ( TypeRep
                                                 , Typeable
                                                 )
 
--- import qualified GhcMod.Monad                  as GM ( GhcModT, runGhcModT, GmlT(..), gmlGetSession, gmlSetSession )
--- import qualified GhcMod.Types                  as GM ( MonadIO(..), GmLogLevel(..), Options(..), defaultOptions, OutputOpts(..) )
-
 import qualified GhcModCore                  as GM ( GhcModT, runGhcModT, GmlT(..), gmlGetSession, gmlSetSession
                                                    , MonadIO(..), GmLogLevel(..), Options(..), defaultOptions, OutputOpts(..) )
 

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -111,9 +111,9 @@ lintCmd = CmdSync $ \uri -> do
 -- AZ:TODO: Why is this in IdeGhcM?
 lintCmd' :: Uri -> IdeGhcM (IdeResult PublishDiagnosticsParams)
 lintCmd' uri = pluginGetFile "lintCmd: " uri $ \fp -> do
-  eitherErrorResult <- GM.withMappedFile fp $ \file' -> 
+  eitherErrorResult <- GM.withMappedFile fp $ \file' ->
     liftIO (try $ runExceptT $ runLintCmd file' [] :: IO (Either IOException (Either [Diagnostic] [Idea])))
-  
+
   case eitherErrorResult of
     Left err ->
       return

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -19,7 +19,7 @@ import           Data.Maybe
 import           Data.Monoid                       ((<>))
 import qualified Data.Text                         as T
 import           GHC.Generics
-import qualified GhcMod.Utils                      as GM
+import qualified GhcModCore                      as GM ( mkRevRedirMapFunc, withMappedFile )
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -22,7 +22,7 @@ module Haskell.Ide.Engine.Plugin.GhcMod
   , extractRenamableTerms
   , extractUnusedTerm
   , infoCmd'
-  , lintCmd'
+  -- , lintCmd'
   , newTypeCmd
   , symbolProvider
   ) where
@@ -37,8 +37,10 @@ import           Data.Monoid ((<>))
 import qualified Data.Text                         as T
 import           Name
 import           GHC.Generics
-import qualified GhcMod                            as GM ( lint, info )
-import qualified GhcModCore                      as GM ( defaultLintOpts, Expression(..), pretty, defaultLintOpts, Expression(..), GhcPs )
+-- import qualified GhcMod                            as GM ( lint, info )
+import qualified GhcMod                            as GM ( info )
+-- import qualified GhcModCore                        as GM ( defaultLintOpts, Expression(..), pretty, defaultLintOpts, Expression(..), GhcPs )
+import qualified GhcModCore                        as GM ( Expression(..), pretty, Expression(..), GhcPs )
 import           Haskell.Ide.Engine.Ghc
 import           Haskell.Ide.Engine.MonadTypes hiding (defaultOptions)
 import           Haskell.Ide.Engine.PluginUtils
@@ -65,7 +67,7 @@ ghcmodDescriptor plId = PluginDescriptor
               <> "from modern IDEs in any editor."
   , pluginCommands =
       [ PluginCommand "check" "check a file for GHC warnings and errors" checkCmd
-      , PluginCommand "lint" "Check files using `hlint'" lintCmd
+      -- , PluginCommand "lint" "Check files using `hlint'" lintCmd
       , PluginCommand "info" "Look up an identifier in the context of FILE (like ghci's `:info')" infoCmd
       , PluginCommand "type" "Get the type of the expression under (LINE,COL)" typeCmd
       , PluginCommand "casesplit" "Generate a pattern match for a binding under (LINE,COL)" Hie.splitCaseCmd
@@ -84,14 +86,14 @@ checkCmd = CmdSync setTypecheckedModule
 
 -- ---------------------------------------------------------------------
 
-lintCmd :: CommandFunc Uri T.Text
-lintCmd = CmdSync lintCmd'
+-- lintCmd :: CommandFunc Uri T.Text
+-- lintCmd = CmdSync lintCmd'
 
--- TODO:AZ why are we not calling hlint directly?
-lintCmd' :: Uri -> IdeGhcM (IdeResult T.Text)
-lintCmd' uri =
-  pluginGetFile "lint: " uri $ \file ->
-    fmap T.pack <$> Hie.runGhcModCommand (GM.lint GM.defaultLintOpts file)
+-- -- TODO:AZ why are we not calling hlint directly?
+-- lintCmd' :: Uri -> IdeGhcM (IdeResult T.Text)
+-- lintCmd' uri =
+--   pluginGetFile "lint: " uri $ \file ->
+--     fmap T.pack <$> Hie.runGhcModCommand (GM.lint GM.defaultLintOpts file)
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -12,7 +12,6 @@ module Haskell.Ide.Engine.Plugin.GhcMod
   -- * For tests
   , Bindings(..)
   , FunctionSig(..)
-  , InfoParams(..)
   , TypeDef(..)
   , TypeParams(..)
   , TypedHoles(..) -- only to keep the GHC 8.4 and below unused field warning happy
@@ -88,26 +87,8 @@ checkCmd = CmdSync setTypecheckedModule
 customOptions :: Options
 customOptions = defaultOptions { fieldLabelModifier = camelTo2 '_' . drop 2}
 
-data InfoParams =
-  IP { ipFile :: Uri
-     , ipExpr :: T.Text
-     } deriving (Eq,Show,Generic)
-
-instance FromJSON InfoParams where
-  parseJSON = genericParseJSON customOptions
-instance ToJSON InfoParams where
-  toJSON = genericToJSON customOptions
-
--- infoCmd :: CommandFunc InfoParams T.Text
--- infoCmd = CmdSync $ \(IP uri expr) ->
---   infoCmd' uri expr
-
--- infoCmd' :: Uri -> T.Text -> IdeGhcM (IdeResult T.Text)
--- infoCmd' uri expr =
---   pluginGetFile "info: " uri $ \file ->
---     fmap T.pack <$> Hie.runGhcModCommand (GM.info file (GM.Expression (T.unpack expr)))
-
 -- ---------------------------------------------------------------------
+
 data TypeParams =
   TP { tpIncludeConstraints :: Bool
      , tpFile               :: Uri
@@ -123,7 +104,6 @@ typeCmd :: CommandFunc TypeParams [(Range,T.Text)]
 typeCmd = CmdSync $ \(TP _bool uri pos) ->
   liftToGhc $ newTypeCmd pos uri
 
--- AZ: currently only used in tests, but
 newTypeCmd :: Position -> Uri -> IdeM (IdeResult [(Range, T.Text)])
 newTypeCmd newPos uri =
   pluginGetFile "newTypeCmd: " uri $ \fp ->

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -37,10 +37,8 @@ import           Data.Monoid ((<>))
 import qualified Data.Text                         as T
 import           Name
 import           GHC.Generics
-import qualified GhcMod                            as GM
-import qualified GhcMod.Gap                        as GM
-import qualified GhcMod.SrcUtils                   as GM
-import qualified GhcMod.Types                      as GM
+import qualified GhcMod                            as GM ( lint, info )
+import qualified GhcModCore                      as GM ( defaultLintOpts, Expression(..), pretty, defaultLintOpts, Expression(..), GhcPs )
 import           Haskell.Ide.Engine.Ghc
 import           Haskell.Ide.Engine.MonadTypes hiding (defaultOptions)
 import           Haskell.Ide.Engine.PluginUtils
@@ -89,6 +87,7 @@ checkCmd = CmdSync setTypecheckedModule
 lintCmd :: CommandFunc Uri T.Text
 lintCmd = CmdSync lintCmd'
 
+-- TODO:AZ why are we not calling hlint directly?
 lintCmd' :: Uri -> IdeGhcM (IdeResult T.Text)
 lintCmd' uri =
   pluginGetFile "lint: " uri $ \file ->

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -21,8 +21,11 @@ import qualified Data.Text                                    as T
 import qualified Data.Text.IO                                 as T
 import           Exception
 import           GHC.Generics                                 (Generic)
-import qualified GhcMod.Error                                 as GM
-import qualified GhcMod.Utils                                 as GM
+-- import qualified GhcMod.Error                                 as GM
+-- import qualified GhcMod.Utils                                 as GM
+
+import qualified GhcModCore                                 as GM (GhcModError(..),withMappedFile,GHandler(..),gcatches)
+
 import           Haskell.Ide.Engine.ArtifactMap
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes

--- a/src/Haskell/Ide/Engine/Plugin/HaRe.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HaRe.hs
@@ -21,10 +21,8 @@ import qualified Data.Text                                    as T
 import qualified Data.Text.IO                                 as T
 import           Exception
 import           GHC.Generics                                 (Generic)
--- import qualified GhcMod.Error                                 as GM
--- import qualified GhcMod.Utils                                 as GM
 
-import qualified GhcModCore                                 as GM (GhcModError(..),withMappedFile,GHandler(..),gcatches)
+import qualified GhcModCore              as GM (GhcModError(..),withMappedFile,GHandler(..),gcatches)
 
 import           Haskell.Ide.Engine.ArtifactMap
 import           Haskell.Ide.Engine.MonadFunctions

--- a/src/Haskell/Ide/Engine/Plugin/Haddock.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Haddock.hs
@@ -18,8 +18,7 @@ import Data.Function
 import Data.Maybe
 import Data.List
 import           GHC
-import qualified GhcMod.LightGhc                              as GM
-import qualified GhcMod.Monad                                 as GM
+import qualified GhcModCore                           as GM ( LightGhc(..), runLightGhc )
 import           GhcMonad
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -17,7 +17,7 @@ import           Data.Monoid                    ( (<>) )
 import qualified Data.Text                     as T
 import qualified Data.Text.IO                  as T
 import qualified GHC.Generics                  as Generics
-import qualified GhcMod.Utils                  as GM
+import qualified GhcModCore                    as GM ( mkRevRedirMapFunc, withMappedFile )
 import           HsImport
 import           Haskell.Ide.Engine.Config
 import           Haskell.Ide.Engine.MonadTypes

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -44,7 +44,7 @@ import           System.FilePath
 #endif
 import           Control.Monad.IO.Class
 import           System.Directory
-import qualified GhcMod.Utils                  as GM
+import qualified GhcModCore                  as GM ( mkRevRedirMapFunc )
 import           Distribution.Types.GenericPackageDescription
 import           Distribution.Types.CondTree
 import qualified Distribution.PackageDescription.PrettyPrint as PP

--- a/src/Haskell/Ide/Engine/Scheduler.hs
+++ b/src/Haskell/Ide/Engine/Scheduler.hs
@@ -32,7 +32,6 @@ import           Control.Monad
 import qualified Data.Set                      as Set
 import qualified Data.Map                      as Map
 import qualified Data.Text                     as T
-import qualified GhcMod.Types                  as GM
 import qualified Language.Haskell.LSP.Core     as Core
 import qualified Language.Haskell.LSP.Types    as J
 
@@ -348,7 +347,8 @@ ghcDispatcher env@DispatcherEnv { docVersionTVar } errorHandler callbackHandler 
 -- | Runs the passed monad only if the request identified by the passed LspId
 -- has not already been cancelled.
 unlessCancelled
-  :: GM.MonadIO m => DispatcherEnv -> J.LspId -> ErrorHandler -> m () -> m ()
+  -- :: GM.MonadIO m => DispatcherEnv -> J.LspId -> ErrorHandler -> m () -> m ()
+  :: MonadIO m => DispatcherEnv -> J.LspId -> ErrorHandler -> m () -> m ()
 unlessCancelled env lid errorHandler callback = do
   cancelled <- liftIO $ STM.atomically isCancelled
   if cancelled

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -50,18 +50,9 @@ import           FastString
 import           Finder
 import           GHC                                          hiding (getContext)
 import           GHC.Generics                                 (Generic)
--- import qualified GhcMod.Error                                 as GM
--- import qualified GhcMod.Exe.CaseSplit                         as GM
--- import qualified GhcMod.Gap                                   as GM
--- import qualified GhcMod.LightGhc                              as GM
--- import qualified GhcMod.Utils                                 as GM
 
-import qualified GhcMod.Error                                 as GM ()
-import qualified GhcMod.Exe.CaseSplit                         as GM (splits',SplitResult(..))
-import qualified GhcMod.Gap                                   as GM (listVisibleModuleNames)
-import qualified GhcMod.LightGhc                              as GM (runLightGhc)
-import qualified GhcMod.Utils                                 as GM (withMappedFile)
-import qualified GhcModCore                                 as GM (GhcModError(..))
+import qualified GhcMod                                       as GM (splits',SplitResult(..))
+import qualified GhcModCore                                   as GM (GhcModError(..), listVisibleModuleNames,runLightGhc, withMappedFile )
 
 import           Haskell.Ide.Engine.ArtifactMap
 import           Haskell.Ide.Engine.Config

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -50,11 +50,19 @@ import           FastString
 import           Finder
 import           GHC                                          hiding (getContext)
 import           GHC.Generics                                 (Generic)
-import qualified GhcMod.Error                                 as GM
-import qualified GhcMod.Exe.CaseSplit                         as GM
-import qualified GhcMod.Gap                                   as GM
-import qualified GhcMod.LightGhc                              as GM
-import qualified GhcMod.Utils                                 as GM
+-- import qualified GhcMod.Error                                 as GM
+-- import qualified GhcMod.Exe.CaseSplit                         as GM
+-- import qualified GhcMod.Gap                                   as GM
+-- import qualified GhcMod.LightGhc                              as GM
+-- import qualified GhcMod.Utils                                 as GM
+
+import qualified GhcMod.Error                                 as GM ()
+import qualified GhcMod.Exe.CaseSplit                         as GM (splits',SplitResult(..))
+import qualified GhcMod.Gap                                   as GM (listVisibleModuleNames)
+import qualified GhcMod.LightGhc                              as GM (runLightGhc)
+import qualified GhcMod.Utils                                 as GM (withMappedFile)
+import qualified GhcModCore                                 as GM (GhcModError(..))
+
 import           Haskell.Ide.Engine.ArtifactMap
 import           Haskell.Ide.Engine.Config
 import           Haskell.Ide.Engine.Context

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -38,8 +38,7 @@ import qualified Data.Set as S
 import qualified Data.SortedList as SL
 import qualified Data.Text as T
 import           Data.Text.Encoding
-import qualified GhcMod.Monad.Types       as GM
-import qualified GhcModCore               as GM
+import qualified GhcModCore               as GM ( loadMappedFileSource, getMMappedFiles )
 import           Haskell.Ide.Engine.Config
 import qualified Haskell.Ide.Engine.Ghc   as HIE
 import           Haskell.Ide.Engine.LSP.CodeActions

--- a/test/dispatcher/Main.hs
+++ b/test/dispatcher/Main.hs
@@ -166,7 +166,7 @@ funcSpec = describe "functional dispatch" $ do
       -- And now we get the deferred response (once the module is loaded)
       ("req1",Right res) <- atomically $ readTChan logChan
       let Just ds = fromDynJSON res :: Maybe [DocumentSymbol]
-          DocumentSymbol mainName _ mainKind _ mainRange _ _ = head ds 
+          DocumentSymbol mainName _ mainKind _ mainRange _ _ = head ds
       mainName `shouldBe` "main"
       mainKind `shouldBe` SkFunction
       mainRange `shouldBe` Range (Position 2 0) (Position 2 23)

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -6,7 +6,7 @@ import           Control.Exception
 import qualified Data.HashMap.Strict                 as H
 import qualified Data.Map                            as Map
 #if __GLASGOW_HASKELL__ < 804
-import           Data.Monoid
+-- import           Data.Monoid
 #endif
 import qualified Data.Set                            as S
 -- import qualified Data.Text                           as T

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -73,14 +73,14 @@ ghcmodSpec =
 
     -- ---------------------------------
 
-    it "runs the info command" $ withCurrentDirectory "./test/testdata" $ do
-      fp <- makeAbsolute "HaReRename.hs"
-      let uri = filePathToUri fp
-          act = infoCmd' uri "main"
-          arg = IP uri "main"
-          res = IdeResultOk "main :: IO () \t-- Defined at HaReRename.hs:2:1\n"
-      -- ghc-mod tries to load the test file in the context of the hie project if we do not cd first.
-      testCommand testPlugins act "ghcmod" "info" arg res
+    -- it "runs the info command" $ withCurrentDirectory "./test/testdata" $ do
+    --   fp <- makeAbsolute "HaReRename.hs"
+    --   let uri = filePathToUri fp
+    --       act = infoCmd' uri "main"
+    --       arg = IP uri "main"
+    --       res = IdeResultOk "main :: IO () \t-- Defined at HaReRename.hs:2:1\n"
+    --   -- ghc-mod tries to load the test file in the context of the hie project if we do not cd first.
+    --   testCommand testPlugins act "ghcmod" "info" arg res
 
 -- ----------------------------------------------------------------------------
 
@@ -97,6 +97,7 @@ ghcmodSpec =
             ]
 
       testCommand testPlugins act "ghcmod" "type" arg res
+
     it "runs the type command, find function type" $ withCurrentDirectory "./test/testdata" $ do
       fp <- makeAbsolute "HaReRename.hs"
       let uri = filePathToUri fp

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -9,7 +9,7 @@ import qualified Data.Map                            as Map
 import           Data.Monoid
 #endif
 import qualified Data.Set                            as S
-import qualified Data.Text                           as T
+-- import qualified Data.Text                           as T
 import           Haskell.Ide.Engine.Ghc
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Plugin.GhcMod
@@ -59,16 +59,17 @@ ghcmodSpec =
     -- ---------------------------------
 
     it "runs the lint command" $ withCurrentDirectory "./test/testdata" $ do
-      fp <- makeAbsolute "FileWithWarning.hs"
-      let uri = filePathToUri fp
-          act = lintCmd' uri
-          arg = uri
-#if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,2,2,0)))
-          res = IdeResultOk (T.pack fp <> ":6:9: Warning: Redundant do\NULFound:\NUL  do return (3 + x)\NULPerhaps:\NUL  return (3 + x)\n")
-#else
-          res = IdeResultOk (T.pack fp <> ":6:9: Warning: Redundant do\NULFound:\NUL  do return (3 + x)\NULWhy not:\NUL  return (3 + x)\n")
-#endif
-      testCommand testPlugins act "ghcmod" "lint" arg res
+      pendingWith "make sure we test this elsewhere"
+--       fp <- makeAbsolute "FileWithWarning.hs"
+--       let uri = filePathToUri fp
+--           act = lintCmd' uri
+--           arg = uri
+-- #if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,2,2,0)))
+--           res = IdeResultOk (T.pack fp <> ":6:9: Warning: Redundant do\NULFound:\NUL  do return (3 + x)\NULPerhaps:\NUL  return (3 + x)\n")
+-- #else
+--           res = IdeResultOk (T.pack fp <> ":6:9: Warning: Redundant do\NULFound:\NUL  do return (3 + x)\NULWhy not:\NUL  return (3 + x)\n")
+-- #endif
+--       testCommand testPlugins act "ghcmod" "lint" arg res
 
     -- ---------------------------------
 

--- a/test/unit/JsonSpec.hs
+++ b/test/unit/JsonSpec.hs
@@ -37,7 +37,7 @@ jsonSpec = do
   describe "General JSON instances round trip" $ do
   -- Plugin params
     prop "ApplyOneParams"    (propertyJsonRoundtrip :: ApplyOneParams -> Bool)
-    prop "InfoParams"        (propertyJsonRoundtrip :: InfoParams -> Bool)
+    prop "TypeParams"        (propertyJsonRoundtrip :: TypeParams -> Bool)
     prop "HarePoint"         (propertyJsonRoundtrip :: HarePoint -> Bool)
     prop "HarePointWithText" (propertyJsonRoundtrip :: HarePointWithText -> Bool)
     prop "HareRange"         (propertyJsonRoundtrip :: HareRange -> Bool)
@@ -62,8 +62,8 @@ smallList = resize 3 . listOf
 instance Arbitrary ApplyOneParams where
   arbitrary = AOP <$> arbitrary <*> arbitrary <*>  arbitrary
 
-instance Arbitrary InfoParams where
-  arbitrary = IP <$> arbitrary <*> arbitrary
+instance Arbitrary TypeParams where
+  arbitrary = TP <$> arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary HarePoint where
   arbitrary = HP <$> arbitrary <*> arbitrary


### PR DESCRIPTION
Since ghc-mod is going to be deprecated soon, and replaced by some new shiny thing as part of @DanielG 's GSOC, this patch attempts to help the process by slimming down and documenting the actual parts of ghc-mod currently used by hie.