### PR TITLE
Use preview of pipeline caching in azure builds

### DIFF
--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -34,7 +34,7 @@ jobs:
         "stack-root"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: $(STACK_ROOT)
+      path: $(STACK_ROOT).tar.gz
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
@@ -42,12 +42,15 @@ jobs:
         "stack-work"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: .stack-work
+      path: .stack-work.tar.gz
     displayName: "Cache stack-work"
   - bash: |
-      rm -rf $STACK_ROOT/programs
-      rm -rf $STACK_ROOT/setup-exe-cache
-    displayName: "Clean STACK_ROOT programs"
+      mkdir -p $STACK_ROOT
+      tar -xzf $STACK_ROOT.tar.gz -C $STACK_ROOT/..
+      mkdir -p .stack-work
+      tar -xzf .stack-work.tar.gz
+    displayName: "Unpack cache"
+    condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
       git submodule sync
       git submodule update --init
@@ -88,6 +91,6 @@ jobs:
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
   - bash: |
-      rm -rf $STACK_ROOT/programs
-      rm -rf $STACK_ROOT/setup-exe-cache
-    displayName: "Clean STACK_ROOT programs"
+      tar -czf $STACK_ROOT.tar.gz $STACK_ROOT
+      tar -czf .stack-work.tar.gz .stack-work
+    displayName: "Pack cache"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -26,6 +26,20 @@ jobs:
       stack-8.2.2:
         YAML_FILE: stack-8.2.2.yaml
   steps:
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        $(Agent.OS)
+        $(Build.SourcesDirectory)/$(YAML_FILE)
+      path: $(Build.SourcesDirectory)/.stack-root
+    displayName: "Cache stack-root"
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        $(Agent.OS)
+        $(Build.SourcesDirectory)/$(YAML_FILE)
+      path: .stack-work
+    displayName: "Cache stack-work"
   - bash: |
       git submodule sync
       git submodule update --init

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -45,6 +45,10 @@ jobs:
       path: .stack-work
     displayName: "Cache stack-work"
   - bash: |
+      rm -rf $STACK_ROOT/programs
+      rm -rf $STACK_ROOT/setup-exe-cache
+    displayName: "Clean STACK_ROOT programs"
+  - bash: |
       git submodule sync
       git submodule update --init
     displayName: Sync submodules

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -35,7 +35,7 @@ jobs:
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .azure-cache
-      cacheHitVar: _RESTORED
+      cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"
   - bash: |
       mkdir -p $STACK_ROOT

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -39,7 +39,7 @@ jobs:
     displayName: "Download cache"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -xzf .azure-cache/stack-root.tar.gz -C $STACK_ROOT/..
+      tar -xzf .azure-cache/stack-root.tar.gz -C /
       mkdir -p .stack-work
       tar -xzf .azure-cache/stack-work.tar.gz
     displayName: "Unpack cache"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -85,4 +85,5 @@ jobs:
   #   displayName: Run Test
   - bash: |
       rm -rf $STACK_ROOT/programs
+      rm -rf $STACK_ROOT/setup-exe-cache
     displayName: "Clean STACK_ROOT programs"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -25,17 +25,21 @@ jobs:
         YAML_FILE: stack-8.4.2.yaml
       stack-8.2.2:
         YAML_FILE: stack-8.2.2.yaml
+  variables:
+    STACK_ROOT: $(Build.SourcesDirectory)/.stack-root
   steps:
   - task: CacheBeta@0
     inputs:
       key: |
+        "stack-root"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: $(Build.SourcesDirectory)/.stack-root
+      path: $(STACK_ROOT)
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
       key: |
+        "stack-work"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .stack-work
@@ -45,7 +49,6 @@ jobs:
       git submodule update --init
     displayName: Sync submodules
   - bash: |
