### PR TITLE
Haskell lsp 0.16

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -71,8 +71,8 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp == 0.15.*
-                     , haskell-lsp-types == 0.15.*
+                     , haskell-lsp == 0.16.*
+                     , haskell-lsp-types == 0.16.*
                      , haskell-src-exts
                      , hie-plugin-api
                      , hoogle >= 5.0.13
@@ -199,7 +199,7 @@ test-suite unit-test
                      , free
                      , ghc
                      , haskell-ide-engine
-                     , haskell-lsp-types >= 0.15.0.0
+                     , haskell-lsp-types == 0.16.*
                      , hie-test-utils
                      , hie-plugin-api
                      , hoogle > 5.0.11
@@ -287,8 +287,8 @@ test-suite func-test
                      , filepath
                      , lsp-test >= 0.6.0.0
                      , haskell-ide-engine
-                     , haskell-lsp-types == 0.15.*
-                     , haskell-lsp == 0.15.*
+                     , haskell-lsp-types == 0.16.*
+                     , haskell-lsp == 0.16.*
                      , hie-test-utils
                      , hie-plugin-api
                      , hspec

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -45,7 +45,7 @@ library
                      , ghc
                      , ghc-mod-core >= 5.9.0.0
                      , ghc-project-types >= 5.9.0.0
-                     , haskell-lsp == 0.15.*
+                     , haskell-lsp == 0.16.*
                      , hslogger
                      , monad-control
                      , mtl

