### PR TITLE
Install: Fix broken stack-build target and fix cabal run help msg

### DIFF
--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -15,9 +15,9 @@ printUsage :: Action ()
 printUsage = do
   printLine ""
   printLine "Usage:"
-  printLineIndented ("stack install.hs <target>")
+  printLineIndented "stack install.hs <target>"
   printLineIndented "or"
-  printLineIndented ("cabal new-run install.hs --project-file shake.project <target>")
+  printLineIndented "cabal new-run install.hs --project-file install/shake.project <target>"
 
 -- | short help message is printed by default
 shortHelpMessage :: Action ()

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -91,7 +91,7 @@ defaultMain = do
       )
 
     -- stack specific targets
-    phony "stack-build"     (need (reverse $ map ("hie-" ++) hieVersions))
+    phony "stack-build"     (need (reverse $ map ("stack-hie-" ++) hieVersions))
     phony "stack-build-all" (need ["build-data", "build"])
     phony "stack-build-data" $ do
       need ["submodules"]


### PR DESCRIPTION
Fixes `stack-build` target which was broken if I executed the script with `cabal v2-run`