-      export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root
       mkdir -p ~/.local/bin
       curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | \
         tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -35,6 +35,7 @@ jobs:
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: $(STACK_ROOT).tar.gz
+      cacheHitVar: STACK_ROOT_RESTORED
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
@@ -43,14 +44,18 @@ jobs:
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .stack-work.tar.gz
+      cacheHitVar: STACK_WORK_RESTORED
     displayName: "Cache stack-work"
   - bash: |
       mkdir -p $STACK_ROOT
       tar -xzf $STACK_ROOT.tar.gz -C $STACK_ROOT/..
+    displayName: "Unpack STACK_ROOT cache"
+    condition: eq(variables.STACK_ROOT_RESTORED, 'true')
+  - bash: |
       mkdir -p .stack-work
       tar -xzf .stack-work.tar.gz
-    displayName: "Unpack cache"
-    condition: eq(variables.CACHE_RESTORED, 'true')
+    displayName: "Unpack .stack-work cache"
+    condition: eq(variables.STACK_WORK_RESTORED, 'true')
   - bash: |
       git submodule sync
       git submodule update --init

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -31,31 +31,19 @@ jobs:
   - task: CacheBeta@0
     inputs:
       key: |
-        "stack-root"
+        "cache"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: $(STACK_ROOT).cache
-      cacheHitVar: STACK_ROOT_RESTORED
-    displayName: "Cache stack-root"
-  - task: CacheBeta@0
-    inputs:
-      key: |
-        "stack-work"
-        $(Agent.OS)
-        $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: .stack-work.cache
-      cacheHitVar: STACK_WORK_RESTORED
-    displayName: "Cache stack-work"
+      path: .azure-cache
+      cacheHitVar: _RESTORED
+    displayName: "Download cache"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -xzf $STACK_ROOT.cache -C $STACK_ROOT/..
-    displayName: "Unpack STACK_ROOT cache"
-    condition: eq(variables.STACK_ROOT_RESTORED, 'true')
-  - bash: |
+      tar -xzf .azure-cache/stack-root.tar.gz -C $STACK_ROOT/..
       mkdir -p .stack-work
-      tar -xzf .stack-work.cache
-    displayName: "Unpack .stack-work cache"
-    condition: eq(variables.STACK_WORK_RESTORED, 'true')
+      tar -xzf .azure-cache/stack-work.tar.gz
+    displayName: "Unpack cache"
+    condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
       git submodule sync
       git submodule update --init
@@ -96,6 +84,7 @@ jobs:
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
   - bash: |
-      tar -czf $STACK_ROOT.cache $STACK_ROOT
-      tar -czf .stack-work.cache .stack-work
+      mkdir .azure-cache
+      tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT
+      tar -czf .azure-cache/stack-work.tar.gz .stack-work
     displayName: "Pack cache"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -34,7 +34,7 @@ jobs:
         "stack-root"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: $(STACK_ROOT).tar.gz
+      path: $(STACK_ROOT).cache
       cacheHitVar: STACK_ROOT_RESTORED
     displayName: "Cache stack-root"
   - task: CacheBeta@0
@@ -43,17 +43,17 @@ jobs:
         "stack-work"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: .stack-work.tar.gz
+      path: .stack-work.cache
       cacheHitVar: STACK_WORK_RESTORED
     displayName: "Cache stack-work"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -xzf $STACK_ROOT.tar.gz -C $STACK_ROOT/..
+      tar -xzf $STACK_ROOT.cache -C $STACK_ROOT/..
     displayName: "Unpack STACK_ROOT cache"
     condition: eq(variables.STACK_ROOT_RESTORED, 'true')
   - bash: |
       mkdir -p .stack-work
-      tar -xzf .stack-work.tar.gz
+      tar -xzf .stack-work.cache
     displayName: "Unpack .stack-work cache"
     condition: eq(variables.STACK_WORK_RESTORED, 'true')
   - bash: |
@@ -96,6 +96,6 @@ jobs:
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
   - bash: |
-      tar -czf $STACK_ROOT.tar.gz $STACK_ROOT
-      tar -czf .stack-work.tar.gz .stack-work
+      tar -czf $STACK_ROOT.cache $STACK_ROOT
+      tar -czf .stack-work.cache .stack-work
     displayName: "Pack cache"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -84,7 +84,7 @@ jobs:
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
   - bash: |
