### PR TITLE
Remove cabal check from stack builds

### DIFF
--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -66,7 +66,7 @@ installCabal = do
   -- install `cabal-install` if not already installed
   unless cabalExeOk $ execStackShake_ ["install", "cabal-install"]
 
--- | check `stack` has the required version
+-- | check `cabal` has the required version
 checkCabal :: Action ()
 checkCabal = do
   cabalVersion <- getCabalVersion
@@ -92,7 +92,7 @@ cabalInstallNotSuportedFailMsg =
     ++ "If this system has been falsely identified, please open an issue at:\n\thttps://github.com/haskell/haskell-ide-engine\n"
 
 
--- | Error message when the `stack` binary is an older version
+-- | Error message when the `cabal` binary is an older version
 cabalInstallIsOldFailMsg :: String -> String
 cabalInstallIsOldFailMsg cabalVersion =
   "The `cabal` executable is outdated.\n"

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -102,7 +102,6 @@ defaultMain = do
       (\version -> phony ("stack-hie-" ++ version) $ do
         need ["submodules"]
         need ["check-stack"]
-        need ["cabal"]
         stackBuildHie version
         stackInstallHie version
       )


### PR DESCRIPTION
Stack should provide its own cabal, so I don't think the system cabal is
relevant here. This worked for me despite the check failing.