### PR TITLE
Improve import action of hsimport

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -152,7 +152,19 @@ renderTarget t = T.intercalate "\n" $
 -- If an error occurs, such as no hoogle database has been found,
 -- or the search term has no match, an empty list will be returned.
 searchModules :: T.Text -> IdeM [T.Text]
-searchModules = fmap (nub . take 5) . searchTargets (fmap (T.pack . fst) . targetModule)
+searchModules = fmap (map fst) . searchModules'
+
+-- | Just like 'searchModules', but includes the signature of the search term
+-- that has been found in the module.
+searchModules' :: T.Text -> IdeM [(T.Text, T.Text)]
+searchModules' = fmap (nub . take 5)
+  . searchTargets
+    (\target
+     -> (\modTarget -> (T.pack $ fst modTarget, normaliseItem . T.pack $ targetItem target))
+     <$> targetModule target)
+     where
+      normaliseItem :: T.Text -> T.Text
+      normaliseItem  = innerText . parseTags
 
 -- | Search for packages that satisfy the given search text.
 -- Will return at most five, unique results.

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE CPP               #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Haskell.Ide.Engine.Plugin.Hoogle where
@@ -5,6 +6,7 @@ module Haskell.Ide.Engine.Plugin.Hoogle where
 import           Control.Monad.IO.Class
 import           Control.Monad (join)
 import           Control.Exception
+import           Control.Applicative (liftA2)
 import           Data.Aeson
 import           Data.Bifunctor
 import           Data.Maybe
@@ -157,14 +159,23 @@ searchModules = fmap (map fst) . searchModules'
 -- | Just like 'searchModules', but includes the signature of the search term
 -- that has been found in the module.
 searchModules' :: T.Text -> IdeM [(T.Text, T.Text)]
-searchModules' = fmap (nub . take 5)
-  . searchTargets
-    (\target
-     -> (\modTarget -> (T.pack $ fst modTarget, normaliseItem . T.pack $ targetItem target))
-     <$> targetModule target)
-     where
-      normaliseItem :: T.Text -> T.Text
-      normaliseItem  = innerText . parseTags
+searchModules' = fmap (take 5 . nub) . searchTargets retrieveModuleAndSignature
+  where
+    -- | Hoogle results contain html like tags.
+    -- We remove them with `tagsoup` here.
+    -- So, if something hoogle related shows html tags,
+    -- then maybe this function is responsible.
+    normaliseItem :: T.Text -> T.Text
+    normaliseItem = innerText . parseTags
+
+    retrieveModuleAndSignature :: Target -> Maybe (T.Text, T.Text)
+    retrieveModuleAndSignature target = liftA2 (,) (packModuleName target) (packSymbolSignature target)
+
+    packModuleName :: Target -> Maybe T.Text
+    packModuleName = fmap (T.pack . fst) . targetModule
+
+    packSymbolSignature :: Target -> Maybe T.Text
+    packSymbolSignature = Just . normaliseItem . T.pack . targetItem
 
 -- | Search for packages that satisfy the given search text.
 -- Will return at most five, unique results.
@@ -172,7 +183,7 @@ searchModules' = fmap (nub . take 5)
 -- If an error occurs, such as no hoogle database has been found,
 -- or the search term has no match, an empty list will be returned.
 searchPackages :: T.Text -> IdeM [T.Text]
-searchPackages = fmap (nub . take 5) . searchTargets (fmap (T.pack . fst) . targetPackage)
+searchPackages = fmap (take 5 . nub) . searchTargets (fmap (T.pack . fst) . targetPackage)
 
 -- | Search for Targets that fit to the given Text and satisfy the given predicate.
 -- Limits the amount of matches to at most ten.

--- a/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Hoogle.hs
@@ -44,10 +44,10 @@ hoogleDescriptor plId = PluginDescriptor
 
 -- ---------------------------------------------------------------------
 
-data HoogleError 
+data HoogleError
   = NoDb
   | DbFail T.Text