-      mkdir .azure-cache
+      mkdir -p .azure-cache
       tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT
       tar -czf .azure-cache/stack-work.tar.gz .stack-work
     displayName: "Pack cache"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -26,7 +26,7 @@ jobs:
       stack-8.2.2:
         YAML_FILE: stack-8.2.2.yaml
   variables:
-    STACK_ROOT: $(Build.SourcesDirectory)/.stack-root
+    STACK_ROOT: /home/vsts/.stack
   steps:
   - task: CacheBeta@0
     inputs:
@@ -83,3 +83,6 @@ jobs:
   #     source .azure/linux.bashrc
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
+  - bash: |
+      rm -rf $STACK_ROOT/programs
+    displayName: "Clean STACK_ROOT programs"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -32,6 +32,18 @@ jobs:
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: $(STACK_ROOT)
     displayName: "Cache stack-root"
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        "stack-work"
+        $(Agent.OS)
+        $(Build.SourcesDirectory)/$(YAML_FILE)
+      path: .stack-work
+    displayName: "Cache stack-work"
+  - bash: |
+      rm -rf $STACK_ROOT/programs
+      rm -rf $STACK_ROOT/setup-exe-cache
+    displayName: "Clean STACK_ROOT programs"
   - bash: |
       git submodule sync
       git submodule update --init

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -22,7 +22,7 @@ jobs:
       stack-8.2.2:
         YAML_FILE: stack-8.2.2.yaml
   variables:
-    STACK_ROOT: $(Build.SourcesDirectory)/.stack-root
+    STACK_ROOT: /Users/vsts/.stack
   steps:
   - task: CacheBeta@0
     inputs:
@@ -32,14 +32,6 @@ jobs:
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: $(STACK_ROOT)
     displayName: "Cache stack-root"
-  - task: CacheBeta@0
-    inputs:
-      key: |
-        "stack-work"
-        $(Agent.OS)
-        $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: .stack-work
-    displayName: "Cache stack-work"
   - bash: |
       git submodule sync
       git submodule update --init
@@ -80,3 +72,6 @@ jobs:
   #     source .azure/macos.bashrc
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
+  - bash: |
+      rm -rf $STACK_ROOT/programs
+    displayName: "Clean STACK_ROOT programs"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -21,17 +21,21 @@ jobs:
         YAML_FILE: stack-8.4.2.yaml
       stack-8.2.2:
         YAML_FILE: stack-8.2.2.yaml
+  variables:
+    STACK_ROOT: $(Build.SourcesDirectory)/.stack-root
   steps:
   - task: CacheBeta@0
     inputs:
       key: |
+        "stack-root"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: $(Build.SourcesDirectory)/.stack-root
+      path: $(STACK_ROOT)
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
       key: |
+        "stack-work"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .stack-work
@@ -41,7 +45,6 @@ jobs:
       git submodule update --init
     displayName: Sync submodules
   - bash: |
-      export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root
       mkdir -p ~/.local/bin
       curl -skL https://get.haskellstack.org/stable/osx-x86_64.tar.gz | \
         tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin;

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -22,6 +22,20 @@ jobs:
       stack-8.2.2:
         YAML_FILE: stack-8.2.2.yaml
   steps:
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        $(Agent.OS)
+        $(Build.SourcesDirectory)/$(YAML_FILE)
+      path: $(Build.SourcesDirectory)/.stack-root
+    displayName: "Cache stack-root"
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        $(Agent.OS)
+        $(Build.SourcesDirectory)/$(YAML_FILE)
+      path: .stack-work
+    displayName: "Cache stack-work"
   - bash: |
       git submodule sync
       git submodule update --init

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -81,7 +81,7 @@ jobs:
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
   - bash: |
-      mkdir .azure-cache
+      mkdir -p .azure-cache
       tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT
       tar -czf .azure-cache/stack-work.tar.gz .stack-work
     displayName: "Pack cache"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -74,4 +74,5 @@ jobs:
   #   displayName: Run Test
   - bash: |
       rm -rf $STACK_ROOT/programs
