### PR TITLE
Simpler completion

### DIFF
--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -41,7 +41,6 @@ import           Data.IORef
 import qualified Data.List                                    as List
 import qualified Data.Map                                     as Map
 import           Data.Maybe
-import           Data.Monoid                                  ( (<>) )
 import qualified Data.Text                                    as T
 import qualified Data.Text.IO                                 as T
 import           Data.Typeable

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -26,7 +26,7 @@ module Haskell.Ide.Engine.Support.HieExtras
   , getFormattingPlugin
   ) where
 
-import           Data.Semigroup (Semigroup)
+import           Data.Semigroup (Semigroup(..))
 import           ConLike
 import           Control.Lens.Operators                       ( (.~), (^.), (^?), (?~), (&) )
 import           Control.Lens.Prism                           ( _Just )

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -156,9 +156,9 @@ instance ToJSON NameDetails where
       mid = unitIdString $ moduleUnitId mdl
 
 instance FromJSON CompItemResolveData where
-  parseJSON = genericParseJSON $ customOptions 2
+  parseJSON = genericParseJSON $ customOptions 0
 instance ToJSON CompItemResolveData where
-  toJSON = genericToJSON $ customOptions 2
+  toJSON = genericToJSON $ customOptions 0
 
 resolveCompletion :: J.CompletionItem -> IdeM J.CompletionItem
 resolveCompletion origCompl =

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -179,14 +179,14 @@ instance ToJSON CompItemResolveData where
 resolveCompletion :: J.CompletionItem -> IdeM J.CompletionItem
 resolveCompletion origCompl =
   case fromJSON <$> origCompl ^. J.xdata of
-    Just (J.Success (CompItemResolveData dets query)) -> do
-      mdocs <- Hoogle.infoCmd' query
+    Just (J.Success compdata) -> do
+      mdocs <- Hoogle.infoCmd' $ hoogleQuery compdata
       let docText = case mdocs of
             Right x -> Just x
             _ -> Nothing
           markup = J.MarkupContent J.MkMarkdown <$> docText
           docs = J.CompletionDocMarkup <$> markup
-      (detail,insert) <- case dets of
+      (detail,insert) <- case nameDetails compdata of
         Nothing -> pure (Nothing,Nothing)
         Just nd -> do
           mtyp <- getTypeForNameDetails nd

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -26,6 +26,7 @@ module Haskell.Ide.Engine.Support.HieExtras
   , getFormattingPlugin
   ) where
 
+import           Data.Semigroup (Semigroup)
 import           ConLike
 import           Control.Lens.Operators                       ( (.~), (^.), (^?), (?~), (&) )
 import           Control.Lens.Prism                           ( _Just )
@@ -72,14 +73,14 @@ import qualified Language.Haskell.LSP.VFS                     as VFS
 import           Language.Haskell.Refact.API                 (showGhc)
 import           Language.Haskell.Refact.Utils.MonadFunctions
 import           Name
+import           NameCache
 import           Outputable                                   (Outputable)
 import qualified Outputable                                   as GHC
 import           Packages
 import           SrcLoc
+import           TcEnv
 import           Type
 import           Var
-import           Unique
-import           UniqFM
 import           Module hiding (getModule)
 
 -- ---------------------------------------------------------------------
@@ -135,25 +136,41 @@ data CompItemResolveData
   } deriving (Eq,Generic)
 
 data NameDetails
-  = NameDetails Unique Module
+  = NameDetails Module OccName
   deriving (Eq)
+
+nsJSON :: NameSpace -> Value
+nsJSON ns
+  | isVarNameSpace ns = String "v"
+  | isDataConNameSpace ns = String "c"
+  | isTcClsNameSpace ns  = String "t"
+  | isTvNameSpace ns = String "z"
+  | otherwise = error "namespace not recognized"
+
+parseNs :: Value -> J.Parser NameSpace
+parseNs (String "v") = pure Name.varName
+parseNs (String "c") = pure dataName
+parseNs (String "t") = pure tcClsName
+parseNs (String "z") = pure tvName
+parseNs _ = mempty
 
 instance FromJSON NameDetails where
   parseJSON v@(Array _)
     = do
