### PR TITLE
Replace every occurrence of build-doc by build-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,14 +221,14 @@ Install **Nightly** (and hoogle docs):
 
 ```bash
 stack ./install.hs hie-8.6.4
-stack ./install.hs build-doc
+stack ./install.hs build-data
 ```
 
 Install **LTS** (and hoogle docs):
 
 ```bash
 stack ./install.hs hie-8.4.4
-stack ./install.hs build-doc
+stack ./install.hs build-data
 ```
 
 The Haskell IDE Engine can also be built with `cabal new-build` instead of `stack build`.
@@ -237,7 +237,7 @@ However, this approach does currently not work for windows due to a missing feat
 To see what GHC versions are available, the command `stack install.hs cabal-ghcs` can be used.
 It will list all GHC versions that are on the path and their respective installation directory.
 If you think, this list is incomplete, you can try to modify the PATH variable, such that the executables can be found.
-Note, that the targets `cabal-build`, `cabal-build-doc` and `cabal-build-all` depend on the found GHC versions.
+Note, that the targets `cabal-build`, `cabal-build-data` and `cabal-build-all` depend on the found GHC versions.
 They install Haskell IDE Engine only for the found GHC versions.
 
 An example output is:
@@ -256,7 +256,7 @@ If your desired ghc has been found, you use it to install Haskell IDE Engine.
 
 ```bash
 stack install.hs cabal-hie-8.4.4
-stack install.hs cabal-build-doc
+stack install.hs cabal-build-data
 ```
 
 To install HIE for all GHC versions that are present on your system, use:

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -29,7 +29,7 @@ The build script `install.hs` defines several targets using the `shake` build sy
 
 * `hie-*`: builds and installs the `hie` binaries. Also renames the binaries to contain the correct version-number.
 * `build`: builds and installs `hie` binaries for all supported `ghc` versions.
-* `build-doc`: builds the hoogle-db required by `hie`
+* `build-data`: builds the hoogle-db required by `hie`
 * `cabal-*`: execute the same task as the original target, but with `cabal` instead of `stack`
 
 Each `stack-*.yaml` contains references to packages in the submodules. Calling `stack` with one of those causes the build to fail if the submodules have not been initialized already. The file `shake.yaml` solves this issue invoking the `git` binary itself to update the submodules. Moreover, it specifies the correct version of `shake` and is used for installing all run-time dependencies such as `cabal` and `hoogle` if necessary.


### PR DESCRIPTION
Since b77e39beb1642abe75f8c4044819ba8e72792687, the `build-doc` goal got renamed into `build-data`. However the documentation is still referencing the old naming convention.

This PR updates the documentation in order to build the Hoogle database using the new `build-data` goal.