+      rm -rf $STACK_ROOT/setup-exe-cache
     displayName: "Clean STACK_ROOT programs"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -30,7 +30,7 @@ jobs:
         "stack-root"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: $(STACK_ROOT)
+      path: $(STACK_ROOT).tar.gz
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
@@ -38,12 +38,15 @@ jobs:
         "stack-work"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: .stack-work
+      path: .stack-work.tar.gz
     displayName: "Cache stack-work"
   - bash: |
-      rm -rf $STACK_ROOT/programs
-      rm -rf $STACK_ROOT/setup-exe-cache
-    displayName: "Clean STACK_ROOT programs"
+      mkdir -p $STACK_ROOT
+      tar -xzf $STACK_ROOT.tar.gz -C $STACK_ROOT/..
+      mkdir -p .stack-work
+      tar -xzf .stack-work.tar.gz
+    displayName: "Unpack cache"
+    condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
       git submodule sync
       git submodule update --init
@@ -85,6 +88,6 @@ jobs:
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
   - bash: |
-      rm -rf $STACK_ROOT/programs
-      rm -rf $STACK_ROOT/setup-exe-cache
-    displayName: "Clean STACK_ROOT programs"
+      tar -czf $STACK_ROOT.tar.gz $STACK_ROOT
+      tar -czf .stack-work.tar.gz .stack-work
+    displayName: "Pack cache"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -30,7 +30,7 @@ jobs:
         "stack-root"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: $(STACK_ROOT).tar.gz
+      path: $(STACK_ROOT).cache
       cacheHitVar: STACK_ROOT_RESTORED
     displayName: "Cache stack-root"
   - task: CacheBeta@0
@@ -39,17 +39,17 @@ jobs:
         "stack-work"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: .stack-work.tar.gz
+      path: .stack-work.cache
       cacheHitVar: STACK_WORK_RESTORED
     displayName: "Cache stack-work"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -xzf $STACK_ROOT.tar.gz -C $STACK_ROOT/..
+      tar -xzf $STACK_ROOT.cache -C $STACK_ROOT/..
     displayName: "Unpack STACK_ROOT cache"
     condition: eq(variables.STACK_ROOT_RESTORED, 'true')
   - bash: |
       mkdir -p .stack-work
-      tar -xzf .stack-work.tar.gz
+      tar -xzf .stack-work.cache
     displayName: "Unpack .stack-work cache"
     condition: eq(variables.STACK_WORK_RESTORED, 'true')
   - bash: |
@@ -93,6 +93,6 @@ jobs:
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
   - bash: |
-      tar -czf $STACK_ROOT.tar.gz $STACK_ROOT
-      tar -czf .stack-work.tar.gz .stack-work
+      tar -czf $STACK_ROOT.cache $STACK_ROOT
+      tar -czf .stack-work.cache .stack-work
     displayName: "Pack cache"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -31,6 +31,7 @@ jobs:
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: $(STACK_ROOT).tar.gz
+      cacheHitVar: STACK_ROOT_RESTORED
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
@@ -39,14 +40,18 @@ jobs:
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .stack-work.tar.gz
+      cacheHitVar: STACK_WORK_RESTORED
     displayName: "Cache stack-work"
   - bash: |
       mkdir -p $STACK_ROOT
       tar -xzf $STACK_ROOT.tar.gz -C $STACK_ROOT/..
+    displayName: "Unpack STACK_ROOT cache"
+    condition: eq(variables.STACK_ROOT_RESTORED, 'true')
+  - bash: |
       mkdir -p .stack-work
       tar -xzf .stack-work.tar.gz
-    displayName: "Unpack cache"
-    condition: eq(variables.CACHE_RESTORED, 'true')
+    displayName: "Unpack .stack-work cache"
+    condition: eq(variables.STACK_WORK_RESTORED, 'true')
   - bash: |
       git submodule sync
       git submodule update --init

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -27,31 +27,19 @@ jobs:
   - task: CacheBeta@0
     inputs:
       key: |
