### PR TITLE
Add different Contexts for Module, import etc...

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -177,6 +177,7 @@ test-suite unit-test
   main-is:             Main.hs
   other-modules:       ApplyRefactPluginSpec
                        CodeActionsSpec
+                       ContextSpec
                        DiffSpec
                        ExtensibleStateSpec
                        GhcModPluginSpec
@@ -196,6 +197,7 @@ test-suite unit-test
                      , directory
                      , filepath
                      , free
+                     , ghc
                      , haskell-ide-engine
                      , haskell-lsp-types >= 0.15.0.0
                      , hie-test-utils

--- a/hie-plugin-api/Haskell/Ide/Engine/Context.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Context.hs
@@ -1,7 +1,6 @@
 module Haskell.Ide.Engine.Context where
 
 import Data.Generics
-import Data.Foldable (asum)
 import Language.Haskell.LSP.Types
 import GHC
 import qualified GhcModCore as GM (GhcPs) -- for GHC 8.2.2
@@ -37,10 +36,10 @@ getContext pos pm
   , pos `isInsideRange` r
   = Just ExportContext
 
-  | Just ctx <- everything (<|>) (Nothing `mkQ` go `extQ` goInline) decl
+  | Just ctx <- something (Nothing `mkQ` go `extQ` goInline) decl
   = Just ctx
 
-  | Just ctx <- asum $ map importGo imports
+  | Just ctx <- something (Nothing `mkQ` importGo) imports
   = Just ctx
 
   | otherwise

--- a/hie-plugin-api/Haskell/Ide/Engine/Context.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Context.hs
@@ -14,14 +14,11 @@ import Control.Applicative ( (<|>) )
 -- smarter code completion
 data Context = TypeContext
              | ValueContext
-             | ModuleContext String
-             | ImportContext String
-             | ImportListContext String
-             | ImportHidingContext String
-             | ExportContext
-             | InstanceContext
-             | ClassContext
-             | DerivingContext
+             | ModuleContext String -- ^ module context with module name
+             | ImportContext String -- ^ import context with module name
+             | ImportListContext String -- ^ import list context with module name
+             | ImportHidingContext String -- ^ import hiding context with module name
+             | ExportContext -- ^ List of exported identifiers from the current module
   deriving (Show, Eq)
 
 -- | Generates a map of where the context is a type and where the context is a value
@@ -56,15 +53,6 @@ getContext pos pm
           | otherwise = Nothing
         go (L (GHC.RealSrcSpan r) GHC.ValD {})
           | pos `isInsideRange` r = Just ValueContext
-          | otherwise = Nothing
-        go (L (GHC.RealSrcSpan r) GHC.InstD {})
-          | pos `isInsideRange` r = Just InstanceContext
-          | otherwise = Nothing
-        go (L (GHC.RealSrcSpan r) GHC.DerivD {})
-          | pos `isInsideRange` r = Just DerivingContext
-          | otherwise = Nothing
-        go (L (GHC.RealSrcSpan r) (GHC.TyClD _ GHC.ClassDecl {}))
-          | pos `isInsideRange` r = Just ClassContext
           | otherwise = Nothing
         go _ = Nothing
 