--- a/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
+++ b/src/Haskell/Ide/Engine/Plugin/ApplyRefact.hs
@@ -148,7 +148,7 @@ parseErrorToDiagnostic (Hlint.ParseError l msg contents) =
   [Diagnostic
       { _range    = srcLoc2Range l
       , _severity = Just DsInfo -- Not displayed
-      , _code     = Just "parser"
+      , _code     = Just (LSP.StringValue "parser")
       , _source   = Just "hlint"
       , _message  = T.unlines [T.pack msg,T.pack contents]
       , _relatedInformation = Nothing
@@ -192,7 +192,7 @@ hintToDiagnostic idea
   = Diagnostic
       { _range    = ss2Range (ideaSpan idea)
       , _severity = Just (hintSeverityMap $ ideaSeverity idea)
-      , _code     = Just (T.pack $ ideaHint idea)
+      , _code     = Just (LSP.StringValue $ T.pack $ ideaHint idea)
       , _source   = Just "hlint"
       , _message  = idea2Message idea
       , _relatedInformation = Nothing
@@ -315,7 +315,7 @@ codeActionProvider plId docId _ context = IdeResultOk <$> hlintActions
     hlintActions = catMaybes <$> mapM mkHlintAction (filter validCommand diags)
 
     -- |Some hints do not have an associated refactoring
-    validCommand (LSP.Diagnostic _ _ (Just code) (Just "hlint") _ _) =
+    validCommand (LSP.Diagnostic _ _ (Just (LSP.StringValue code)) (Just "hlint") _ _) =
       case code of
         "Eta reduce" -> False
         _            -> True
@@ -324,7 +324,7 @@ codeActionProvider plId docId _ context = IdeResultOk <$> hlintActions
     LSP.List diags = context ^. LSP.diagnostics
 
     mkHlintAction :: LSP.Diagnostic -> IdeM (Maybe LSP.CodeAction)
-    mkHlintAction diag@(LSP.Diagnostic (LSP.Range start _) _s (Just code) (Just "hlint") m _) =
+    mkHlintAction diag@(LSP.Diagnostic (LSP.Range start _) _s (Just (LSP.StringValue code)) (Just "hlint") m _) =
       Just . codeAction <$> mkLspCommand plId "applyOne" title (Just args)
      where
        codeAction cmd = LSP.CodeAction title (Just LSP.CodeActionRefactor) (Just (LSP.List [diag])) Nothing (Just cmd)

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -20,14 +20,14 @@ extra-deps:
 - ghc-exactprint-0.5.8.2
 - haddock-api-2.18.1
 - haddock-library-1.4.4
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.1.17 # last hlint supporting GHC 8.2
 - hoogle-5.0.17.9
 - hsimport-0.8.8
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -19,14 +19,14 @@ extra-deps:
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.2
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -19,14 +19,14 @@ extra-deps:
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.2
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -18,14 +18,14 @@ extra-deps:
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.2
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2
 - optparse-simple-0.1.0
 - pretty-show-1.9.5

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -21,14 +21,14 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.21.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.2
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - monoid-subclasses-0.4.6.1

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -17,14 +17,14 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.21.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.2
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -17,14 +17,14 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.21.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.2
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -17,13 +17,13 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.22.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - hlint-2.2.2
 - hoogle-5.0.17.9
 - hsimport-0.10.0
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -17,13 +17,13 @@ extra-deps:
 - floskell-0.10.0
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.22.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - haskell-src-exts-1.21.0
 - hlint-2.2.2
 - hsimport-0.10.0
 - hoogle-5.0.17.9
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,11 +18,11 @@ extra-deps:
 - floskell-0.10.1
 - ghc-lib-parser-8.8.0.20190723
 - haddock-api-2.22.0
-- haskell-lsp-0.15.0.0
-- haskell-lsp-types-0.15.0.0
+- haskell-lsp-0.16.0.0
+- haskell-lsp-types-0.16.0.0
 - hlint-2.2.2
 - hsimport-0.10.0
-- lsp-test-0.6.0.0
+- lsp-test-0.7.0.0
 - monad-dijkstra-0.1.1.2@rev:1
 - syz-0.2.0.0
 - temporary-1.2.1.1

--- a/test/dispatcher/Main.hs
+++ b/test/dispatcher/Main.hs
@@ -249,7 +249,7 @@ funcSpec = describe "functional dispatch" $ do
                         [ Diagnostic
                             (Range (Position 9 6) (Position 10 18))
                             (Just DsInfo)
-                            (Just "Redundant do")
+                            (Just (StringValue "Redundant do"))
                             (Just "hlint")
                             "Redundant do\nFound:\n  do putStrLn \"hello\"\nWhy not:\n  putStrLn \"hello\"\n"
                             Nothing

--- a/test/functional/DeferredSpec.hs
+++ b/test/functional/DeferredSpec.hs
@@ -115,7 +115,7 @@ spec = do
                   [ Diagnostic
                       (Range (Position 9 6) (Position 10 18))
                       (Just DsInfo)
-                      (Just "Redundant do")
+                      (Just (StringValue "Redundant do"))
                       (Just "hlint")
                       "Redundant do\nFound:\n  do putStrLn \"hello\"\nWhy not:\n  putStrLn \"hello\"\n"
                       Nothing

--- a/test/functional/DiagnosticsSpec.hs
+++ b/test/functional/DiagnosticsSpec.hs
@@ -35,7 +35,7 @@ spec = describe "diagnostics providers" $ do
           length diags `shouldBe` 2
           reduceDiag ^. LSP.range `shouldBe` Range (Position 1 0) (Position 1 12)
           reduceDiag ^. LSP.severity `shouldBe` Just DsInfo
-          reduceDiag ^. LSP.code `shouldBe` Just "Eta reduce"
+          reduceDiag ^. LSP.code `shouldBe` Just (StringValue "Eta reduce")
           reduceDiag ^. LSP.source `shouldBe` Just "hlint"
 
         diags2a <- waitForDiagnostics

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -34,7 +34,7 @@ spec = describe "code actions" $ do
         length diags `shouldBe` 2
         reduceDiag ^. L.range `shouldBe` Range (Position 1 0) (Position 1 12)
         reduceDiag ^. L.severity `shouldBe` Just DsInfo
-        reduceDiag ^. L.code `shouldBe` Just "Eta reduce"
+        reduceDiag ^. L.code `shouldBe` Just (StringValue "Eta reduce")
         reduceDiag ^. L.source `shouldBe` Just "hlint"
 
       (CACodeAction ca:_) <- getAllCodeActions doc
@@ -79,7 +79,7 @@ spec = describe "code actions" $ do
         length diags `shouldBe` 2
         reduceDiag ^. L.range `shouldBe` Range (Position 1 0) (Position 1 12)
         reduceDiag ^. L.severity `shouldBe` Just DsInfo
-        reduceDiag ^. L.code `shouldBe` Just "Eta reduce"
+        reduceDiag ^. L.code `shouldBe` Just (StringValue "Eta reduce")
         reduceDiag ^. L.source `shouldBe` Just "hlint"
 
       (CACodeAction ca:_) <- getAllCodeActions doc

--- a/test/functional/FunctionalLiquidSpec.hs
+++ b/test/functional/FunctionalLiquidSpec.hs
@@ -33,7 +33,7 @@ spec = describe "liquid haskell diagnostics" $ do
           length diags `shouldBe` 2
           reduceDiag ^. range `shouldBe` Range (Position 5 18) (Position 5 22)
           reduceDiag ^. severity `shouldBe` Just DsHint
-          reduceDiag ^. code `shouldBe` Just "Use negate"
+          reduceDiag ^. code `shouldBe` Just (StringValue "Use negate")
           reduceDiag ^. source `shouldBe` Just "hlint"
 
         -- liftIO $ putStrLn "b"
@@ -77,7 +77,7 @@ spec = describe "liquid haskell diagnostics" $ do
           length diags `shouldBe` 2
           reduceDiag ^. range `shouldBe` Range (Position 5 18) (Position 5 22)
           reduceDiag ^. severity `shouldBe` Just DsHint
-          reduceDiag ^. code `shouldBe` Just "Use negate"
+          reduceDiag ^. code `shouldBe` Just (StringValue "Use negate")
           reduceDiag ^. source `shouldBe` Just "hlint"
 
         -- Enable liquid haskell plugin and disable hlint

--- a/test/unit/ApplyRefactPluginSpec.hs
+++ b/test/unit/ApplyRefactPluginSpec.hs
@@ -112,7 +112,7 @@ applyRefactSpec = do
                [Diagnostic {_range = Range { _start = Position {_line = 13, _character = 0}
                                            , _end = Position {_line = 13, _character = 100000}}
                            , _severity = Just DsInfo
-                           , _code = Just "parser"
+                           , _code = Just (StringValue "parser")
                            , _source = Just "hlint"
                            , _message = "Parse error: virtual }\n  data instance Sing (z :: (a :~: b)) where\n      SRefl :: Sing Refl +\n> \n\n"
                            , _relatedInformation = Nothing }]}

--- a/test/unit/ApplyRefactPluginSpec.hs
+++ b/test/unit/ApplyRefactPluginSpec.hs
@@ -8,6 +8,7 @@ import qualified Data.Text                             as T
 import           Haskell.Ide.Engine.Plugin.ApplyRefact
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.PluginUtils
+import           Language.Haskell.LSP.Types
 import           System.Directory
 import           TestUtils
 
@@ -74,13 +75,13 @@ applyRefactSpec = do
              , _diagnostics = List $
                [ Diagnostic (Range (Position 1 7) (Position 1 25))
                             (Just DsHint)
-                            (Just "Redundant bracket")
+                            (Just (StringValue "Redundant bracket"))
                             (Just "hlint")
                             "Redundant bracket\nFound:\n  (putStrLn \"hello\")\nWhy not:\n  putStrLn \"hello\"\n"
                             Nothing
                , Diagnostic (Range (Position 3 8) (Position 3 15))
                             (Just DsHint)
-                            (Just "Redundant bracket")
+                            (Just (StringValue "Redundant bracket"))
                             (Just "hlint")
                             "Redundant bracket\nFound:\n  (x + 1)\nWhy not:\n  x + 1\n"
                             Nothing
@@ -103,7 +104,7 @@ applyRefactSpec = do
                [Diagnostic {_range = Range { _start = Position {_line = 12, _character = 23}
                                            , _end = Position {_line = 12, _character = 100000}}
                            , _severity = Just DsInfo
-                           , _code = Just "parser"
+                           , _code = Just (StringValue "parser")
                            , _source = Just "hlint"
                            , _message = T.pack filePathNoUri <> ":13:24: error:\n    Operator applied to too few arguments: +\n  data instance Sing (z :: (a :~: b)) where\n>     SRefl :: Sing Refl +\n\n"
                            , _relatedInformation = Nothing }]}
@@ -140,7 +141,7 @@ applyRefactSpec = do
             , _diagnostics = List
               [ Diagnostic (Range (Position 3 11) (Position 3 20))
                            (Just DsInfo)
-                           (Just "Redundant bracket")
+                           (Just (StringValue "Redundant bracket"))
                            (Just "hlint")
                            "Redundant bracket\nFound:\n  (\"hello\")\nWhy not:\n  \"hello\"\n"
                            Nothing


### PR DESCRIPTION
Bump haskell-lsp to 0.16

This is needed for GHC 8.8.1 support.