### PR TITLE
Adapt liquid haskell tests for version 0.8.6.2

### DIFF
--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -164,7 +164,7 @@ runLiquidHaskell fp = do
       let cmd = lh ++ " --json \"" ++ fp ++ "\""
           dir = takeDirectory fp
           cp = (shell cmd) { cwd = Just dir }
-      -- logm $ "runLiquidHaskell:cmd=[" ++ cmd ++ "]"
+      logm $ "runLiquidHaskell:cmd=[" ++ cmd ++ "]"
       mpp <- lookupEnv "GHC_PACKAGE_PATH"
       mge <- lookupEnv "GHC_ENVIRONMENT"
       -- logm $ "runLiquidHaskell:mpp=[" ++ show mpp ++ "]"

--- a/src/Haskell/Ide/Engine/Plugin/Liquid.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Liquid.hs
@@ -164,7 +164,7 @@ runLiquidHaskell fp = do
       let cmd = lh ++ " --json \"" ++ fp ++ "\""
           dir = takeDirectory fp
           cp = (shell cmd) { cwd = Just dir }
-      logm $ "runLiquidHaskell:cmd=[" ++ cmd ++ "]"
+      -- logm $ "runLiquidHaskell:cmd=[" ++ cmd ++ "]"
       mpp <- lookupEnv "GHC_PACKAGE_PATH"
       mge <- lookupEnv "GHC_ENVIRONMENT"
       -- logm $ "runLiquidHaskell:mpp=[" ++ show mpp ++ "]"

--- a/test/dispatcher/Main.hs
+++ b/test/dispatcher/Main.hs
@@ -21,6 +21,7 @@ import           Haskell.Ide.Engine.Types
 import           Language.Haskell.LSP.Types
 import           TestUtils
 import           System.Directory
+import           System.Environment
 import           System.FilePath
 
 import           Test.Hspec
@@ -71,12 +72,19 @@ startServer :: IO (Scheduler IO, TChan LogVal, ThreadId)
 startServer = do
   scheduler <- newScheduler plugins testOptions
   logChan  <- newTChanIO
-  dispatcher <- forkIO $
+  dispatcher <- forkIO $ do
+    -- We need to clear these environment variables to prevent
+    -- collisions with stack usages
+    -- See https://github.com/commercialhaskell/stack/issues/4875
+    unsetEnv "GHC_PACKAGE_PATH"
+    unsetEnv "GHC_ENVIRONMENT"
+    unsetEnv "HASKELL_PACKAGE_SANDBOX"
+    unsetEnv "HASKELL_PACKAGE_SANDBOXES"
     runScheduler
-    scheduler
-    (\lid errCode e -> logToChan logChan ("received an error", Left (lid, errCode, e)))
-    (\g x -> g x)
-    def
+      scheduler
+      (\lid errCode e -> logToChan logChan ("received an error", Left (lid, errCode, e)))
+      (\g x -> g x)
+      def
 
   return (scheduler, logChan, dispatcher)
 

--- a/test/dispatcher/Main.hs
+++ b/test/dispatcher/Main.hs
@@ -21,7 +21,6 @@ import           Haskell.Ide.Engine.Types
 import           Language.Haskell.LSP.Types
 import           TestUtils
 import           System.Directory
-import           System.Environment
 import           System.FilePath
 
 import           Test.Hspec
@@ -73,13 +72,7 @@ startServer = do
   scheduler <- newScheduler plugins testOptions
   logChan  <- newTChanIO
   dispatcher <- forkIO $ do
-    -- We need to clear these environment variables to prevent
-    -- collisions with stack usages
-    -- See https://github.com/commercialhaskell/stack/issues/4875
-    unsetEnv "GHC_PACKAGE_PATH"
-    unsetEnv "GHC_ENVIRONMENT"
-    unsetEnv "HASKELL_PACKAGE_SANDBOX"
-    unsetEnv "HASKELL_PACKAGE_SANDBOXES"
+    flushStackEnvironment
     runScheduler
       scheduler
       (\lid errCode e -> logToChan logChan ("received an error", Left (lid, errCode, e)))

--- a/test/functional/FunctionalLiquidSpec.hs
+++ b/test/functional/FunctionalLiquidSpec.hs
@@ -98,11 +98,16 @@ spec = describe "liquid haskell diagnostics" $ do
         -- liftIO $ show diags3 `shouldBe` ""
         liftIO $ do
           length diags3 `shouldBe` 1
