### PR TITLE
Do not traverse into Generated bindings when creating TypeMap

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/Compat.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Compat.hs
@@ -134,6 +134,25 @@ pattern FunBindType t <-
     GHC.FunBind (GHC.L _ (Var.varType -> t)) _ _ _ _
 #endif
 
+pattern FunBindGen :: Type.Type -> GHC.MatchGroup GhcTc (GHC.LHsExpr GhcTc) -> GHC.HsBindLR GhcTc GhcTc
+pattern FunBindGen t fmatches <-
+#if MIN_VERSION_ghc(8, 6, 0)
+    GHC.FunBind _ (GHC.L _ (Var.varType -> t)) fmatches _ _
+#elif MIN_VERSION_ghc(8, 4, 0)
+    GHC.FunBind (GHC.L _ (Var.varType -> t)) fmatches _ _ _
+#else
+    GHC.FunBind (GHC.L _ (Var.varType -> t)) fmatches _ _ _
+#endif
+
+pattern AbsBinds :: GHC.LHsBinds GhcTc -> GHC.HsBindLR GhcTc GhcTc
+pattern AbsBinds bs <-
+#if MIN_VERSION_ghc(8, 6, 0)
+    GHC.AbsBinds _ _ _ _ _ bs _
+#elif MIN_VERSION_ghc(8, 4, 0)
+    GHC.AbsBinds _ _ _ _ bs _
+#else
+    GHC.AbsBinds _ _ _ _ bs
+#endif
 
 #if MIN_VERSION_ghc(8, 6, 0)
 matchGroupType :: GHC.MatchGroupTc -> GHC.Type

--- a/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
@@ -22,7 +22,7 @@ import qualified TcHsSyn
 import qualified CoreUtils
 import qualified Type
 import qualified Desugar
-import           Haskell.Ide.Engine.Compat
+import qualified Haskell.Ide.Engine.Compat as Compat
 
 import           Haskell.Ide.Engine.ArtifactMap
 
@@ -40,7 +40,7 @@ everythingInTypecheckedSourceM xs = bs
   where
     bs = foldBag (liftA2 IM.union) processBind (return IM.empty) xs
 
-processBind :: GhcMonad m => GHC.LHsBindLR GHC.GhcTc GHC.GhcTc -> m TypeMap
+processBind :: GhcMonad m => GHC.LHsBindLR Compat.GhcTc Compat.GhcTc -> m TypeMap
 processBind x@(GHC.L (GHC.RealSrcSpan spn) b) =
   case b of
     GHC.FunBind _ fid fmatches _ _ ->
@@ -73,7 +73,7 @@ types = everythingButTypeM @GHC.Id (ty `combineM` fun `combineM` funBind)
 
   funBind :: forall a' . (GhcMonad m, Data a') => a' -> m TypeMap
   funBind term = case cast term of
-    (Just (GHC.L (GHC.RealSrcSpan spn) (FunBindType t))) ->
+    (Just (GHC.L (GHC.RealSrcSpan spn) (Compat.FunBindType t))) ->
       return (IM.singleton (rspToInt spn) t)
     _ -> return IM.empty
 
@@ -128,19 +128,19 @@ everythingButM f x = do
 --
 -- See #16233<https://gitlab.haskell.org/ghc/ghc/issues/16233>
 getType
