### PR TITLE
install.hs: Make all available GHCs in PATH buildable

### DIFF
--- a/install.hs
+++ b/install.hs
@@ -206,10 +206,10 @@ findInstalledGhcs = do
     (reverse hieVersions)
   availableGhcs <- getGhcPaths
   return
-    -- filter out stack provided GHCs
-    $ filter (not . isInfixOf ".stack" . snd)
     -- nub by version. knownGhcs takes precedence.
-    $ nubBy ((==) `on` fst) (knownGhcs ++ availableGhcs)
+    $ nubBy ((==) `on` fst)
+    -- filter out stack provided GHCs
+    $ filter (not . isInfixOf ".stack" . snd) (knownGhcs ++ availableGhcs)
 
 cabalBuildHie :: VersionNumber -> Action ()
 cabalBuildHie versionNumber = do

--- a/install.hs
+++ b/install.hs
@@ -19,6 +19,7 @@ import           Control.Monad.Extra                      ( unlessM
                                                           )
 import           Data.Maybe                               ( isJust )
 import           System.Directory                         ( findExecutable
+                                                          , findExecutables
                                                           , listDirectory
                                                           )
 import           System.Environment                       ( getProgName
@@ -34,6 +35,8 @@ import           Data.Maybe                               ( isNothing
 import           Data.List                                ( dropWhileEnd
                                                           , intersperse
                                                           , intercalate
+                                                          , isInfixOf
+                                                          , nubBy
                                                           , sort
                                                           )
 import qualified Data.Text as T
@@ -42,7 +45,9 @@ import           Data.Version                             ( parseVersion
                                                           , makeVersion
                                                           , showVersion
                                                           )
-import           Data.Function                            ( (&) )
+import           Data.Function                            ( (&)
+                                                          , on
+                                                          )
 import           Text.ParserCombinators.ReadP             ( readP_to_S )
 
 type VersionNumber = String
@@ -143,7 +148,7 @@ main = do
       forM_ ghcVersions cabalTest
 
     forM_
-      hieVersions
+      ghcVersions
       (\version -> phony ("cabal-hie-" ++ version) $ do
         validateCabalNewInstallIsSupported
         need ["submodules"]
@@ -182,7 +187,7 @@ validateCabalNewInstallIsSupported = when isWindowsSystem $ do
 
 configureCabal :: VersionNumber -> Action ()
 configureCabal versionNumber = do
-  ghcPath <- getGhcPath versionNumber >>= \case
+  ghcPath <- getGhcPathOf versionNumber >>= \case
     Nothing -> do
       liftIO $ putStrLn $ embedInStars (ghcVersionNotFoundFailMsg versionNumber)
       error (ghcVersionNotFoundFailMsg versionNumber)
@@ -193,12 +198,18 @@ configureCabal versionNumber = do
 findInstalledGhcs :: IO [(VersionNumber, GhcPath)]
 findInstalledGhcs = do
   hieVersions <- getHieVersions :: IO [VersionNumber]
-  mapMaybeM
-    (\version -> getGhcPath version >>= \case
+  knownGhcs <- mapMaybeM
+    (\version -> getGhcPathOf version >>= \case
       Nothing -> return Nothing
       Just p  -> return $ Just (version, p)
     )
     (reverse hieVersions)
+  availableGhcs <- getGhcPaths
+  return
+    -- filter out stack provided GHCs
+    $ filter (not . isInfixOf ".stack" . snd)
+    -- nub by version. knownGhcs takes precedence.
+    $ nubBy ((==) `on` fst) (knownGhcs ++ availableGhcs)
 
 cabalBuildHie :: VersionNumber -> Action ()
 cabalBuildHie versionNumber = do
@@ -515,16 +526,19 @@ getStackGhcPathShake = do
 -- First, it is checked whether there is a GHC with the name `ghc-$VersionNumber`.
 -- If this yields no result, it is checked, whether the numeric-version of the `ghc`
 -- command fits to the desired version.
-getGhcPath :: MonadIO m => VersionNumber -> m (Maybe GhcPath)
-getGhcPath ghcVersion = liftIO $
-  findExecutable ("ghc-" ++ ghcVersion) >>= \case
-    Nothing -> do
-      findExecutable "ghc" >>= \case
-        Nothing -> return Nothing
-        Just p  -> do
-          Stdout version <- cmd p ["--numeric-version"] :: IO (Stdout String)
-          if ghcVersion == trim version then return $ Just p else return Nothing
-    p -> return p
+getGhcPathOf :: MonadIO m => VersionNumber -> m (Maybe GhcPath)
+getGhcPathOf ghcVersion =
+  liftIO $ findExecutable ("ghc-" ++ ghcVersion) >>= \case
+    Nothing -> lookup ghcVersion <$> getGhcPaths
+    path -> return path
+
+-- | Get a list of GHCs that are available in $PATH
+getGhcPaths :: MonadIO m => m [(VersionNumber, GhcPath)]
+getGhcPaths = liftIO $ do
+  paths <- findExecutables "ghc"
+  forM paths $ \path -> do
+    Stdout version <- cmd path ["--numeric-version"]
+    return (trim version, path)
 
 -- | Read the local install root of the stack project specified by the VersionNumber
 -- Returns the filepath of the local install root.


### PR DESCRIPTION
This PR extends the GHC search logic so that `install.hs` can find all available `ghc`s in `$PATH`.

The motivation is that at our company we have our own build of GHCs installed in some directories with custom versioning (e.g. `ghc-8.6.4.0`) and make them available by modifying `$PATH` variable. Currently `stack install.hs cabal-ghcs` cannot find them because it only tries to find GHCs whose version matches one of the versions returned by `getHieVersions`.

The new search logic does the following:
* Find all known GHCs in `$PATH`
    * This is the original behavior.
* Find all available `ghc`s in `$PATH`
* Merge the two sets of paths.
    * If stack-provided GHCs are included, exclude them.
    * If both sets have the same version, the known GHC takes precedence.

This can also be useful to try `hie` with GHC alpha/HEAD etc. You can make the GHC available in `$PATH` and type `stack install.hs cabal-ghc-8.7.20190618` for example.