-          d ^. range `shouldBe` Range (Position 8 0) (Position 8 7)
+          d ^. range `shouldBe` Range (Position 8 0) (Position 8 11)
           d ^. severity `shouldBe` Just DsError
           d ^. code `shouldBe` Nothing
           d ^. source `shouldBe` Just "liquid"
-          d ^. message `shouldSatisfy` (T.isPrefixOf "Error: Liquid Type Mismatch\n  Inferred type\n    VV : {v : Int | v == (7 : int)}\n \n  not a subtype of Required type\n    VV : {VV : Int | VV mod 2 == 0}\n")
+          d ^. message `shouldSatisfy` T.isPrefixOf ("Error: Liquid Type Mismatch\n" <>
+                                        "  Inferred type\n" <>
+                                        "    VV : {v : GHC.Types.Int | v == 7}\n" <>
+                                        " \n" <>
+                                        "  not a subtype of Required type\n" <>
+                                        "    VV : {VV : GHC.Types.Int | VV mod 2 == 0}\n ")
 
 
 -- ---------------------------------------------------------------------

--- a/test/unit/LiquidSpec.hs
+++ b/test/unit/LiquidSpec.hs
@@ -15,7 +15,7 @@ import           System.Directory
 import           System.Exit
 import           System.FilePath
 import           Test.Hspec
-import Control.Monad.IO.Class
+-- import Control.Monad.IO.Class
 
 main :: IO ()
 main = hspec spec
@@ -37,8 +37,10 @@ spec = do
       let
         fp = cwd </> "test/testdata/liquid/Evens.hs"
       Just (ef, (msg:_)) <- runLiquidHaskell fp
-      liftIO $ putStrLn $ "msg=" ++ msg
-      msg `shouldSatisfy` isPrefixOf "RESULT\n[{\"start\":{\"line\""
+      -- liftIO $ putStrLn $ "msg=" ++ msg
+      -- liftIO $ putStrLn $ "msg=" ++ unlines (drop 3 (lines msg))
+      let msg' = unlines (drop 3 (lines msg))
+      msg' `shouldSatisfy` isInfixOf "RESULT\n[{\"start\":{\"line\""
       ef `shouldBe` ExitFailure 1
 
     -- ---------------------------------
@@ -60,12 +62,15 @@ spec = do
       let Just v = decode jf :: Maybe LiquidJson
       let [LE { start, stop, message }] = errors v
       start `shouldBe` LP 9 1
-      stop `shouldBe` LP 9 8
+      stop `shouldBe` LP 9 12
       message `shouldSatisfy` T.isPrefixOf
-               ("Error: Liquid Type Mismatch\n  Inferred type\n" <>
-                "    VV : {v : Int | v == (7 : int)}\n \n" <>
+               ("Error: Liquid Type Mismatch\n" <>
+                "  Inferred type\n" <>
+                "    VV : {v : GHC.Types.Int | v == 7}\n" <>
+                " \n" <>
                 "  not a subtype of Required type\n" <>
-                "    VV : {VV : Int | VV mod 2 == 0}\n")
+                "    VV : {VV : GHC.Types.Int | VV mod 2 == 0}\n" <>
+                " ")
 
     -- ---------------------------------
 
@@ -100,8 +105,8 @@ spec = do
       take 2 ts
         `shouldBe`
           [LE (LP 1 1) (LP 1 1) "GHC.Types.Module"
-          ,LE (LP 6 1) (LP 6 10) "[{v : GHC.Types.Int | v mod 2 == 0}]"]
-      length ts `shouldBe` 38
+          ,LE (LP 6 1) (LP 6 10) "[{VV : GHC.Types.Int | VV mod 2 == 0}]"]
+      length ts `shouldBe` 53
 
     -- ---------------------------------
 
@@ -112,8 +117,8 @@ spec = do
       take 2 ts
         `shouldBe`
           [LE (LP 1 1) (LP 1 1) "GHC.Types.Module"
-          ,LE (LP 6 1) (LP 6 10) "[{v : GHC.Types.Int | v mod 2 == 0}]"]
-      length ts `shouldBe` 38
+          ,LE (LP 6 1) (LP 6 10) "[{VV : GHC.Types.Int | VV mod 2 == 0}]"]
+      length ts `shouldBe` 53
 
     -- ---------------------------------
 


### PR DESCRIPTION
This needs https://github.com/alanz/haskell-dockerfiles/pull/2 for CI,
to update the base image GHC and liquid haskell version.