### PR TITLE
Trying out haskell-lsp 0.14

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -70,8 +70,8 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp == 0.13.*
-                     , haskell-lsp-types == 0.13.*
+                     , haskell-lsp == 0.14.*
+                     , haskell-lsp-types == 0.14.*
                      , haskell-src-exts
                      , hie-plugin-api
                      , hlint (>= 2.0.11 && < 2.1.18) || >= 2.1.22
@@ -278,8 +278,8 @@ test-suite func-test
                      , filepath
                      , lsp-test >= 0.5.2
                      , haskell-ide-engine
-                     , haskell-lsp-types == 0.13.*
-                     , haskell-lsp == 0.13.*
+                     , haskell-lsp-types == 0.14.*
+                     , haskell-lsp == 0.14.*
                      , hie-test-utils
                      , hie-plugin-api
                      , hspec

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -45,7 +45,7 @@ library
                      , ghc
                      , ghc-mod-core >= 5.9.0.0
                      , ghc-project-types >= 5.9.0.0
-                     , haskell-lsp == 0.13.*
+                     , haskell-lsp == 0.14.*
                      , hslogger
                      , monad-control
                      , mtl

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -21,14 +21,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0@rev:2
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17 # last hlint supporting GHC 8.2
 - hoogle-5.0.17.9
 - hsimport-0.8.8
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -20,14 +20,14 @@ extra-deps:
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0@rev:2
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.24
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -19,14 +19,14 @@ extra-deps:
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0@rev:2
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.24
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -19,14 +19,14 @@ extra-deps:
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.24
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2
 - optparse-simple-0.1.0
 - pretty-show-1.9.5

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -21,14 +21,14 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.21.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.24
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - monoid-subclasses-0.4.6.1

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -17,14 +17,14 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.21.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.24
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -17,14 +17,14 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.21.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.24
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -17,13 +17,13 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.22.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - hlint-2.1.24
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -17,13 +17,13 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.22.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - haskell-src-exts-1.21.0
 - hlint-2.1.24
 - hsimport-0.10.0
 - hoogle-5.0.17.9
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,11 +21,11 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - ghc-lib-parser-8.8.0.20190424
 - haddock-api-2.22.0
-- haskell-lsp-0.13.0.0
-- haskell-lsp-types-0.13.0.0
+- haskell-lsp-0.14.0.0
+- haskell-lsp-types-0.14.0.1
 - hlint-2.1.24
 - hsimport-0.10.0
-- lsp-test-0.5.2.3
+- lsp-test-0.5.4.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1


### PR DESCRIPTION
Tests failing, suspect a JSON encoding problem.

ping @cocreature, see the circle logs

Locally I get the first two of many failing tests, all with a spurious `<0>`

```
      test/functional/FunctionalCodeActionsSpec.hs:557:9: 
      1) FunctionalCodeActions, code actions, import suggestions, formats with brittany, Execute HsImport with formatter brittany, works with 3.8 code action kinds
           expected: "Import module Control.Monad (when)"
            but got: "Import module Control.Monad (<0>when)"
    
      To rerun use: --match "/FunctionalCodeActions/code actions/import suggestions/formats with brittany/Execute HsImport with formatter brittany/works with 3.8 code action kinds/"
    
      test/functional/FunctionalCodeActionsSpec.hs:598:16: 
      2) FunctionalCodeActions, code actions, import suggestions, formats with brittany, Execute HsImport with formatter brittany, import-list formats
           Actual list is not a permutation of expected list!
             expected list contains:   ["import qualified Data.Maybe", "import           Control.Monad                  ( when )", "main :: IO ()", "main = when True $ putStrLn \"hello\""]
             actual list contains:     ["import qualified Data.Maybe", "import Control.Monad ((<0>when))", "main :: IO ()", "main = when True $ putStrLn \"hello\""]
             the missing elements are: ["import           Control.Monad                  ( when )"]
             the extra elements are:   ["import Control.Monad ((<0>when))"]
    
      To rerun use: --match "/FunctionalCodeActions/code actions/import suggestions/formats with brittany/Execute HsImport with formatter brittany/import-list formats/"
```