### PR TITLE
Fix UriCaches being leaked

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -455,7 +455,7 @@ withIndefiniteProgress t c f = do
     Just wp -> control $ \run -> wp t c (run f)
 
 data IdeState = IdeState
-  { moduleCache :: GhcModuleCache
+  { moduleCache :: !GhcModuleCache
   -- | A queue of requests to be performed once a module is loaded
   , requestQueue :: Map.Map FilePath [UriCacheResult -> IdeM ()]
   , extensibleState :: !(Map.Map TypeRep Dynamic)


### PR DESCRIPTION
This fixes UriCaches from being leaked via GhcModuleCaches. This is the result of 72 hours at ZuriHac between 3 people and a lot of time spent in gdb.

Fixes #412, #806, #665
Blog post coming soon

Co-Authored-By: Matthew Pickering <matthewtpickering@gmail.com>
Co-Authored-By: Daniel Gröber <dxld@darkboxed.org>