### PR TITLE
lift required stack-version to 2.1.1

### DIFF
--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -86,7 +86,7 @@ stackExeIsOldFailMsg stackVersion =
     ++ "Please run `stack upgrade` to upgrade your stack installation"
 
 requiredStackVersion :: RequiredVersion
-requiredStackVersion = [1, 9, 3]
+requiredStackVersion = [2, 1, 1]
 
 -- |Stack build fails message
 stackBuildFailMsg :: String


### PR DESCRIPTION
Closes #1328. 

Is lifting the stack-version to 2.1.1 ok? Do we need still to support stack 1.9 ?