-  | NoResults 
+  | NoResults
   deriving (Eq,Ord,Show)
 
 newtype HoogleDb = HoogleDb (Maybe FilePath)

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -440,7 +440,7 @@ codeActionProvider plId docId _ context = do
         Hiding _ -> "hiding "
         -- ^ Note, that it must never happen
         -- in combination with `symbolType == Nothing`
-        Import _ -> ""
+        Import _ -> " "
       <> case symbolType of
         Just s  -> case s of
           Only sym  -> "(" <> sym <> ")"

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -470,27 +470,27 @@ codeActionProvider plId docId _ context = do
 -- signature of an unknown function.
 -- If this is not possible, Nothing is returned.
 extractImportableTerm :: T.Text -> Maybe (T.Text, SymbolImport SymbolType)
-extractImportableTerm dirtyMsg =
-  let extractedTerm = asum
-        [ (\name -> (name, Import Symbol))
-            <$> T.stripPrefix "Variable not in scope: " importMsg
-        , (\name -> (T.init name, Import Type))
-            <$> T.stripPrefix
-              "Not in scope: type constructor or class ‘"
-              importMsg
-        , (\name -> (name, Import Constructor))
-            <$> T.stripPrefix "Data constructor not in scope: " importMsg]
-  in do
-       (n, s) <- extractedTerm
-       let n' = T.strip n
-       return (n', s)
+extractImportableTerm dirtyMsg = do
+  (n, s) <- extractedTerm
+  let n' = T.strip n
+  return (n', s)
   where
     importMsg = head
-       -- Get rid of the rename suggestion parts
+      -- Get rid of the rename suggestion parts
       $ T.splitOn "Perhaps you meant "
       $ T.replace "\n" " "
-       -- Get rid of trailing/leading whitespace on each individual line
+      -- Get rid of trailing/leading whitespace on each individual line
       $ T.unlines
       $ map T.strip
       $ T.lines
       $ T.replace "• " "" dirtyMsg
+
+    extractedTerm = asum
+      [ (\name -> (name, Import Symbol))
+          <$> T.stripPrefix "Variable not in scope: " importMsg
+      , (\name -> (T.init name, Import Type))
+          <$> T.stripPrefix
+            "Not in scope: type constructor or class ‘"
+            importMsg
+      , (\name -> (name, Import Constructor))
+          <$> T.stripPrefix "Data constructor not in scope: " importMsg]

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -437,15 +437,15 @@ codeActionProvider plId docId _ context = do
     title = "Import module "
       <> modName
       <> case termType importDiagnostic of
-        Hiding _ -> "hiding "
+        Hiding _ -> "hiding"
         -- ^ Note, that it must never happen
         -- in combination with `symbolType == Nothing`
-        Import _ -> " "
+        Import _ -> ""
       <> case symbolType of
         Just s  -> case s of
-          Only sym  -> "(" <> sym <> ")"
-          AllOf dt -> "(" <> dt <> " (..))"
-          OneOf dt sym -> "(" <> dt <> " (" <> sym <> "))"
+          Only sym  -> " (" <> sym <> ")"
+          AllOf dt -> " (" <> dt <> " (..))"
+          OneOf dt sym -> " (" <> dt <> " (" <> sym <> "))"
         Nothing -> ""
 
     importStyleParam :: ImportStyle

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -157,7 +157,7 @@ spec = describe "code actions" $ do
         [ "{-# LANGUAGE NoImplicitPrelude #-}"
         , "import           System.IO                     ( IO"
         , "                                               , hPutStrLn"
-        , "                                               , stdout"
+        , "                                               , stderr"
         , "                                               )"
         , "import           Prelude                       ( Bool(..) )"
         , "import           Control.Monad                 ( when )"
@@ -169,7 +169,7 @@ spec = describe "code actions" $ do
         , "main :: IO ()"
         , "main ="
         , "    when True"
-        , "        $ hPutStrLn stdout"
+        , "        $ hPutStrLn stderr"
         , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
         ]
       ]
@@ -199,7 +199,7 @@ spec = describe "code actions" $ do
         ]
       ,  -- Complex imports for Constructos and functions
         [ "{-# LANGUAGE NoImplicitPrelude #-}"
-        , "import           System.IO (IO, hPutStrLn, stdout)"
+        , "import           System.IO (IO, hPutStrLn, stderr)"
         , "import           Prelude (Bool(..))"
         , "import           Control.Monad (when)"
         , "import           Data.Maybe (fromMaybe, Maybe(Just))"
@@ -208,7 +208,7 @@ spec = describe "code actions" $ do
         , "main :: IO ()"
         , "main ="
         , "    when True"
-        , "        $ hPutStrLn stdout"
+        , "        $ hPutStrLn stderr"
         , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
         ]
       ]
