### PR TITLE
Fix more code actions in windows

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
+++ b/src/Haskell/Ide/Engine/Plugin/GhcMod.hs
@@ -304,27 +304,18 @@ extractRenamableTerms msg
   | "ot in scope:" `T.isInfixOf` msg = extractSuggestions msg
   | otherwise = []
   where
-    extractSuggestions = map extractTerm
+    extractSuggestions = map Hie.extractTerm
                        . concatMap singleSuggestions
                        . filter isKnownSymbol
                        . T.lines
     singleSuggestions = T.splitOn "), " -- Each suggestion is comma delimited
     isKnownSymbol t = " (imported from" `T.isInfixOf` t  || " (line " `T.isInfixOf` t
 
-extractTerm :: T.Text -> T.Text
-extractTerm txt =
-  case extract '‘' '’' txt of
-    ""  -> extract '`' '\'' txt -- Needed for windows
-    term -> term
-  where extract b e = T.dropWhile (== b)
-                    . T.dropWhileEnd (== e)
-                    . T.dropAround (\c -> c /= b && c /= e)
-
 extractRedundantImport :: T.Text -> Maybe T.Text
 extractRedundantImport msg =
   if ("The import of " `T.isPrefixOf` firstLine || "The qualified import of " `T.isPrefixOf` firstLine)
       && " is redundant" `T.isSuffixOf` firstLine
-    then Just $ extractTerm firstLine
+    then Just $ Hie.extractTerm firstLine
     else Nothing
   where
     firstLine = case T.lines msg of
@@ -397,7 +388,7 @@ extractMissingSignature msg = extractSignature <$> stripMessageStart msg
     extractSignature = T.strip
 
 extractUnusedTerm :: T.Text -> Maybe T.Text
-extractUnusedTerm msg = extractTerm <$> stripMessageStart msg
+extractUnusedTerm msg = Hie.extractTerm <$> stripMessageStart msg
   where
     stripMessageStart = T.stripPrefix "Defined but not used:"
                       . T.strip

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -483,17 +483,19 @@ extractImportableTerm dirtyMsg = do
       $ T.unlines
       $ map T.strip
       $ T.lines
+      $ T.replace "* " "" -- Needed for Windows
       $ T.replace "• " "" dirtyMsg
 
+    extractTerm prefix symTy =
+      importMsg
+          >>= T.stripPrefix prefix
+          >>= \name -> Just (name, Import symTy)
+
+    extractType b =
+      extractTerm ("Not in scope: type constructor or class " <> b) Type
+
     extractedTerm = asum
-      [ importMsg
-          >>= T.stripPrefix "Variable not in scope: "
-          >>= \name -> Just (name, Import Symbol)
-      , importMsg
-          >>= T.stripPrefix "Not in scope: type constructor or class ‘"
-          >>= \name -> Just (T.init name, Import Type)
-      , importMsg
-          >>= T.stripPrefix "Data constructor not in scope: "
-          >>= \name -> Just (name, Import Constructor)]
-
-
+      [ extractTerm "Variable not in scope: " Symbol
+      , extractType "‘"
+      , extractType "`" -- Needed for windows
+      , extractTerm "Data constructor not in scope: " Constructor]

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -338,11 +338,19 @@ codeActionProvider plId docId _ context = do
 -- | Extract a module name from an error message.
 extractModuleName :: T.Text -> Maybe Package
 extractModuleName msg
-  | T.isPrefixOf "Could not find module " msg = Just $ T.tail $ T.init nameAndQuotes
-  | T.isPrefixOf "Could not load module " msg = Just $ T.tail $ T.init nameAndQuotes
+  | T.isPrefixOf "Could not find module " msg = Just $ extractTerm line
+  | T.isPrefixOf "Could not load module " msg = Just $ extractTerm line
   | otherwise = Nothing
   where line = head $ T.lines msg
-        nameAndQuotes = T.dropWhileEnd (/= '’') $ T.dropWhile (/= '‘') line
+
+extractTerm :: T.Text -> T.Text
+extractTerm txt =
+  case extract '‘' '’' txt of
+    ""  -> extract '`' '\'' txt -- Needed for windows
+    term -> term
+  where extract b e = T.dropWhile (== b)
+                    . T.dropWhileEnd (== e)
+                    . T.dropAround (\c -> c /= b && c /= e)
 
 -- Example error messages
 {- GHC 8.6.2 error message is

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -9,6 +9,7 @@ module Haskell.Ide.Engine.Plugin.Package where
 import           Haskell.Ide.Engine.MonadTypes
 import qualified Haskell.Ide.Engine.Plugin.Hoogle as Hoogle
 import           Haskell.Ide.Engine.PluginUtils
+import           Haskell.Ide.Engine.Support.HieExtras as Hie
 import           GHC.Generics
 import           GHC.Exts
 import           Control.Lens
@@ -338,19 +339,10 @@ codeActionProvider plId docId _ context = do
 -- | Extract a module name from an error message.
 extractModuleName :: T.Text -> Maybe Package
 extractModuleName msg
-  | T.isPrefixOf "Could not find module " msg = Just $ extractTerm line
-  | T.isPrefixOf "Could not load module " msg = Just $ extractTerm line
+  | T.isPrefixOf "Could not find module " msg = Just $ Hie.extractTerm line
+  | T.isPrefixOf "Could not load module " msg = Just $ Hie.extractTerm line
   | otherwise = Nothing
   where line = head $ T.lines msg
-
-extractTerm :: T.Text -> T.Text
-extractTerm txt =
-  case extract '‘' '’' txt of
-    ""  -> extract '`' '\'' txt -- Needed for windows
-    term -> term
-  where extract b e = T.dropWhile (== b)
-                    . T.dropWhileEnd (== e)
-                    . T.dropAround (\c -> c /= b && c /= e)
 
 -- Example error messages
 {- GHC 8.6.2 error message is

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -12,6 +12,7 @@ module Haskell.Ide.Engine.Support.HieExtras
   , getSymbolsAtPoint
   , getReferencesInDoc
   , getModule
+  , extractTerm
   , findDef
   , findTypeDef
   , showName
@@ -229,6 +230,18 @@ getModule df n = do
   let uid = moduleUnitId m
   let pkg = showName . packageName <$> lookupPackage df uid
   return (pkg, T.pack $ moduleNameString $ moduleName m)
+
+-- | Extract a term from a compiler message.
+-- It looks for terms delimited between '‘' and '’' falling back to '`' and '\''
+-- (the used ones in Windows systems).
+extractTerm :: T.Text -> T.Text
+extractTerm txt =
+  case extract '‘' '’' txt of
+    ""  -> extract '`' '\'' txt -- Needed for windows
+    term -> term
+  where extract b e = T.dropWhile (== b)
+                    . T.dropWhileEnd (== e)
+                    . T.dropAround (\c -> c /= b && c /= e)
 
 -- ---------------------------------------------------------------------
 


### PR DESCRIPTION
* Follow up of #1392 
* It turns out that there were more places where the code assumed ``‘`` and ``’`` as term delimiters
  * And it assumed that the symbol to start a list option was `•` (in windows is `*`)
* It fixes almost all failed tests listed in #1391 (all except 11, 12 and 13) :smile: 
* The duplicated function `extractTerm` could be in common module but i am not sure where would be: maybe `Haskell.Ide.Engine.PluginUtils` in `hie-plugin-api`?
* An alternative impl for `extractTerm`would be `T.init $ T.tail $ T.dropWhileEnd (/= b) $ T.dropWhile (/= e)`, do you think that it would be better?