### PR TITLE
Add support for building with cabal-3.0.0.0

### DIFF
--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -17,7 +17,6 @@ import           Print
 import           Env
 import           Stack
 
-
 execCabal :: CmdResult r => [String] -> Action r
 execCabal = command [] "cabal"
 
@@ -26,8 +25,8 @@ execCabal_ = command_ [] "cabal"
 
 cabalBuildData :: Action ()
 cabalBuildData = do
-  execCabal_ ["new-build", "hoogle"]
-  execCabal_ ["new-exec", "hoogle", "generate"]
+  execCabal_ ["v2-build", "hoogle"]
+  execCabal_ ["v2-exec", "hoogle", "generate"]
 
 cabalBuildHie :: VersionNumber -> Action ()
 cabalBuildHie versionNumber = do
@@ -37,18 +36,27 @@ cabalBuildHie versionNumber = do
       error (ghcVersionNotFoundFailMsg versionNumber)
     Just p -> return p
   execCabal_
-    ["new-build", "-w", ghcPath, "--write-ghc-environment-files=never", "--max-backjumps=5000"]
+    ["v2-build", "-w", ghcPath, "--write-ghc-environment-files=never", "--max-backjumps=5000", "--disable-tests"]
 
 cabalInstallHie :: VersionNumber -> Action ()
 cabalInstallHie versionNumber = do
+
   localBin <- getLocalBin
-  execCabal_
-    [ "new-install"
+  cabalVersion <- getCabalVersion
+  
+  let isCabal3 = checkVersion [3,0,0,0] cabalVersion
+      installDirOpt | isCabal3 = "--installdir"
+                    | otherwise = "--symlink-bindir"
+      installMethod | isWindowsSystem && isCabal3 = ["--install-method=copy"]
+                    | otherwise = []
+  execCabal_ $
+    [ "v2-install"
     , "--write-ghc-environment-files=never"
-    , "--symlink-bindir=" ++ localBin
+    , installDirOpt ++ "=" ++ localBin
     , "exe:hie"
     , "--overwrite-policy=always"
     ]
+    ++ installMethod
   liftIO $ do
     copyFile (localBin </> "hie" <.> exe)
              (localBin </> "hie-" ++ versionNumber <.> exe)
@@ -66,7 +74,7 @@ installCabal = do
   -- install `cabal-install` if not already installed
   unless cabalExeOk $ execStackShake_ ["install", "cabal-install"]
 
--- | check `stack` has the required version
+-- | check `cabal` has the required version
 checkCabal :: Action ()
 checkCabal = do
   cabalVersion <- getCabalVersion
@@ -79,20 +87,24 @@ getCabalVersion = trimmedStdout <$> execCabal ["--numeric-version"]
 
 -- TODO: this restriction will be gone in the next release of cabal
 validateCabalNewInstallIsSupported :: Action ()
-validateCabalNewInstallIsSupported = when isWindowsSystem $ do
-  printInStars cabalInstallNotSuportedFailMsg
-  error cabalInstallNotSuportedFailMsg
+validateCabalNewInstallIsSupported = do
+  cabalVersion <- getCabalVersion
+  let isUnsupportedVersion =
+        not $ checkVersion requiredCabalVersionForWindows cabalVersion 
+  when (isWindowsSystem && isUnsupportedVersion) $ do
+    printInStars cabalInstallNotSuportedFailMsg
+    error cabalInstallNotSuportedFailMsg
 
--- | Error message when a windows system tries to install HIE via `cabal new-install`
+-- | Error message when a windows system tries to install HIE via `cabal v2-install`
 cabalInstallNotSuportedFailMsg :: String
 cabalInstallNotSuportedFailMsg =
   "This system has been identified as a windows system.\n"
-    ++ "Unfortunately, `cabal new-install` is currently not supported on windows.\n"
-    ++ "Please use one of the stack-based targets.\n\n"
+    ++ "Unfortunately, `cabal v2-install` is supported since version "++ cabalVersion ++".\n"
+    ++ "Please upgrade your cabal executable or use one of the stack-based targets.\n\n"
     ++ "If this system has been falsely identified, please open an issue at:\n\thttps://github.com/haskell/haskell-ide-engine\n"
+  where cabalVersion = versionToString requiredCabalVersionForWindows
 
-
--- | Error message when the `stack` binary is an older version
+-- | Error message when the `cabal` binary is an older version
 cabalInstallIsOldFailMsg :: String -> String
 cabalInstallIsOldFailMsg cabalVersion =
   "The `cabal` executable is outdated.\n"
@@ -103,6 +115,8 @@ cabalInstallIsOldFailMsg cabalVersion =
     ++ versionToString requiredCabalVersion
     ++ "`."
 
-
 requiredCabalVersion :: RequiredVersion
 requiredCabalVersion = [2, 4, 1, 0]
+
+requiredCabalVersionForWindows :: RequiredVersion
+requiredCabalVersionForWindows = [3, 0, 0, 0]

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -17,6 +17,7 @@ import           Print
 import           Env
 import           Stack
 
+
 execCabal :: CmdResult r => [String] -> Action r
 execCabal = command [] "cabal"
 
@@ -40,10 +41,9 @@ cabalBuildHie versionNumber = do
 
 cabalInstallHie :: VersionNumber -> Action ()
 cabalInstallHie versionNumber = do
-
   localBin <- getLocalBin
   cabalVersion <- getCabalVersion
-  
+
   let isCabal3 = checkVersion [3,0,0,0] cabalVersion
       installDirOpt | isCabal3 = "--installdir"
                     | otherwise = "--symlink-bindir"
@@ -85,7 +85,6 @@ checkCabal = do
 getCabalVersion :: Action String
 getCabalVersion = trimmedStdout <$> execCabal ["--numeric-version"]
 
--- TODO: this restriction will be gone in the next release of cabal
 validateCabalNewInstallIsSupported :: Action ()
 validateCabalNewInstallIsSupported = do
   cabalVersion <- getCabalVersion
@@ -114,6 +113,7 @@ cabalInstallIsOldFailMsg cabalVersion =
     ++ "required version is `"
     ++ versionToString requiredCabalVersion
     ++ "`."
+
 
 requiredCabalVersion :: RequiredVersion
 requiredCabalVersion = [2, 4, 1, 0]


### PR DESCRIPTION
* Use `symlink-bindir` or `install-dir` depending on cabal version
* Add support for building in windows, using `install-method=copy`
* Use `v2-` prefix instead `new-` (available since `cabal-2.4.1.0`)

Fixes #1250