### PR TITLE
Update Arch Linux install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ Follow the instructions at https://github.com/Infinisil/all-hies
 
 ### Installation on ArchLinux
 
-An [haskell-ide-engine-git](https://aur.archlinux.org/packages/haskell-ide-engine-git/) package is available on the AUR.
+An [haskell-ide-engine](https://aur.archlinux.org/packages/haskell-ide-engine/) package is available on the AUR.
 
 Using [Aura](https://github.com/aurapm/aura):
 
 ```
-# aura -A haskell-ide-engine-git
+# aura -A haskell-ide-engine
 ```
 
 


### PR DESCRIPTION
This is my first pull request to a public project (ever), so forgive me if I'm doing it wrong on not going through the proper process.

The suggested Arch Linux instructions direct the user to install an evidently unmaintained package. This patch changes that so that the user is directed to install a maintained package instead.