### PR TITLE
Change url for nix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ we talk to clients.__
 
 ### Installation with Nix
 
-Follow the instructions at https://github.com/domenkozar/hie-nix
+Follow the instructions at https://github.com/Infinisil/all-hies
 
 
 ### Installation on ArchLinux


### PR DESCRIPTION
[hie-nix](https://github.com/domenkozar/hie-nix) has now been archived and superseded by [all-hies](https://github.com/Infinisil/all-hies).