-  :: GhcMonad m => GHC.LHsExpr GhcTc -> m (Maybe (GHC.SrcSpan, Type.Type))
+  :: GhcMonad m => GHC.LHsExpr Compat.GhcTc -> m (Maybe (GHC.SrcSpan, Type.Type))
 getType e@(GHC.L spn e') =
   -- Some expression forms have their type immediately available
   let
     tyOpt = case e' of
-      HsOverLitType t -> Just t
-      HsLitType t -> Just t
-      HsLamType t -> Just t
-      HsLamCaseType t -> Just t
-      HsCaseType t -> Just t
-      ExplicitListType t -> Just t
-      ExplicitSumType t -> Just t
-      HsMultiIfType t -> Just t
+      Compat.HsOverLitType t -> Just t
+      Compat.HsLitType t -> Just t
+      Compat.HsLamType t -> Just t
+      Compat.HsLamCaseType t -> Just t
+      Compat.HsCaseType t -> Just t
+      Compat.ExplicitListType t -> Just t
+      Compat.ExplicitSumType t -> Just t
+      Compat.HsMultiIfType t -> Just t
 
       _                        -> Nothing
   in  case tyOpt of

--- a/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/TypeMap.hs
@@ -12,7 +12,6 @@ import qualified GHC
 import           GHC                            ( TypecheckedModule, GhcMonad )
 import           Bag
 import           BasicTypes
-import           Var
 
 import           Data.Data                     as Data
 import           Control.Monad.IO.Class
@@ -43,13 +42,13 @@ everythingInTypecheckedSourceM xs = bs
 processBind :: GhcMonad m => GHC.LHsBindLR Compat.GhcTc Compat.GhcTc -> m TypeMap
 processBind x@(GHC.L (GHC.RealSrcSpan spn) b) =
   case b of
-    GHC.FunBind _ fid fmatches _ _ ->
+    Compat.FunBindGen t fmatches ->
       case GHC.mg_origin fmatches of
         Generated -> return IM.empty
         FromSource -> do
           im <- types fmatches
-          return $ (IM.singleton (rspToInt spn) (varType (GHC.unLoc fid))) `IM.union` im
-    GHC.AbsBinds _ _ _ _ _ bs _ -> everythingInTypecheckedSourceM bs
+          return $ IM.singleton (rspToInt spn) t `IM.union` im
+    Compat.AbsBinds bs -> everythingInTypecheckedSourceM bs
     _ -> types x
 processBind _ = return IM.empty
 

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -486,7 +486,6 @@ ghcmodSpec =
               , (Range (toPos (33, 15)) (toPos (33, 19)), "Int -> Test -> ShowS")
               , (Range (toPos (33, 15)) (toPos (33, 19)), "Test -> String")
               , (Range (toPos (33, 15)) (toPos (33, 19)), "[Test] -> ShowS")
-              , (Range (toPos (33, 15)) (toPos (33, 19)), "Int -> Test -> ShowS")
 #if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,0,0)))
 #else
               , (Range (toPos (33, 15)) (toPos (33, 19)), "[Test] -> ShowS")
@@ -503,7 +502,6 @@ ghcmodSpec =
           arg = TP False uri (toPos (33,21))
           res = IdeResultOk
               [ (Range (toPos (33, 21)) (toPos (33, 23)), "(Test -> Test -> Bool) -> (Test -> Test -> Bool) -> Eq Test")
-              , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
 #if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,0,0)))

--- a/test/unit/GhcModPluginSpec.hs
+++ b/test/unit/GhcModPluginSpec.hs
@@ -488,6 +488,7 @@ ghcmodSpec =
               , (Range (toPos (33, 15)) (toPos (33, 19)), "[Test] -> ShowS")
 #if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,0,0)))
 #else
+              , (Range (toPos (33, 15)) (toPos (33, 19)), "Int -> Test -> ShowS")
               , (Range (toPos (33, 15)) (toPos (33, 19)), "[Test] -> ShowS")
 #endif
               ]
@@ -506,6 +507,7 @@ ghcmodSpec =
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
 #if (defined(MIN_VERSION_GLASGOW_HASKELL) && (MIN_VERSION_GLASGOW_HASKELL(8,4,0,0)))
 #else
+              , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
               , (Range (toPos (33, 21)) (toPos (33, 23)), "Test -> Test -> Bool")
 #endif
               ]


### PR DESCRIPTION
Backported from https://github.com/mpickering/haskell-ide-engine/commit/13daf07124770a2643b63f8d581f88cacdea7ce1 by cherry-picking.