-      [uchar,uint,modname,modid] <- parseJSON v
-      ch  <- parseJSON uchar
-      i   <- parseJSON uint
+      [modname,modid,namesp,occname] <- parseJSON v
       mn  <- parseJSON modname
       mid <- parseJSON modid
-      pure $ NameDetails (mkUnique ch i) (mkModule (stringToUnitId mid) (mkModuleName mn))
+      ns <- parseNs namesp
+      occn <- parseJSON occname
+      pure $ NameDetails (mkModule (stringToUnitId mid) (mkModuleName mn)) (mkOccName ns occn)
   parseJSON _ = mempty
 instance ToJSON NameDetails where
-  toJSON (NameDetails uniq mdl) = toJSON [toJSON ch,toJSON uint,toJSON mname,toJSON mid]
+  toJSON (NameDetails mdl occ) = toJSON [toJSON mname,toJSON mid,nsJSON ns,toJSON occs]
     where
-      (ch,uint) = unpkUnique uniq
       mname = moduleNameString $ moduleName mdl
       mid = unitIdString $ moduleUnitId mdl
+      ns = occNameSpace occ
+      occs = occNameString occ
 
 instance FromJSON CompItemResolveData where
   parseJSON = genericParseJSON $ customOptions 0
@@ -172,8 +189,8 @@ resolveCompletion origCompl =
           docs = J.CompletionDocMarkup <$> markup
       (detail,insert) <- case dets of
         Nothing -> pure (Nothing,Nothing)
-        Just (NameDetails uniq mdl) -> do
-          mtyp <- getTypeForNameDirectly uniq mdl
+        Just nd -> do
+          mtyp <- getTypeForNameDetails nd
           case mtyp of
             Nothing -> pure (Nothing, Nothing)
             Just typ -> do
@@ -216,7 +233,7 @@ mkCompl CI{origName,importedFrom,thingType,label,isInfix} =
           case (thingType, nameModule_maybe origName) of
             (Just _,_) -> Nothing
             (Nothing, Nothing) -> Nothing
-            (Nothing, Just mdl) -> Just (NameDetails (nameUnique origName) mdl)
+            (Nothing, Just mdl) -> Just (NameDetails mdl (nameOccName origName))
 
 stripForall :: T.Text -> T.Text
 stripForall t
@@ -280,6 +297,7 @@ instance Semigroup QualCompls where
 
 instance Monoid QualCompls where
   mempty = QualCompls Map.empty
