### PR TITLE
Add unix-time constraint to cabal file

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -93,6 +93,7 @@ library
                      , tagsoup
                      , text
                      , transformers
+                     , unix-time >= 0.4.7
                      , unordered-containers
                      , vector
                      , versions


### PR DESCRIPTION
This makes sure PR #1304 is complete, constraining the cabal build as
well, for Windows 7