### PR TITLE
Remove unnecesary extra-dep unix-time

### DIFF
--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -30,8 +30,6 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
-# To make build work in windows 7
-- unix-time-0.4.7
 - yaml-0.8.32
 
 flags:

--- a/stack.yaml
+++ b/stack.yaml
@@ -26,8 +26,6 @@ extra-deps:
 - monad-dijkstra-0.1.1.2@rev:1
 - syz-0.2.0.0
 - temporary-1.2.1.1
-# To make build work in windows 7
-- unix-time-0.4.7
 - yaml-0.8.32
 
 flags:


### PR DESCRIPTION
The version with the fix for windows 7 already is in both resolvers.