+  mappend = (<>)
 
 data CachedCompletions = CC
   { allModNamesAsNS :: [T.Text]
@@ -522,35 +540,30 @@ getCompletions uri prefixInfo (WithSnippets withSnippets) =
 -- ---------------------------------------------------------------------
 
 getTypeForName :: Name -> IdeM (Maybe Type)
-getTypeForName n = case nameModule_maybe n of
-  Nothing -> pure Nothing
-  Just mdl -> getTypeForNameDirectly (nameUnique n) mdl
-
-getTypeForNameDirectly :: Unique -> Module -> IdeM (Maybe Type)
-getTypeForNameDirectly n m = do
+getTypeForName n = do
   hscEnvRef <- ghcSession <$> readMTS
   mhscEnv <- liftIO $ traverse readIORef hscEnvRef
   case mhscEnv of
-    Nothing -> return Nothing
+    Nothing -> pure Nothing
+    Just hscEnv -> liftIO $ getTypeForName_ hscEnv n
+
+getTypeForNameDetails :: NameDetails -> IdeM (Maybe Type)
+getTypeForNameDetails (NameDetails mdl occ) = do
+  hscEnvRef <- ghcSession <$> readMTS
+  mhscEnv <- liftIO $ traverse readIORef hscEnvRef
+  case mhscEnv of
+    Nothing -> pure Nothing
     Just hscEnv -> do
-      mt <- liftIO $ lookupGlobalDirectly hscEnv n m
-      return $ fmap varType $ safeTyThingId =<< mt
+      nc <- liftIO $ readIORef $ hsc_NC hscEnv
+      case lookupOrigNameCache (nsNames nc) mdl occ of
+        Nothing -> pure Nothing
+        Just n -> liftIO $ getTypeForName_ hscEnv n
 
-lookupTypeDirectly
-  :: HomePackageTable
-  -> PackageTypeEnv
-  -> Unique
-  -> Module
-  -> Maybe TyThing
-lookupTypeDirectly hpt pte name mdl
-  = case lookupHptByModule hpt mdl of
-       Just hm -> lookupUFM_Directly (md_types (hm_details hm)) name
-       Nothing -> lookupUFM_Directly pte name
-
-lookupGlobalDirectly :: HscEnv -> Unique -> Module -> IO (Maybe TyThing)
-lookupGlobalDirectly hsc_env name mdl = do
-    eps <- readIORef (hsc_EPS hsc_env)
-    return $! lookupTypeDirectly (hsc_HPT hsc_env) (eps_PTE eps) name mdl
+getTypeForName_ :: HscEnv -> Name -> IO (Maybe Type)
+getTypeForName_ hscEnv n = do
+  mt <- (Just <$> lookupGlobal hscEnv n)
+          `catch` \(_ :: SomeException) -> return Nothing
+  pure $ fmap varType $ safeTyThingId =<< mt
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Transport/LspStdio.hs
+++ b/src/Haskell/Ide/Engine/Transport/LspStdio.hs
@@ -19,7 +19,7 @@ import           Control.Concurrent
 import           Control.Concurrent.STM.TChan
 import qualified Control.Exception as E
 import qualified Control.FoldDebounce as Debounce
-import           Control.Lens ( (^.), (.~) )
+import           Control.Lens ( (^.) )
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
@@ -30,7 +30,6 @@ import qualified Data.ByteString.Lazy as BL
 import           Data.Coerce (coerce)
 import           Data.Default
 import           Data.Foldable
-import           Data.Function
 import qualified Data.Map as Map
 import           Data.Maybe
 import           Data.Semigroup (Semigroup(..), Option(..), option)
@@ -649,22 +648,11 @@ reactor inp diagIn = do
         ReqCompletionItemResolve req -> do
           liftIO $ U.logs $ "reactor:got CompletionItemResolveRequest:" ++ show req
           let origCompl = req ^. J.params
-              mquery = case J.fromJSON <$> origCompl ^. J.xdata of
-                         Just (J.Success q) -> Just q
-                         _ -> Nothing
-              callback docText = do
-                let markup = J.MarkupContent J.MkMarkdown <$> docText
-                    docs = J.CompletionDocMarkup <$> markup
-                    rspMsg = Core.makeResponseMessage req $
-                              origCompl & J.documentation .~ docs
+              callback res = do
+                let rspMsg = Core.makeResponseMessage req $ res
                 reactorSend $ RspCompletionItemResolve rspMsg
-              hreq = IReq tn (req ^. J.id) callback $ runIdeResultT $ case mquery of
-                        Nothing -> return Nothing
-                        Just query -> do
-                          result <- lift $ lift $ Hoogle.infoCmd' query
-                          case result of
-                            Right x -> return $ Just x
-                            _ -> return Nothing
+              hreq = IReq tn (req ^. J.id) callback $ runIdeResultT $ do
+                lift $ lift $ Hie.resolveCompletion origCompl
           makeRequest hreq
 
         -- -------------------------------

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module CompletionSpec where
 
 import Control.Applicative.Combinators
@@ -25,9 +26,47 @@ spec = describe "completions" $ do
     liftIO $ do
       item ^. label `shouldBe` "putStrLn"
       item ^. kind `shouldBe` Just CiFunction
-      item ^. detail `shouldBe` Just "String -> IO ()\nPrelude"
-      item ^. insertTextFormat `shouldBe` Just Snippet
-      item ^. insertText `shouldBe` Just "putStrLn ${1:String}"
+      item ^. detail `shouldBe` Just "Prelude"
+    resolvedRes <- request CompletionItemResolve item
+    let Just (resolved :: CompletionItem) = resolvedRes ^. result
+    liftIO $ do
+      resolved ^. label `shouldBe` "putStrLn"
+      resolved ^. kind `shouldBe` Just CiFunction
+      resolved ^. detail `shouldBe` Just "String -> IO ()\nPrelude"
+      resolved ^. insertTextFormat `shouldBe` Just Snippet
+      resolved ^. insertText `shouldBe` Just "putStrLn ${1:String}"
+
+  it "does not pull in unnecessary modules until needed" $
+      runSession hieCommand fullCaps "test/testdata/completion" $ do
+    doc <- openDoc "Completion.hs" "haskell"
+    _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+
+    let te = TextEdit (Range (Position 5 7) (Position 5 24)) "enum"
+    _ <- applyEdit doc te
+
+    compls <- getCompletions doc (Position 5 11)
+    let item = head $ filter ((== "enumFrom") . (^. label)) compls
+    resolvedRes <- request CompletionItemResolve item
+    let Just (resolved :: CompletionItem) = resolvedRes ^. result
+    liftIO $ do
+      resolved ^. label `shouldBe` "enumFrom"
+      resolved ^. kind `shouldBe` Just CiFunction
+      resolved ^. detail `shouldBe` Just "Prelude"
+      resolved ^. insertText `shouldBe` Nothing
+
+    let te2 = TextEdit (Range (Position 5 7) (Position 5 11)) "putStrLn (enumFrom 'a')"
+    _ <- applyEdit doc te2
+    _ <- skipManyTill loggingNotification (count 2 noDiagnostics)
+
+    compls2 <- getCompletions doc (Position 5 22)
+    let item2 = head $ filter ((== "enumFrom") . (^. label)) compls2
+    resolvedRes2 <- request CompletionItemResolve item2
+    let Just (resolved2 :: CompletionItem) = resolvedRes2 ^. result
+    liftIO $ do
+      resolved2 ^. label `shouldBe` "enumFrom"
+      resolved2 ^. kind `shouldBe` Just CiFunction
+      resolved2 ^. detail `shouldBe` Just "Enum a => a -> [a]\nPrelude"
+      resolved2 ^. insertText `shouldBe` Just "enumFrom ${1:a}"
 
   it "completes imports" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
@@ -193,8 +232,10 @@ spec = describe "completions" $ do
     _ <- applyEdit doc te
     compls <- getCompletions doc (Position 5 9)
     let item = head $ filter ((== "id") . (^. label)) compls
+    resolvedRes <- request CompletionItemResolve item
+    let Just (resolved :: CompletionItem) = resolvedRes ^. result
     liftIO $
-      item ^. detail `shouldBe` Just "a -> a\nPrelude"
+      resolved ^. detail `shouldBe` Just "a -> a\nPrelude"
 
   it "have implicit foralls with multiple type variables" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
     doc <- openDoc "Completion.hs" "haskell"
@@ -203,8 +244,10 @@ spec = describe "completions" $ do
     _ <- applyEdit doc te
     compls <- getCompletions doc (Position 5 11)
     let item = head $ filter ((== "flip") . (^. label)) compls
+    resolvedRes <- request CompletionItemResolve item
+    let Just (resolved :: CompletionItem) = resolvedRes ^. result
     liftIO $
-      item ^. detail `shouldBe` Just "(a -> b -> c) -> b -> a -> c\nPrelude"
+      resolved ^. detail `shouldBe` Just "(a -> b -> c) -> b -> a -> c\nPrelude"
 
   describe "snippets" $ do
     it "work for argumentless constructors" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
@@ -229,11 +272,13 @@ spec = describe "completions" $ do
 
       compls <- getCompletions doc (Position 5 11)
       let item = head $ filter ((== "foldl") . (^. label)) compls
+      resolvedRes <- request CompletionItemResolve item
+      let Just (resolved :: CompletionItem) = resolvedRes ^. result
       liftIO $ do
-        item ^. label `shouldBe` "foldl"
-        item ^. kind `shouldBe` Just CiFunction
-        item ^. insertTextFormat `shouldBe` Just Snippet
-        item ^. insertText `shouldBe` Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
+        resolved ^. label `shouldBe` "foldl"
+        resolved ^. kind `shouldBe` Just CiFunction
+        resolved ^. insertTextFormat `shouldBe` Just Snippet
+        resolved ^. insertText `shouldBe` Just "foldl ${1:b -> a -> b} ${2:b} ${3:t a}"
 
     it "work for complex types" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Completion.hs" "haskell"
@@ -244,11 +289,13 @@ spec = describe "completions" $ do
 
       compls <- getCompletions doc (Position 5 11)
       let item = head $ filter ((== "mapM") . (^. label)) compls
+      resolvedRes <- request CompletionItemResolve item
+      let Just (resolved :: CompletionItem) = resolvedRes ^. result
       liftIO $ do
-        item ^. label `shouldBe` "mapM"
-        item ^. kind `shouldBe` Just CiFunction
-        item ^. insertTextFormat `shouldBe` Just Snippet
-        item ^. insertText `shouldBe` Just "mapM ${1:a -> m b} ${2:t a}"
+        resolved ^. label `shouldBe` "mapM"
+        resolved ^. kind `shouldBe` Just CiFunction
+        resolved ^. insertTextFormat `shouldBe` Just Snippet
+        resolved ^. insertText `shouldBe` Just "mapM ${1:a -> m b} ${2:t a}"
 
     it "work for infix functions" $ runSession hieCommand fullCaps "test/testdata/completion" $ do
       doc <- openDoc "Completion.hs" "haskell"

--- a/test/testdata/completion/Completion.hs
+++ b/test/testdata/completion/Completion.hs
@@ -7,3 +7,9 @@ main = putStrLn "hello"
 
 foo :: Either a b -> Either a b
 foo = id
+
+bar :: Int
+bar = foldl (-) 0 [1,2,3]
+
+baz :: [String]
+baz = mapM head [["a"]]

--- a/test/testdata/completion/Completion.hs
+++ b/test/testdata/completion/Completion.hs
@@ -7,9 +7,3 @@ main = putStrLn "hello"
 
 foo :: Either a b -> Either a b
 foo = id
-
-bar :: Int
-bar = foldl (-) 0 [1,2,3]
-
-baz :: [String]
-baz = mapM head [["a"]]


### PR DESCRIPTION
After @mpickering pointed this out yesterday, I noticed that completion was a lot more complicated than it needed to be. Instead of the convoluted wrangling we do with import declarations, all the information we need is in the `GlobalRdrEnv`.

In addition to this, I've separated out the step of getting the type information/snippets for the completion into the LSP `CompletionItemResolve` request. Type information for local variables which
is readily at hand in the `TypecheckedModule` itself is still reported in the original completion request.

A potential performance issue I've tried to fix is that looking up the types of all the possible completions would result in GHC loading a bunch of interface files it didn't need to.

For example, consider a module that imports `Prelude`, but doesn't use any functions from `GHC.Enum`(like `enumFrom`). Normally, GHC will not load the interface file for `GHC.Enum`. However, when we try to get the type of the `enumFrom` completion, this forces GHC to go and actually load the interface file for that module. 

~~I've implemented the function we used to look up the type information to just return `Nothing` in this case and not try to load the `GHC.Enum` interface file. You can see this in action in the `"does not pull in unnecessary modules until needed"` test case I've added.~~

~~The above behaviour is up for discussion, and I will re-implement the old/default behaviour for `getTypeForName` depending on the consensus.~~ 

The interface file will now be pulled in when the client requests to "resolve" the completion.

The behavioural changes due to this PR are:

- Completion items need to be resolved to get their type information/snippets.
- ~~The types/snippets for some functions from modules that haven't been used previously may not be available, as described above.~~