### PR TITLE
Use the new key format in one line for azure cache

### DIFF
--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -30,10 +30,7 @@ jobs:
   steps:
   - task: CacheBeta@0
     inputs:
-      key: |
-        "cache"
-        $(Agent.OS)
-        $(Build.SourcesDirectory)/$(YAML_FILE)
+      key: stack-root | $(Agent.OS) | $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -26,10 +26,7 @@ jobs:
   steps:
   - task: CacheBeta@0
     inputs:
-      key: |
-        "cache"
-        $(Agent.OS)
-        $(Build.SourcesDirectory)/$(YAML_FILE)
+      key: stack-root | $(Agent.OS) | $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -29,10 +29,7 @@ jobs:
   steps:
   - task: CacheBeta@0
     inputs:
-      key: |
-        "stack-root"
-        $(Agent.OS)
-        $(Build.SourcesDirectory)/$(YAML_FILE)
+      key: stack-root | $(Agent.OS) | $(Build.SourcesDirectory)/$(YAML_FILE)
       path: $(STACK_ROOT)
     displayName: "Cache stack-root"
   - task: CacheBeta@0


### PR DESCRIPTION
* Azure builds are emitting warnings about the actual multiline cache key so it seems it is deprecated