### PR TITLE
Bump resolver for ghc 8.6.3 due to lts mutation

### DIFF
--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.10 # Last GHC 8.6.3
+resolver: lts-13.11 # Last GHC 8.6.3
 packages:
 - .
 - hie-plugin-api


### PR DESCRIPTION
Closes #1236.
Caveat: On my system this still tries to use ghc 8.6.4? Although it should use ghc 8.6.3.