-        "stack-root"
+        "cache"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: $(STACK_ROOT).cache
-      cacheHitVar: STACK_ROOT_RESTORED
-    displayName: "Cache stack-root"
-  - task: CacheBeta@0
-    inputs:
-      key: |
-        "stack-work"
-        $(Agent.OS)
-        $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: .stack-work.cache
-      cacheHitVar: STACK_WORK_RESTORED
-    displayName: "Cache stack-work"
+      path: .azure-cache
+      cacheHitVar: CACHE_RESTORED
+    displayName: "Download cache"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -xzf $STACK_ROOT.cache -C $STACK_ROOT/..
-    displayName: "Unpack STACK_ROOT cache"
-    condition: eq(variables.STACK_ROOT_RESTORED, 'true')
-  - bash: |
+      tar -xzf .azure-cache/stack-root.tar.gz -C /
       mkdir -p .stack-work
-      tar -xzf .stack-work.cache
-    displayName: "Unpack .stack-work cache"
-    condition: eq(variables.STACK_WORK_RESTORED, 'true')
+      tar -xzf .azure-cache/stack-work.tar.gz
+    displayName: "Unpack cache"
+    condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
       git submodule sync
       git submodule update --init
@@ -93,6 +81,7 @@ jobs:
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
   - bash: |
-      tar -czf $STACK_ROOT.cache $STACK_ROOT
-      tar -czf .stack-work.cache .stack-work
+      mkdir .azure-cache
+      tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT
+      tar -czf .azure-cache/stack-work.tar.gz .stack-work
     displayName: "Pack cache"

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -23,17 +23,22 @@ jobs:
         YAML_FILE: stack-8.4.2.yaml
       stack-8.2.2:
         YAML_FILE: stack-8.2.2.yaml
+  variables:
+    STACK_ROOT: "C:\\sr"
+
   steps:
   - task: CacheBeta@0
     inputs:
       key: |
+        "stack-root"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
-      path: "C:\\sr"
+      path: $(STACK_ROOT)
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
       key: |
+        "stack-work"
         $(Agent.OS)
         $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .stack-work

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -24,6 +24,20 @@ jobs:
       stack-8.2.2:
         YAML_FILE: stack-8.2.2.yaml
   steps:
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        $(Agent.OS)
+        $(Build.SourcesDirectory)/$(YAML_FILE)
+      path: "C:\\sr"
+    displayName: "Cache stack-root"
+  - task: CacheBeta@0
+    inputs:
+      key: |
+        $(Agent.OS)
+        $(Build.SourcesDirectory)/$(YAML_FILE)
+      path: .stack-work
+    displayName: "Cache stack-work"
   - bash: |
       git submodule sync
       git submodule update --init

--- a/.azure/windows.bashrc
+++ b/.azure/windows.bashrc
@@ -1,4 +1,3 @@
-export STACK_ROOT="C:\\sr"
 export LOCAL_BIN_PATH=$(cygpath $APPDATA\\local\\bin)
 export Z3_BIN_PATH=/usr/local/z3-4.8.5-x64-win/bin
 export PATH=$Z3_BIN_PATH:$LOCAL_BIN_PATH:$PATH


### PR DESCRIPTION
* Azure has started recently to offer caching services as a preview:  https://docs.microsoft.com/en-us/azure/devops/pipelines/caching
* It has some warts affecting linux and macos builds:
  * [Cached files lost their attributes](https://github.com/microsoft/azure-pipelines-tasks/issues/10841) inluding being executables so the cache cant be used out-of-the-box (ironically in windows works). I had to pack the directories in tar files to preserve its attrs..
  * But tar files cant be cached directly [cause the `tar` utility sees them as directories although they are not](https://github.com/microsoft/azure-pipelines-tasks/issues/10925#issuecomment-513215241) (!!) .. so i had to put the tar files in a directory to keep them safe

When the first issue is corrected, the unix and macos config will be similar to windows one.

With cache builds terminate in about 15 mins! 
See linux and windows builds here: https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=177