### PR TITLE
Find and run cabal in user original $PATH

### DIFF
--- a/install/hie-install.cabal
+++ b/install/hie-install.cabal
@@ -21,6 +21,7 @@ library
   build-depends:       base >= 4.9 && < 5
                      , shake == 0.17.8
                      , directory
+                     , filepath
                      , extra
                      , text
   default-extensions: LambdaCase

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -24,7 +24,7 @@ execCabal_ :: [String] -> Action ()
 execCabal_ = execCabalWithOriginalPath
 
 execCabalWithOriginalPath :: CmdResult r => [String] -> Action r
-execCabalWithOriginalPath = withOriginalPath . (command [] "cabal")
+execCabalWithOriginalPath = withoutStackCachedBinaries . (command [] "cabal")
 
 cabalBuildData :: Action ()
 cabalBuildData = do
@@ -77,7 +77,7 @@ cabalInstallHie versionNumber = do
 installCabalWithStack :: Action ()
 installCabalWithStack = do
   -- try to find existing `cabal` executable with appropriate version
-  mbc <- withOriginalPath (liftIO (findExecutable "cabal"))
+  mbc <- withoutStackCachedBinaries (liftIO (findExecutable "cabal"))
 
   case mbc of
     Just c  -> do

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -12,17 +12,21 @@ import           System.Directory                         ( findExecutable
                                                           , copyFile
                                                           )
 
+import           BuildSystem
 import           Version
 import           Print
 import           Env
 import           Stack
-
+import           Debug.Trace
 
 execCabal :: CmdResult r => [String] -> Action r
-execCabal = command [] "cabal"
+execCabal = execCabalWithOriginalPath
 
 execCabal_ :: [String] -> Action ()
-execCabal_ = command_ [] "cabal"
+execCabal_ = execCabalWithOriginalPath
+
+execCabalWithOriginalPath :: CmdResult r => [String] -> Action r
+execCabalWithOriginalPath = withOriginalPath . (command [] "cabal")
 
 cabalBuildData :: Action ()
 cabalBuildData = do
@@ -76,7 +80,8 @@ installCabal :: Action ()
 installCabal = do
   -- try to find existing `cabal` executable with appropriate version
   cabalExeOk <- do
-    c <- liftIO (findExecutable "cabal")
+    c <- withOriginalPath (liftIO (findExecutable "cabal"))
+    liftIO $ traceIO $ show c
     when (isJust c) checkCabal
     return $ isJust c
   

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -12,7 +12,6 @@ import           System.Directory                         ( findExecutable
                                                           , copyFile
                                                           )
 
-import           BuildSystem
 import           Version
 import           Print
 import           Env

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -117,9 +117,9 @@ defaultMain = do
     forM_
       ghcVersions
       (\version -> phony ("cabal-hie-" ++ version) $ do
-        validateCabalNewInstallIsSupported
         need ["submodules"]
         need ["cabal"]
+        validateCabalNewInstallIsSupported
         cabalBuildHie version
         cabalInstallHie version
       )

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -63,7 +63,7 @@ defaultMain = do
     want ["short-help"]
     -- general purpose targets
     phony "submodules"  updateSubmodules
-    phony "cabal"       installCabal
+    phony "cabal"       installCabalWithStack
     phony "short-help"  shortHelpMessage
     phony "all"         shortHelpMessage
     phony "help"        (helpMessage versions)

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -99,16 +99,16 @@ stackBuildFailMsg =
     ++ "If this does not work, open an issue at \n"
     ++ "\thttps://github.com/haskell/haskell-ide-engine"
 
--- | Run actions with the original user path, without stack additions
-withOriginalPath :: Action a -> Action a
-withOriginalPath action = do
+-- |Run actions without the stack cached binaries 
+withoutStackCachedBinaries :: Action a -> Action a
+withoutStackCachedBinaries action = do
   mbPath <- liftIO (lookupEnv "PATH")
 
   case (mbPath, isRunFromStack) of
 
     (Just paths, True) -> do
       snapshotDir <- trimmedStdout <$> execStackShake ["path", "--snapshot-install-root"]
-      localInstallDir <- trimmedStdout <$> execStackShake ["path", "--local-install-dir"]
+      localInstallDir <- trimmedStdout <$> execStackShake ["path", "--local-install-root"]
 
       let cacheBinPaths = [snapshotDir </> "bin", localInstallDir </> "bin"]
       let origPaths = removePathsContaining cacheBinPaths paths

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -104,7 +104,7 @@ withOriginalPath :: Action a -> Action a
 withOriginalPath action = do
   mbPath <- liftIO (lookupEnv "PATH")
 
-  case (mbPath,isRunFromStack) of
+  case (mbPath, isRunFromStack) of
 
     (Just paths, True) -> do
       snapshotDir <- trimmedStdout <$> execStackShake ["path", "--snapshot-install-root"]
@@ -122,7 +122,8 @@ withOriginalPath action = do
     otherwise -> action
 
   where removePathsContaining str path =
-          intercalate [searchPathSeparator] (filter (not.(isInfixOf str)) (splitPaths path))
+           joinPaths (filter (not.(isInfixOf str)) (splitPaths path))
+        joinPaths = intercalate [searchPathSeparator]
         splitPaths s =
           case dropWhile (== searchPathSeparator) s of
                       "" -> []


### PR DESCRIPTION
* We've found that the `cabal`executable used within `stack install.hs` executions after a first `stack install.hs stack-install-cabal` is the cached in `$STACK_ROOT/snapshots/{hash}/bin`. The cause is `stack` prepends that directory to the `$PATH` environment variable. That supposes:
  * If you delete the cabal executable in `$PATH` after running `stack install.hs stack-install-cabal`, another invocation doesn't copy again the cabal executable, cause the version cached by stack is found. (thanks @jchia for detected it)
  * All `stack install.hs cabal-*` use that cached version and no the original one, so if you upgrade your cabal in `$PATH` to `3.0.0.0` stack will continue using its cached version, (currently `2.4.1.0`)
    * So in windows you could not use those goals

To avoid it i had to remove manually `$STACK_ROOT/snapshots/{hash}/bin` from `$PATH`, an ugly ugly hack, but i didint find better way to do it (via stack flags or alternative env vars)

I think this one would fix https://github.com/alanz/vscode-hie-server/issues/131