### PR TITLE
Clear out pattern matching and error message of executeCodeActionByName

### DIFF
--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -751,11 +751,11 @@ hsImportSpec formatterName [e1, e2, e3, e4] =
       let actions = filter (\actn -> actn ^. L.title `elem` names) allActions
       case actions of
         (action:_) -> executeCodeAction action
-        xs ->
+        [] ->
           error
-            $  "Found an unexpected amount of action. Expected 1, but got: "
-            ++ show (length xs)
-            ++ ".\n Titles: " ++ show (map (^. L.title) allActions)
+            $  "No action found to be executed: "
+            ++ ".\n Actual actions titles: " ++ show (map (^. L.title) allActions)
+            ++ ".\n Expected action titles:" ++ show names
 
 -- Silence warnings
 hsImportSpec formatter args =

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -755,7 +755,7 @@ hsImportSpec formatterName [e1, e2, e3, e4] =
           error
             $  "No action found to be executed!"
             ++ "\n Actual actions titles: " ++ show (map (^. L.title) allActions)
-            ++ "\n Expected action titles: " ++ show names
+            ++ "\n Expected actions titles: " ++ show names
 
 -- Silence warnings
 hsImportSpec formatter args =

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -753,9 +753,9 @@ hsImportSpec formatterName [e1, e2, e3, e4] =
         (action:_) -> executeCodeAction action
         [] ->
           error
-            $  "No action found to be executed: "
-            ++ ".\n Actual actions titles: " ++ show (map (^. L.title) allActions)
-            ++ ".\n Expected action titles:" ++ show names
+            $  "No action found to be executed!"
+            ++ "\n Actual actions titles: " ++ show (map (^. L.title) allActions)
+            ++ "\n Expected action titles: " ++ show names
 
 -- Silence warnings
 hsImportSpec formatter args =


### PR DESCRIPTION
It seems the message had become obsolete, the unique error case is the empty list.
I've added the list ot actions candidates to be run.