@@ -685,13 +685,13 @@ hsImportSpec formatterName [e1, e2, e3, e4] =
       let config = def { formatOnImportOn = False, formattingProvider = formatterName }
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
 
-      let wantedCodeActionTitles = [ "Import module System.IO (hPutSetrLn)"
-                                   , "Import module System.IO (stdout)"
+      let wantedCodeActionTitles = [ "Import module System.IO (hPutStrLn)"
                                    , "Import module Control.Monad (when)"
                                    , "Import module Data.Maybe (fromMaybe)"
                                    , "Import module Data.Function (($))"
-                                   , "Import module Data.Maybe (Maybe(Just))"
-                                   , "Import module Prelude (Bool(..))"
+                                   , "Import module Data.Maybe (Maybe (Just))"
+                                   , "Import module Prelude (Bool (..))"
+                                   , "Import module System.IO (stderr)"
                                    ]
 
       executeAllCodeActions doc wantedCodeActionTitles
@@ -708,12 +708,12 @@ hsImportSpec formatterName [e1, e2, e3, e4] =
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (toJSON config))
 
       let wantedCodeActionTitles = [ "Import module System.IO (hPutStrLn)"
-                                   , "Import module System.IO (stdout)"
                                    , "Import module Control.Monad (when)"
                                    , "Import module Data.Maybe (fromMaybe)"
                                    , "Import module Data.Function (($))"
-                                   , "Import module Data.Maybe (Maybe(Just))"
-                                   , "Import module Prelude (Bool(..))"
+                                   , "Import module Data.Maybe (Maybe (Just))"
+                                   , "Import module Prelude (Bool (..))"
+                                   , "Import module System.IO (stderr)"
                                    ]
 
       executeAllCodeActions doc wantedCodeActionTitles
@@ -722,7 +722,7 @@ hsImportSpec formatterName [e1, e2, e3, e4] =
       liftIO $ do
         let [l1, l2, l3, l4, l5, l6, l7, l8, l9, l10, l11, l12] = T.lines contents
         l1  `shouldBe` "{-# LANGUAGE NoImplicitPrelude #-}"
-        l2  `shouldBe` "import System.IO (IO, hPutStrLn, stdout)"
+        l2  `shouldBe` "import System.IO (IO, hPutStrLn, stderr)"
         l3  `shouldBe` "import Prelude (Bool(..))"
         l4  `shouldBe` "import Control.Monad (when)"
         l5  `shouldBe` "import Data.Maybe (fromMaybe, Maybe(Just))"
@@ -731,7 +731,7 @@ hsImportSpec formatterName [e1, e2, e3, e4] =
         l8  `shouldBe` "main :: IO ()"
         l9  `shouldBe` "main ="
         l10 `shouldBe` "    when True"
-        l11 `shouldBe` "        $ hPutStrLn stdout"
+        l11 `shouldBe` "        $ hPutStrLn stderr"
         l12 `shouldBe` "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
 
   where
@@ -754,7 +754,7 @@ hsImportSpec formatterName [e1, e2, e3, e4] =
           error
             $  "Found an unexpected amount of action. Expected 1, but got: "
             ++ show (length xs)
-            ++ "\n. Titles: " ++ show (map (^. L.title) allActions)
+            ++ ".\n Titles: " ++ show (map (^. L.title) allActions)
 
 -- Silence warnings
 hsImportSpec formatter args =

--- a/test/testdata/CodeActionImportListElaborate.hs
+++ b/test/testdata/CodeActionImportListElaborate.hs
@@ -4,5 +4,5 @@ import           System.IO (IO)
 main :: IO ()
 main =
     when True
