### PR TITLE
Fix code renaming in windows

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -314,7 +314,7 @@ extractRenamableTerms msg
                      . T.dropWhileEnd (== e)
                      . T.dropAround (\c -> c /= b && c /= e)
     getEnclosed txt = case getEnclosed' '‘' '’' txt of
-                        ""  -> getEnclosed' '`' '\'' txt
+                        ""  -> getEnclosed' '`' '\'' txt -- Needed for windows
                         enc -> enc
 
 extractRedundantImport :: T.Text -> Maybe T.Text

--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -310,9 +310,12 @@ extractRenamableTerms msg
                        . T.lines
     singleSuggestions = T.splitOn "), " -- Each suggestion is comma delimited
     isKnownSymbol t = " (imported from" `T.isInfixOf` t  || " (line " `T.isInfixOf` t
-    getEnclosed = T.dropWhile (== '‘')
-                . T.dropWhileEnd (== '’')
-                . T.dropAround (\c -> c /= '‘' && c /= '’')
+    getEnclosed' b e = T.dropWhile (== b)
+                     . T.dropWhileEnd (== e)
+                     . T.dropAround (\c -> c /= b && c /= e)
+    getEnclosed txt = case getEnclosed' '‘' '’' txt of
+                        ""  -> getEnclosed' '`' '\'' txt
+                        enc -> enc
 
 extractRedundantImport :: T.Text -> Maybe T.Text
 extractRedundantImport msg =


### PR DESCRIPTION
*  Taking in account terms between backquote and single quote
* In my `hie.log` i'be observed that the quickfix request is
```
{
  "jsonrpc": "2.0",
  "id": 38,
  "method": "textDocument/codeAction",
  "params": {
    "textDocument": {
      "uri": "file:///d%3A/ws/haskell/haskell-ide-engine/test/testdata/CodeActionRename.hs"
    },
    "range": {
      "start": {
        "line": 0,
        "character": 11
      },
      "end": {
        "line": 0,
        "character": 11
      }
    },
    "context": {
      "diagnostics": [
        {
          "range": {
            "start": {
              "line": 0,
              "character": 7
            },
            "end": {
              "line": 0,
              "character": 15
            }
          },
          "message": "* Variable not in scope: butStrLn :: [Char] -> t\n* Perhaps you meant `putStrLn' (imported from Prelude)",
          "severity": 1,
          "source": "ghcmod"
        }
      ]
    }
  }
}
```

* So the suggestion `putStrLn` is between `` ` `` and `` ' `` instead `` ‘ `` and `` ’ `` (the delimiters expected by code)
* Not sure why it is different in windows but the code now pass the tests 1 and 2 of #1391 .