### PR TITLE
Fix build for Windows 7

### DIFF
--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -33,6 +33,8 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - sorted-list-0.2.1.0
 - syz-0.2.0.0
+# To make build work in windows 7
+- unix-time-0.4.7
 
 flags:
   haskell-ide-engine:

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -32,6 +32,8 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
+# To make build work in windows 7
+- unix-time-0.4.7
 - windns-0.1.0.0
 - yaml-0.8.32
 - yi-rope-0.11

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -31,6 +31,8 @@ extra-deps:
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
+# To make build work in windows 7
+- unix-time-0.4.7
 - temporary-1.2.1.1
 
 flags:

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -31,6 +31,8 @@ extra-deps:
 - pretty-show-1.9.5
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
+# To make build work in windows 7
+- unix-time-0.4.7
 - temporary-1.2.1.1
 
 flags:

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -38,6 +38,8 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
+# To make build work in windows 7
+- unix-time-0.4.7
 - yaml-0.8.32
 
 flags:

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -31,6 +31,8 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
+# To make build work in windows 7
+- unix-time-0.4.7
 - yaml-0.8.32
 
 flags:

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -32,6 +32,8 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
+# To make build work in windows 7
+- unix-time-0.4.7
 - yaml-0.8.32
 
 flags:

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -30,6 +30,8 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
+# To make build work in windows 7
+- unix-time-0.4.7
 - yaml-0.8.32
 
 flags:

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.23 # First GHC 8.6.5
+resolver: lts-13.26 # First GHC 8.6.5 with unix-time >= 0.4.6
 packages:
 - .
 - hie-plugin-api

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.26 # First GHC 8.6.5 with unix-time >= 0.4.6
+resolver: lts-13.23 # First GHC 8.6.5
 packages:
 - .
 - hie-plugin-api
@@ -30,6 +30,8 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
+# To make build work in windows 7
+- unix-time-0.4.7
 - yaml-0.8.32
 
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-05-31 # GHC 8.6.5
+resolver: nightly-2019-06-20 # GHC 8.6.5
 packages:
 - .
 - hie-plugin-api

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-06-20 # GHC 8.6.5
+resolver: nightly-2019-05-31 # GHC 8.6.5
 packages:
 - .
 - hie-plugin-api
@@ -31,6 +31,8 @@ extra-deps:
 - multistate-0.8.0.1
 - syz-0.2.0.0
 - temporary-1.2.1.1
+# To make build work in windows 7
+- unix-time-0.4.7
 - yaml-0.8.32
 
 flags:


### PR DESCRIPTION
* Actually the project cant be built in windows 7 due a bug in the package `unix-time` (via `hoogle` -> `wai-logger` -> `fast-logger`)
* The issue was resolved in the package: see https://github.com/kazu-yamamoto/unix-time/issues/51
* The first version of the package with the fix was `0.4.7`

This pr update the resolver for `stack-yaml` and `stack-8.6.5.yaml` to get one with the patched version and add `unix-time-0.4.7` as exta dependency for the rest of stack config files.