-        $ hPutStrLn stdout
+        $ hPutStrLn stderr
         $ fromMaybe "Good night, World!" (Just "Hello, World!")

--- a/test/testdata/CodeActionImportListElaborate.hs
+++ b/test/testdata/CodeActionImportListElaborate.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+import           System.IO (IO)
+-- | Main entry point to the program
+main :: IO ()
+main =
+    when True
+        $ hPutStrLn stdout
+        $ fromMaybe "Good night, World!" (Just "Hello, World!")

--- a/test/unit/CodeActionsSpec.hs
+++ b/test/unit/CodeActionsSpec.hs
@@ -15,19 +15,22 @@ spec = do
   describe "import code actions" $ do
     it "pick up variable not in scope" $
       let msg =  "Variable not in scope: fromJust :: Maybe Integer -> t"
-        in extractImportableTerm msg `shouldBe` Just "fromJust :: Maybe Integer -> t"
+        in extractImportableTerm msg `shouldBe` Just ("fromJust :: Maybe Integer -> t", Import Symbol)
     it "pick up variable not in scope with 'perhaps you meant'" $
       let msg =  "• Variable not in scope: msgs :: T.Text\n• Perhaps you meant ‘msg’ (line 90)"
-        in extractImportableTerm msg `shouldBe` Just "msgs :: T.Text"
+        in extractImportableTerm msg `shouldBe` Just ("msgs :: T.Text", Import Symbol)
     it "pick up multi-line variable not in scope" $
       let msg = "Variable not in scope:\nliftIO\n:: IO [FilePath]\n-> GhcMod.Monad.Newtypes.GmT\n                (GhcMod.Monad.Newtypes.GmOutT IdeM) [[t0]]"
-        in extractImportableTerm msg `shouldBe` Just "liftIO :: IO [FilePath] -> GhcMod.Monad.Newtypes.GmT (GhcMod.Monad.Newtypes.GmOutT IdeM) [[t0]]"
+        in extractImportableTerm msg `shouldBe` Just ("liftIO :: IO [FilePath] -> GhcMod.Monad.Newtypes.GmT (GhcMod.Monad.Newtypes.GmOutT IdeM) [[t0]]", Import Symbol)
     it "pick up when" $
       let msg = "Variable not in scope: when :: Bool -> IO () -> t"
-        in extractImportableTerm msg `shouldBe` Just "when :: Bool -> IO () -> t"
+        in extractImportableTerm msg `shouldBe` Just ("when :: Bool -> IO () -> t", Import Symbol)
     it "pick up data constructors" $
       let msg = "Data constructor not in scope: ExitFailure :: Integer -> t"
-        in extractImportableTerm msg `shouldBe` Just "ExitFailure :: Integer -> t"
+        in extractImportableTerm msg `shouldBe` Just ("ExitFailure :: Integer -> t", Import Constructor)
+    it "pick up type" $
+      let msg = "Not in scope: type constructor or class ‘Text"
+        in extractImportableTerm msg `shouldBe` Just ("Text", Import Type)
 
   describe "rename code actions" $ do
     it "pick up variable not in scope perhaps you meant" $
@@ -146,7 +149,7 @@ spec = do
                 \                              Text.Megaparsec.Error.ShowErrorComponent e, Ord t) =>\n\
                 \                             OutputFormat -> Format.Result t e -> IO b"
         in extractMissingSignature msg `shouldBe` Just expected
-  
+
   describe "unused term code actions" $ do
     it "pick up unused term" $
       let msg = "  Defined but not used: ‘imUnused’"


### PR DESCRIPTION
Current implementation of the hsimport plugin can not deal with constructors, e.g. trying to import `Null` from `Data.Aeson` will wrongly try to import `Data.Aeson (Null)` instead of the correct `Data.Aeson (Value(Null))`. This pr aims to change that, while also preparing the implementation of #1191. 
Clones the API of HsImport with small adaptations for our use case, e.g. currently no support for qualified imports.
This pr also fixes the import of operators.

* [x] Tests
* [x] Cleanup code