--- a/hie-plugin-api/Haskell/Ide/Engine/Context.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Context.hs
@@ -1,12 +1,12 @@
-{-# LANGUAGE LambdaCase #-}
 module Haskell.Ide.Engine.Context where
 
 import Data.Generics
-import Data.List (find)
+import Data.Foldable (asum)
 import Language.Haskell.LSP.Types
 import GHC
 import qualified GhcModCore as GM (GhcPs) -- for GHC 8.2.2
 import Haskell.Ide.Engine.PluginUtils
+import Control.Applicative ( (<|>) )
 
 -- | A context of a declaration in the program
 -- e.g. is the declaration a type declaration or a value declaration
@@ -17,7 +17,12 @@ data Context = TypeContext
              | ValueContext
              | ModuleContext String
              | ImportContext String
+             | ImportListContext String
+             | ImportHidingContext String
              | ExportContext
+             | InstanceContext
+             | ClassContext
+             | DerivingContext
   deriving (Show, Eq)
 
 -- | Generates a map of where the context is a type and where the context is a value
@@ -32,42 +37,64 @@ getContext pos pm
   , pos `isInsideRange` r
   = Just ExportContext
 
-  | Just ctx <- everything join (Nothing `mkQ` go `extQ` goInline) decl
+  | Just ctx <- everything (<|>) (Nothing `mkQ` go `extQ` goInline) decl
   = Just ctx
 
-  | Just (L _ impDecl) <- importRegion
-  = Just (ImportContext (moduleNameString $ unLoc $ ideclName impDecl))
+  | Just ctx <- asum $ map importGo imports
+  = Just ctx
 
   | otherwise
   = Nothing
-  
+
   where decl = hsmodDecls $ unLoc $ pm_parsed_source pm
         moduleHeader = hsmodName $ unLoc $ pm_parsed_source pm
         exportList = hsmodExports $ unLoc $ pm_parsed_source pm
         imports = hsmodImports $ unLoc $ pm_parsed_source pm
 
         go :: LHsDecl GM.GhcPs -> Maybe Context
-        go (L (RealSrcSpan r) (SigD {}))
+        go (L (RealSrcSpan r) SigD {})
           | pos `isInsideRange` r = Just TypeContext
           | otherwise = Nothing
-        go (L (GHC.RealSrcSpan r) (GHC.ValD {}))
+        go (L (GHC.RealSrcSpan r) GHC.ValD {})
           | pos `isInsideRange` r = Just ValueContext
           | otherwise = Nothing
+        go (L (GHC.RealSrcSpan r) GHC.InstD {})
+          | pos `isInsideRange` r = Just InstanceContext
+          | otherwise = Nothing
+        go (L (GHC.RealSrcSpan r) GHC.DerivD {})
+          | pos `isInsideRange` r = Just DerivingContext
+          | otherwise = Nothing
+        go (L (GHC.RealSrcSpan r) (GHC.TyClD _ GHC.ClassDecl {}))
+          | pos `isInsideRange` r = Just ClassContext
+          | otherwise = Nothing
         go _ = Nothing
+
         goInline :: GHC.LHsType GM.GhcPs -> Maybe Context
         goInline (GHC.L (GHC.RealSrcSpan r) _)
           | pos `isInsideRange` r = Just TypeContext
           | otherwise = Nothing
         goInline _ = Nothing
-        join Nothing x = x
-        join (Just x) _ = Just x
+
         p `isInsideRange` r = sp <= p && p <= ep
           where (sp, ep) = unpackRealSrcSpan r
 
-        importRegion = find
-          (\case
-            (L (RealSrcSpan r) _) -> pos `isInsideRange` r
-            _                     -> False
-          )
-          imports
+        importGo :: GHC.LImportDecl GM.GhcPs -> Maybe Context
+        importGo (L (RealSrcSpan r) impDecl)
+          | pos `isInsideRange` r
+          = importInline importModuleName (ideclHiding impDecl)
+          <|> Just (ImportContext importModuleName)
+
+          | otherwise = Nothing
+          where importModuleName = moduleNameString $ unLoc $ ideclName impDecl
+
+        importGo _ = Nothing
+
+        importInline :: String -> Maybe (Bool,  GHC.Located [GHC.LIE GM.GhcPs]) -> Maybe Context
+        importInline modName (Just (True, L (RealSrcSpan r) _))
+          | pos `isInsideRange` r = Just $ ImportHidingContext modName
+          | otherwise = Nothing
+        importInline modName (Just (False, L (RealSrcSpan r) _))
+          | pos `isInsideRange` r = Just $ ImportListContext modName
+          | otherwise = Nothing
+        importInline _ _ = Nothing
 

--- a/src/Haskell/Ide/Engine/LSP/Completions.hs
+++ b/src/Haskell/Ide/Engine/LSP/Completions.hs
@@ -373,6 +373,7 @@ getCompletions uri prefixInfo (WithSnippets withSnippets) =
                 ctxCompls' = case context of
                               TypeContext -> filter isTypeCompl compls
                               ValueContext -> filter (not . isTypeCompl) compls
+                              _ -> []
                 -- Add whether the text to insert has backticks
                 ctxCompls = map (\comp -> comp { isInfix = infixCompls }) ctxCompls'
 

--- a/src/Haskell/Ide/Engine/LSP/Completions.hs
+++ b/src/Haskell/Ide/Engine/LSP/Completions.hs
@@ -373,7 +373,7 @@ getCompletions uri prefixInfo (WithSnippets withSnippets) =
                 ctxCompls' = case context of
                               TypeContext -> filter isTypeCompl compls
                               ValueContext -> filter (not . isTypeCompl) compls
-                              _ -> []
+                              _ -> filter (not . isTypeCompl) compls
                 -- Add whether the text to insert has backticks
                 ctxCompls = map (\comp -> comp { isInfix = infixCompls }) ctxCompls'
 

--- a/test/testdata/context/ExampleContext.hs
+++ b/test/testdata/context/ExampleContext.hs
@@ -1,0 +1,8 @@
+module ExampleContext (foo) where
+
+import Data.List
+import Control.Monad
+
+foo :: Int -> Int
+foo xs = xs + 1
+

--- a/test/testdata/context/ExampleContext.hs
+++ b/test/testdata/context/ExampleContext.hs
@@ -1,8 +1,17 @@
 module ExampleContext (foo) where
 
-import Data.List
-import Control.Monad
+import Data.List (find)
+import Control.Monad hiding (fix)
 
 foo :: Int -> Int
 foo xs = xs + 1
+
+data Foo a = Foo a
+    deriving (Show)
+
+class Bar a where
+    bar :: a -> Integer
+
+instance Integral a => Bar (Foo a) where
+    bar (Foo a) = toInteger a
 

--- a/test/testdata/context/ExampleContext.hs
+++ b/test/testdata/context/ExampleContext.hs
@@ -4,9 +4,12 @@ import Data.List (find)
 import Control.Monad hiding (fix)
 
 foo :: Int -> Int
-foo xs = xs + 1
+foo xs = bar xs + 1
+    where
+        bar :: Int -> Int
+        bar x = x + 2
 
-data Foo a = Foo a
+data Foo a = Foo a 
     deriving (Show)
 
 class Bar a where

--- a/test/testdata/context/Foo/Bar.hs
+++ b/test/testdata/context/Foo/Bar.hs
@@ -1,0 +1,3 @@
+module Foo.Bar where
+
+

--- a/test/unit/ContextSpec.hs
+++ b/test/unit/ContextSpec.hs
@@ -32,10 +32,10 @@ spec = describe "Context of different cursor positions" $ do
     it "module header context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-              fp_ <- makeAbsolute "./ExampleContext.hs"
+              fp <- makeAbsolute "./ExampleContext.hs"
               let res = IdeResultOk (Just (ModuleContext "ExampleContext"))
 
-              actual <- getContextAt fp_ (toPos (1, 10))
+              actual <- getContextAt fp (toPos (1, 10))
 
               actual `shouldBe` res
 
@@ -43,71 +43,71 @@ spec = describe "Context of different cursor positions" $ do
     it "module export list context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-              fp_ <- makeAbsolute "./ExampleContext.hs"
+              fp <- makeAbsolute "./ExampleContext.hs"
               let res = IdeResultOk (Just ExportContext)
-              actual <- getContextAt fp_ (toPos (1, 24))
+              actual <- getContextAt fp (toPos (1, 24))
 
               actual `shouldBe` res
 
     it "value context" $ withCurrentDirectory "./test/testdata/context" $ do
-        fp_ <- makeAbsolute "./ExampleContext.hs"
+        fp <- makeAbsolute "./ExampleContext.hs"
         let res = IdeResultOk (Just ValueContext)
-        actual <- getContextAt fp_ (toPos (7, 6))
+        actual <- getContextAt fp (toPos (7, 6))
 
         actual `shouldBe` res
 
     it "value addition context" $ withCurrentDirectory "./test/testdata/context" $ do
-        fp_ <- makeAbsolute "./ExampleContext.hs"
+        fp <- makeAbsolute "./ExampleContext.hs"
         let res = IdeResultOk (Just ValueContext)
-        actual <- getContextAt fp_ (toPos (7, 12))
+        actual <- getContextAt fp (toPos (7, 12))
 
         actual `shouldBe` res
 
     it "import context" $ withCurrentDirectory "./test/testdata/context" $ do
-        fp_ <- makeAbsolute "./ExampleContext.hs"
+        fp <- makeAbsolute "./ExampleContext.hs"
         let res = IdeResultOk (Just (ImportContext "Data.List"))
-        actual <- getContextAt fp_ (toPos (3, 8))
+        actual <- getContextAt fp (toPos (3, 8))
 
         actual `shouldBe` res
 
     it "import list context" $ withCurrentDirectory "./test/testdata/context" $ do
-        fp_ <- makeAbsolute "./ExampleContext.hs"
+        fp <- makeAbsolute "./ExampleContext.hs"
         let res = IdeResultOk (Just (ImportListContext "Data.List"))
-        actual <- getContextAt fp_ (toPos (3, 20))
+        actual <- getContextAt fp (toPos (3, 20))
 
         actual `shouldBe` res
 
     it "import hiding context" $ withCurrentDirectory "./test/testdata/context" $ do
-        fp_ <- makeAbsolute "./ExampleContext.hs"
+        fp <- makeAbsolute "./ExampleContext.hs"
         let res = IdeResultOk (Just (ImportHidingContext "Control.Monad"))
-        actual <- getContextAt fp_ (toPos (4, 32))
+        actual <- getContextAt fp (toPos (4, 32))
 
         actual `shouldBe` res
 
     it "function declaration context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-              fp_ <- makeAbsolute "./ExampleContext.hs"
+              fp <- makeAbsolute "./ExampleContext.hs"
               let res = IdeResultOk (Just TypeContext)
-              actual <- getContextAt fp_ (toPos (6, 1))
+              actual <- getContextAt fp (toPos (6, 1))
 
               actual `shouldBe` res
-              
+
     it "function signature context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk (Just TypeContext)
-            actual <- getContextAt fp_ (toPos (6, 8))
+            actual <- getContextAt fp (toPos (6, 8))
             actual `shouldBe` res
 
 
     it "function definition context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-              fp_ <- makeAbsolute "./ExampleContext.hs"
+              fp <- makeAbsolute "./ExampleContext.hs"
               let res = IdeResultOk (Just ValueContext)
-              actual <- getContextAt fp_ (toPos (7, 1))
+              actual <- getContextAt fp (toPos (7, 1))
               actual `shouldBe` res
 
     -- This is interesting, the context for this is assumed to be ValueContext
@@ -118,17 +118,17 @@ spec = describe "Context of different cursor positions" $ do
     it "inner function declaration context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk (Just ValueContext)
-            actual <- getContextAt fp_ (toPos (9, 10))
+            actual <- getContextAt fp (toPos (9, 10))
             actual `shouldBe` res
 
     it "inner function value context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk (Just ValueContext)
-            actual <- getContextAt fp_ (toPos (10, 10))
+            actual <- getContextAt fp (toPos (10, 10))
             actual `shouldBe` res
 
 
@@ -136,51 +136,55 @@ spec = describe "Context of different cursor positions" $ do
     it "data declaration context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk Nothing
-            actual <- getContextAt fp_ (toPos (12, 8))
+            actual <- getContextAt fp (toPos (12, 8))
             actual `shouldBe` res
 
     -- Define a datatype.
     it "data definition context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk (Just TypeContext)
-            actual <- getContextAt fp_ (toPos (12, 18))
+            actual <- getContextAt fp (toPos (12, 18))
             actual `shouldBe` res
 
+    -- Declaration of a class. Should be something with types.
     it "class declaration context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
-            let res = IdeResultOk (Just ClassContext)
-            actual <- getContextAt fp_ (toPos (15, 8))
+            fp <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk Nothing
+            actual <- getContextAt fp (toPos (15, 8))
             actual `shouldBe` res
 
+    -- Function signature in class declaration.
+    -- Ought to be TypeContext
     it "class declaration function sig context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
-            let res = IdeResultOk (Just ClassContext)
-            actual <- getContextAt fp_ (toPos (16, 7))
+            fp <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk Nothing
+            actual <- getContextAt fp (toPos (16, 7))
             actual `shouldBe` res
 
     it "instance declaration context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
-            let res = IdeResultOk (Just InstanceContext)
-            actual <- getContextAt fp_ (toPos (18, 7))
+            fp <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk Nothing
+            actual <- getContextAt fp (toPos (18, 7))
             actual `shouldBe` res
 
-    -- Function definition
+    -- Function definition in an instance declaration
+    -- Should be ValueContext, but nothing is fine, too for now
     it "instance declaration function def context"
             $ withCurrentDirectory "./test/testdata/context"
             $ do
-                fp_ <- makeAbsolute "./ExampleContext.hs"
-                let res = IdeResultOk (Just InstanceContext)
-                actual <- getContextAt fp_ (toPos (19, 6))
+                fp <- makeAbsolute "./ExampleContext.hs"
+                let res = IdeResultOk Nothing
+                actual <- getContextAt fp (toPos (19, 6))
                 actual `shouldBe` res
 
     -- This seems plain wrong, if the cursor is on the String "deriving",
@@ -189,9 +193,9 @@ spec = describe "Context of different cursor positions" $ do
     it "deriving context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk Nothing
-            actual <- getContextAt fp_ (toPos (13, 9))
+            actual <- getContextAt fp (toPos (13, 9))
             actual `shouldBe` res
 
     -- Cursor is directly before the open parenthesis of a deriving clause.
@@ -201,9 +205,9 @@ spec = describe "Context of different cursor positions" $ do
     it "deriving parenthesis context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk Nothing
-            actual <- getContextAt fp_ (toPos (13, 14))
+            actual <- getContextAt fp (toPos (13, 14))
             actual `shouldBe` res
 
     -- Cursor is directly after the open parenthesis of a deriving clause.
@@ -215,32 +219,32 @@ spec = describe "Context of different cursor positions" $ do
     it "deriving parenthesis context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk (Just TypeContext)
-            actual <- getContextAt fp_ (toPos (13, 15))
+            actual <- getContextAt fp (toPos (13, 15))
             actual `shouldBe` res
 
     it "deriving typeclass context"
         $ withCurrentDirectory "./test/testdata/context"
         $ do
-            fp_ <- makeAbsolute "./ExampleContext.hs"
+            fp <- makeAbsolute "./ExampleContext.hs"
             let res = IdeResultOk (Just TypeContext)
-            actual <- getContextAt fp_ (toPos (13, 18))
+            actual <- getContextAt fp (toPos (13, 18))
             actual `shouldBe` res
 
     -- Point at an empty line.
     -- There is no context
     it "nothing" $ withCurrentDirectory "./test/testdata/context" $ do
-        fp_ <- makeAbsolute "./ExampleContext.hs"
+        fp <- makeAbsolute "./ExampleContext.hs"
         let res = IdeResultOk Nothing
-        actual <- getContextAt fp_ (toPos (2, 1))
+        actual <- getContextAt fp (toPos (2, 1))
         actual `shouldBe` res
 
-getContextAt :: [Char] -> Position -> IO (IdeResult (Maybe Context))
-getContextAt fp_ pos = do
-    let arg = filePathToUri fp_
+getContextAt :: FilePath -> Position -> IO (IdeResult (Maybe Context))
+getContextAt fp pos = do
+    let arg = filePathToUri fp
     runSingle (IdePlugins mempty) $ do
         _ <- setTypecheckedModule arg
-        pluginGetFile "getContext: " arg $ \fp ->
-            ifCachedModuleAndData fp (IdeResultOk Nothing) $ \tm _ () ->
+        pluginGetFile "getContext: " arg $ \fp_ ->
+            ifCachedModuleAndData fp_ (IdeResultOk Nothing) $ \tm _ () ->
                 return $ IdeResultOk $ getContext pos (tm_parsed_module tm)

--- a/test/unit/ContextSpec.hs
+++ b/test/unit/ContextSpec.hs
@@ -56,7 +56,7 @@ spec = describe "Context of different cursor positions" $ do
 
         actual `shouldBe` res
 
-    it "value context" $ withCurrentDirectory "./test/testdata/context" $ do
+    it "value addition context" $ withCurrentDirectory "./test/testdata/context" $ do
         fp_ <- makeAbsolute "./ExampleContext.hs"
         let res = IdeResultOk (Just ValueContext)
         actual <- getContextAt fp_ (toPos (7, 12))
@@ -67,6 +67,13 @@ spec = describe "Context of different cursor positions" $ do
         fp_ <- makeAbsolute "./ExampleContext.hs"
         let res = IdeResultOk (Just (ImportContext "Data.List"))
         actual <- getContextAt fp_ (toPos (3, 8))
+
+        actual `shouldBe` res
+
+    it "import list context" $ withCurrentDirectory "./test/testdata/context" $ do
+        fp_ <- makeAbsolute "./ExampleContext.hs"
+        let res = IdeResultOk (Just (ImportListContext "Data.List"))
+        actual <- getContextAt fp_ (toPos (3, 20))
 
         actual `shouldBe` res
 
@@ -95,6 +102,62 @@ spec = describe "Context of different cursor positions" $ do
               let res = IdeResultOk (Just TypeContext)
               actual <- getContextAt fp_ (toPos (6, 8))
               actual `shouldBe` res
+
+    it "data declaration context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+            fp_ <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk Nothing
+            actual <- getContextAt fp_ (toPos (9, 8))
+            actual `shouldBe` res
+
+    it "class declaration context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+            fp_ <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk (Just ClassContext)
+            actual <- getContextAt fp_ (toPos (12, 8))
+            actual `shouldBe` res
+
+    it "class declaration function sig context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+            fp_ <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk (Just ClassContext)
+            actual <- getContextAt fp_ (toPos (13, 7))
+            actual `shouldBe` res
+
+    it "instance declaration context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+            fp_ <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk (Just InstanceContext)
+            actual <- getContextAt fp_ (toPos (15, 7))
+            actual `shouldBe` res
+
+    it "instance declaration function def context"
+            $ withCurrentDirectory "./test/testdata/context"
+            $ do
+                fp_ <- makeAbsolute "./ExampleContext.hs"
+                let res = IdeResultOk (Just InstanceContext)
+                actual <- getContextAt fp_ (toPos (16, 6))
+                actual `shouldBe` res
+
+    it "deriving context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+            fp_ <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk Nothing
+            actual <- getContextAt fp_ (toPos (10, 9))
+            actual `shouldBe` res
+
+    it "deriving typeclass context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+            fp_ <- makeAbsolute "./ExampleContext.hs"
+            let res = IdeResultOk (Just TypeContext)
+            actual <- getContextAt fp_ (toPos (10, 18))
+            actual `shouldBe` res
 
     it "nothing" $ withCurrentDirectory "./test/testdata/context" $ do
         fp_ <- makeAbsolute "./ExampleContext.hs"

--- a/test/unit/ContextSpec.hs
+++ b/test/unit/ContextSpec.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ContextSpec where
+
+
+import           Test.Hspec
+
+import           GHC                            ( tm_parsed_module )
+import           System.Directory
+
+import           Haskell.Ide.Engine.PluginApi
+import           Haskell.Ide.Engine.PluginsIdeMonads
+import           Haskell.Ide.Engine.PluginUtils
+import           Haskell.Ide.Engine.ModuleCache
+import           Haskell.Ide.Engine.Context
+
+import           TestUtils
+
+spec :: Spec
+spec = describe "Context of different cursor positions" $ do
+    it "can set the module as type checked"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+              fp <- makeAbsolute "./ExampleContext.hs"
+              let arg = filePathToUri fp
+              let res = IdeResultOk (Nothing :: Maybe Context)
+              actual <- runSingle (IdePlugins mempty) $ do
+                  _ <- setTypecheckedModule arg
+                  return $ IdeResultOk Nothing
+
+              actual `shouldBe` res
+
+    it "module header context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+              fp_ <- makeAbsolute "./ExampleContext.hs"
+              let res = IdeResultOk (Just (ModuleContext "ExampleContext"))
+
+              actual <- getContextAt fp_ (toPos (1, 10))
+
+              actual `shouldBe` res
+
+
+    it "module export list context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+              fp_ <- makeAbsolute "./ExampleContext.hs"
+              let res = IdeResultOk (Just ExportContext)
+              actual <- getContextAt fp_ (toPos (1, 24))
+
+              actual `shouldBe` res
+
+    it "value context" $ withCurrentDirectory "./test/testdata/context" $ do
+        fp_ <- makeAbsolute "./ExampleContext.hs"
+        let res = IdeResultOk (Just ValueContext)
+        actual <- getContextAt fp_ (toPos (7, 6))
+
+        actual `shouldBe` res
+
+    it "value context" $ withCurrentDirectory "./test/testdata/context" $ do
+        fp_ <- makeAbsolute "./ExampleContext.hs"
+        let res = IdeResultOk (Just ValueContext)
+        actual <- getContextAt fp_ (toPos (7, 12))
+
+        actual `shouldBe` res
+
+    it "import context" $ withCurrentDirectory "./test/testdata/context" $ do
+        fp_ <- makeAbsolute "./ExampleContext.hs"
+        let res = IdeResultOk (Just (ImportContext "Data.List"))
+        actual <- getContextAt fp_ (toPos (3, 8))
+
+        actual `shouldBe` res
+
+    it "function declaration context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+              fp_ <- makeAbsolute "./ExampleContext.hs"
+              let res = IdeResultOk (Just TypeContext)
+              actual <- getContextAt fp_ (toPos (6, 1))
+
+              actual `shouldBe` res
+
+
+    it "function definition context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+              fp_ <- makeAbsolute "./ExampleContext.hs"
+              let res = IdeResultOk (Just ValueContext)
+              actual <- getContextAt fp_ (toPos (7, 1))
+              actual `shouldBe` res
+
+    it "function signature context"
+        $ withCurrentDirectory "./test/testdata/context"
+        $ do
+              fp_ <- makeAbsolute "./ExampleContext.hs"
+              let res = IdeResultOk (Just TypeContext)
+              actual <- getContextAt fp_ (toPos (6, 8))
+              actual `shouldBe` res
+
+    it "nothing" $ withCurrentDirectory "./test/testdata/context" $ do
+        fp_ <- makeAbsolute "./ExampleContext.hs"
+        let res = IdeResultOk Nothing
+        actual <- getContextAt fp_ (toPos (2, 1))
+        actual `shouldBe` res
+
+getContextAt :: [Char] -> Position -> IO (IdeResult (Maybe Context))
+getContextAt fp_ pos = do
+    let arg = filePathToUri fp_
+    runSingle (IdePlugins mempty) $ do
+        _ <- setTypecheckedModule arg
+        pluginGetFile "getContext: " arg $ \fp ->
+            ifCachedModuleAndData fp (IdeResultOk Nothing) $ \tm _ () ->
+                return $ IdeResultOk $ getContext pos (tm_parsed_module tm)


### PR DESCRIPTION
Add more Contexts for the function `getContext`.
Goal: Provide information with the Contexts that otherwise need to be reparsed or are simply not available for completions.
So far, this pr provides context for the module header `module Foo.Bar where`, export list from the module and imports.

Currently, the performance may take a hit when there are a lot of imports, but I dont know what 'a lot' might be. 
 
Also, adds tests for the different contexts.

PR aims to not change the existing completion system but rather expand available contexts.
Completion system should be changed in a different PR.

Contexts that are planned to be implemented here:
* [x] Module Declaration, extracts module name
* [x] Module Declaration, export list
* [x] Imports, import name
* [x] Imports, import list, etc...  
* ~[x] Class declaration~
* ~[x] Instance declaration~
* ~[ ] Language pragma (Seems impossible?)~
