### PR TITLE
Various improvements and fixes over shake install

### DIFF
--- a/.azure/linux-installhs-stack.yml
+++ b/.azure/linux-installhs-stack.yml
@@ -29,4 +29,8 @@ jobs:
   - bash: |
       source .azure/linux.bashrc
       stack install.hs help
-    displayName: Run help of `instal.hs`
+    displayName: Run help of `install.hs`
+  - bash: |
+      source .azure/linux.bashrc
+      stack install.hs stack-install-cabal
+    displayName: Run stack-install-cabal target of `install.hs`

--- a/.azure/linux-installhs-stack.yml
+++ b/.azure/linux-installhs-stack.yml
@@ -34,3 +34,7 @@ jobs:
       source .azure/linux.bashrc
       stack install.hs stack-install-cabal
     displayName: Run stack-install-cabal target of `install.hs`
+  - bash: |
+      source .azure/linux.bashrc
+      stack install.hs build-latest
+    displayName: Run build-latest target of `install.hs`

--- a/.azure/macos-installhs-stack.yml
+++ b/.azure/macos-installhs-stack.yml
@@ -29,4 +29,8 @@ jobs:
   - bash: |
       source .azure/macos.bashrc
       stack install.hs help
-    displayName: Run help of `instal.hs`
+    displayName: Run help of `install.hs`
+  - bash: |
+      source .azure/macos.bashrc
+      stack install.hs stack-install-cabal
+    displayName: Run stack-install-cabal target of `install.hs`

--- a/.azure/macos-installhs-stack.yml
+++ b/.azure/macos-installhs-stack.yml
@@ -35,6 +35,6 @@ jobs:
       stack install.hs stack-install-cabal
     displayName: Run stack-install-cabal target of `install.hs`
   - bash: |
-      source .azure/linux.bashrc
+      source .azure/macos.bashrc
       stack install.hs build-latest
     displayName: Run build-latest target of `install.hs`

--- a/.azure/macos-installhs-stack.yml
+++ b/.azure/macos-installhs-stack.yml
@@ -34,3 +34,7 @@ jobs:
       source .azure/macos.bashrc
       stack install.hs stack-install-cabal
     displayName: Run stack-install-cabal target of `install.hs`
+  - bash: |
+      source .azure/linux.bashrc
+      stack install.hs build-latest
+    displayName: Run build-latest target of `install.hs`

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -20,7 +20,7 @@ jobs:
       stack-8.4.2:
         YAML_FILE: stack-8.4.2.yaml
   variables:
-    STACK_ROOT: /Users/vsts/.stack
+    STACK_ROOT: $(Build.SourcesDirectory)/.stack
   steps:
   - task: CacheBeta@0
     inputs:

--- a/.azure/windows-installhs-stack.yml
+++ b/.azure/windows-installhs-stack.yml
@@ -27,4 +27,8 @@ jobs:
   - bash: |
       source .azure/windows.bashrc
       stack install.hs help
-    displayName: Run help of `instal.hs`
+    displayName: Run help of `install.hs`
+  - bash: |
+      source .azure/windows.bashrc
+      stack install.hs stack-install-cabal
+    displayName: Run stack-install-cabal target of `install.hs`

--- a/.azure/windows-installhs-stack.yml
+++ b/.azure/windows-installhs-stack.yml
@@ -32,3 +32,7 @@ jobs:
       source .azure/windows.bashrc
       stack install.hs stack-install-cabal
     displayName: Run stack-install-cabal target of `install.hs`
+  - bash: |
+      source .azure/linux.bashrc
+      stack install.hs build-latest
+    displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-stack.yml
+++ b/.azure/windows-installhs-stack.yml
@@ -33,6 +33,6 @@ jobs:
       stack install.hs stack-install-cabal
     displayName: Run stack-install-cabal target of `install.hs`
   - bash: |
-      source .azure/linux.bashrc
+      source .azure/windows.bashrc
       stack install.hs build-latest
     displayName: Run build-latest target of `install.hs`

--- a/README.md
+++ b/README.md
@@ -244,12 +244,12 @@ stack ./install.hs hie-8.4.4
 stack ./install.hs build-data
 ```
 
-The Haskell IDE Engine can also be built with `cabal new-build` instead of `stack build`.
+The Haskell IDE Engine can also be built with `cabal v2-build` instead of `stack build`.
 This has the advantage that you can decide how the GHC versions have been installed.
 To see what GHC versions are available, the command `stack install.hs cabal-ghcs` can be used.
 It will list all GHC versions that are on the path and their respective installation directory.
 If you think, this list is incomplete, you can try to modify the PATH variable, such that the executables can be found.
-Note, that the targets `cabal-build`, `cabal-build-data` and `cabal-build-all` depend on the found GHC versions.
+Note, that the targets `cabal-build` and `cabal-build-data` depend on the found GHC versions.
 They install Haskell IDE Engine only for the found GHC versions.
 
 An example output is:
@@ -269,12 +269,6 @@ If your desired ghc has been found, you use it to install Haskell IDE Engine.
 ```bash
 stack install.hs cabal-hie-8.4.4
 stack install.hs cabal-build-data
-```
-
-To install HIE for all GHC versions that are present on your system, use:
-
-```bash
-stack ./install.hs cabal-build-all
 ```
 
 In general, targets that use `cabal` instead of `stack` are prefixed with `cabal-*` and are identical to their counterpart, except they do not install a GHC if it is missing but fail.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ cabal v2-run ./install.hs --project-file install/shake.project <target>
 
 Running the script with cabal on windows requires a cabal version greater or equal to `3.0.0.0`.
 
-Unfortunately, it is still required to have `stack` installed so that the install-script can locate the `local-bin` directory (on Linux `~/.local/bin`) and copy the `hie` binaries to `hie-x.y.z`, which is required for the `hie-wrapper` to function as expected.
+Unfortunately, it is still required to have `stack` installed so that the install-script can locate the `local-bin` directory (on Linux `~/.local/bin`) and copy the `hie` binaries to `hie-x.y.z`, which is required for the `hie-wrapper` to function as expected. There are plans to remove this requirement and let users build hie only with one build tool or another.
 
 For brevity, only the `stack`-based commands are presented in the following sections.
 
@@ -246,7 +246,6 @@ stack ./install.hs build-data
 
 The Haskell IDE Engine can also be built with `cabal new-build` instead of `stack build`.
 This has the advantage that you can decide how the GHC versions have been installed.
-However, this approach does currently not work for windows due to a missing feature upstream.
 To see what GHC versions are available, the command `stack install.hs cabal-ghcs` can be used.
 It will list all GHC versions that are on the path and their respective installation directory.
 If you think, this list is incomplete, you can try to modify the PATH variable, such that the executables can be found.

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -28,10 +28,10 @@ See the project's `README` for detailed information about installing `hie`.
 The build script `install.hs` defines several targets using the `shake` build system. The targets are roughly:
 
 * `hie-*`: builds and installs the `hie` binaries. Also renames the binaries to contain the correct version-number.
-* `build-lastest`: builds ad installs `hie` for the lastest available and supported `ghc` version.
+* `build-latest`: builds ad installs `hie` for the latest available and supported `ghc` version.
 * `build-all`: builds and installs `hie` binaries for all supported `ghc` versions. This option may take a long time and computer resources so use it with caution.
 * `build-data`: builds the hoogle-db required by `hie`
-* `build`:  builds ad installs `hie` for the lastest supported `ghc` version (like `build-lastest`) and the hoogle-db (like `build-data`)
+* `build`:  builds ad installs `hie` for the latest supported `ghc` version (like `build-latest`) and the hoogle-db (like `build-data`)
 * `cabal-*`: execute the same task as the original target, but with `cabal` instead of `stack`
 
 Each `stack-*.yaml` contains references to packages in the submodules. Calling `stack` with one of those causes the build to fail if the submodules have not been initialized already. The file `shake.yaml` solves this issue invoking the `git` binary itself to update the submodules. Moreover, it specifies the correct version of `shake` and is used for installing all run-time dependencies such as `cabal` and `hoogle` if necessary.

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -13,7 +13,6 @@ The design of the build system has the following main goals:
     - `stack`
     - `git`
 * is completely functional right after a simple `git clone` and after every `git pull`
-* one-stop-shop for building and naming all executables required for using `hie` in IDEs.
 * prevents certain build failures by either identifying a failed precondition (such as wrong `stack` version) or by performing the necessary steps so users can't forget them (such as invoking `git` to update submodules)
 
 
@@ -29,7 +28,6 @@ The build script `install.hs` defines several targets using the `shake` build sy
 
 * `hie-*`: builds and installs the `hie` binaries. Also renames the binaries to contain the correct version-number.
 * `build-latest`: builds and installs `hie` for the latest available and supported `ghc` version.
-* `build-all`: builds and installs `hie` binaries for all supported `ghc` versions. This option may take a long time and computer resources so use it with caution.
 * `build-data`: builds the hoogle-db required by `hie`
 * `build`:  builds and installs `hie` for the latest supported `ghc` version (like `build-latest`) and the hoogle-db (like `build-data`)
 * `cabal-*`: execute the same task as the original target, but with `cabal` instead of `stack`

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -28,8 +28,10 @@ See the project's `README` for detailed information about installing `hie`.
 The build script `install.hs` defines several targets using the `shake` build system. The targets are roughly:
 
 * `hie-*`: builds and installs the `hie` binaries. Also renames the binaries to contain the correct version-number.
-* `build`: builds and installs `hie` binaries for all supported `ghc` versions.
+* `build-lastest`: builds ad installs `hie` for the last available and supported `ghc` version.
+* `build-all`: builds and installs `hie` binaries for all supported `ghc` versions. This option may take a long time and computer resources so use it with caution.
 * `build-data`: builds the hoogle-db required by `hie`
+* `build`:  builds ad installs `hie` for the last supported `ghc` version (like `build-lastest`) and the hoogle-db (like `build-data`)
 * `cabal-*`: execute the same task as the original target, but with `cabal` instead of `stack`
 
 Each `stack-*.yaml` contains references to packages in the submodules. Calling `stack` with one of those causes the build to fail if the submodules have not been initialized already. The file `shake.yaml` solves this issue invoking the `git` binary itself to update the submodules. Moreover, it specifies the correct version of `shake` and is used for installing all run-time dependencies such as `cabal` and `hoogle` if necessary.
@@ -38,7 +40,7 @@ Each `stack-*.yaml` contains references to packages in the submodules. Calling `
 
 `hie` depends on a correct environment in order to function properly:
 
-* `cabal-install`: If no `cabal` executable can be found or has an outdated version, `cabal-install` is installed via `stack`.
+* `cabal-install`: This dependency is required by `hie` to handle correctly projects that are not `stack` based (without `stack.yaml`). You can install an appropiate version using `stack` with the `stack-install-cabal` target.
 * The `hoogle` database: `hoogle generate` needs to be called with the most-recent `hoogle` version.
 
 ### Steps to build `hie`
@@ -47,10 +49,9 @@ Installing `hie` is a multi-step process:
 
 1. `git submodule sync && git submodule update --init`
 2. `hoogle generate` (`hoogle>=5.0.17` to be safe)
-3. ensure that `cabal-install` is installed in the correct version
-4. `stack --stack-yaml=stack-<X>.yaml install` or `cabal new-install -w ghc-<X>`
-5. rename `hie` binary to `hie-<X>` in `$HOME/.local/bin`, where `<X>` is the GHC version used
-6. repeat step 4 and 5 for all desired GHC versions
+3. `stack --stack-yaml=stack-<X>.yaml install` or `cabal new-install -w ghc-<X>`
+4. rename `hie` binary to `hie-<X>` in `$HOME/.local/bin`, where `<X>` is the GHC version used
+5. repeat step 4 and 5 for all desired GHC versions
 
 This ensures that a complete install is always possible after each `git pull` or a `git clone`.
 
@@ -90,19 +91,17 @@ The final step is to configure the `hie` client to use a custom `hie-wrapper` sc
 The `install.hs` script performs some checks to ensure that a correct installation is possible and provide meaningful error messages for known issues.
 
 * `stack` needs to be up-to-date. Version `1.9.3` is required
+* `cabal` needs to be up-to-date. Version `3.0.0.0` is required for windows systems and `2.4.1.0` for other ones.
 * `ghc-8.6.3` is broken on windows. Trying to install `hie-8.6.3` on windows is not possible.
-* `cabal new-build` does not work on windows at the moment. All `cabal-*` targets exit with an error message about that.
 * When the build fails, an error message, that suggests to remove `.stack-work` directory, is displayed.
 
 ### Tradeoffs
 
 #### `stack` is a build dependency
 
-Currently, it is not possible to build all `hie-*` executables automatically without `stack`, since the `install.hs` script is executed by `stack`.
+Currently, `stack` is needed even if you run the script with `cabal` to get the path where install the binaries but there are plans to remove that dependency (see #1380).
 
-We are open to suggestions of other build systems that honor the requirements above, but are executable without `stack`.
-
-#### `install.hs` installs a GHC before running
+#### run `install.hs` with `stack` installs a GHC before running
 
 Before the code in `install.hs` can be executed, `stack` installs a `GHC`, depending on the `resolver` field in `shake.yaml`. This is necessary if `install.hs` should be completely functional right after a fresh `git clone` without further configuration.
 

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -28,10 +28,10 @@ See the project's `README` for detailed information about installing `hie`.
 The build script `install.hs` defines several targets using the `shake` build system. The targets are roughly:
 
 * `hie-*`: builds and installs the `hie` binaries. Also renames the binaries to contain the correct version-number.
-* `build-latest`: builds ad installs `hie` for the latest available and supported `ghc` version.
+* `build-latest`: builds and installs `hie` for the latest available and supported `ghc` version.
 * `build-all`: builds and installs `hie` binaries for all supported `ghc` versions. This option may take a long time and computer resources so use it with caution.
 * `build-data`: builds the hoogle-db required by `hie`
-* `build`:  builds ad installs `hie` for the latest supported `ghc` version (like `build-latest`) and the hoogle-db (like `build-data`)
+* `build`:  builds and installs `hie` for the latest supported `ghc` version (like `build-latest`) and the hoogle-db (like `build-data`)
 * `cabal-*`: execute the same task as the original target, but with `cabal` instead of `stack`
 
 Each `stack-*.yaml` contains references to packages in the submodules. Calling `stack` with one of those causes the build to fail if the submodules have not been initialized already. The file `shake.yaml` solves this issue invoking the `git` binary itself to update the submodules. Moreover, it specifies the correct version of `shake` and is used for installing all run-time dependencies such as `cabal` and `hoogle` if necessary.

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -49,15 +49,15 @@ Installing `hie` is a multi-step process:
 
 1. `git submodule sync && git submodule update --init`
 2. `hoogle generate` (`hoogle>=5.0.17` to be safe)
-3. `stack --stack-yaml=stack-<X>.yaml install` or `cabal new-install -w ghc-<X>`
+3. `stack --stack-yaml=stack-<X>.yaml install` or `cabal v2-install -w ghc-<X>`
 4. rename `hie` binary to `hie-<X>` in `$HOME/.local/bin`, where `<X>` is the GHC version used
-5. repeat step 4 and 5 for all desired GHC versions
+5. repeat step 3 and 4 for all desired GHC versions
 
 This ensures that a complete install is always possible after each `git pull` or a `git clone`.
 
 #### Building `hie` with profiling support
 
-To build `hie` with profiling enabled `cabal new-install` needs to be used instead of `stack`.
+To build `hie` with profiling enabled `cabal v2-install` needs to be used instead of `stack`.
 
 Configure `cabal` to enable profiling by setting `profiling: True` in `cabal.project.local` for all packages. If that file does not already exist, create it as follows:
 
@@ -72,7 +72,7 @@ Then `hie` can be compiled for a specific GHC version:
 
 ```bash
 export GHCP=<path-to-ghc-binary>
-cabal new-install exe:hie -w $GHCP \
+cabal v2-install exe:hie -w $GHCP \
   --write-ghc-environment-files=never --symlink-bindir=$HOME/.local/bin \
   --overwrite-policy=always --reinstall
 ```

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -89,7 +89,7 @@ The final step is to configure the `hie` client to use a custom `hie-wrapper` sc
 The `install.hs` script performs some checks to ensure that a correct installation is possible and provide meaningful error messages for known issues.
 
 * `stack` needs to be up-to-date. Version `1.9.3` is required
-* `cabal` needs to be up-to-date. Version `3.0.0.0` is required for windows systems and `2.4.1.0` for other ones.
+* `cabal` needs to be up-to-date. Version `2.4.1.0` is required to *use* haskell-ide-engine until the pull request #1126 is merged. Unfortunately cabal version `3.0.0.0` is needed to *install* hie in windows systems but that inconsistence will be fixed by the mentioned pull request.
 * `ghc-8.6.3` is broken on windows. Trying to install `hie-8.6.3` on windows is not possible.
 * When the build fails, an error message, that suggests to remove `.stack-work` directory, is displayed.
 

--- a/docs/Build.md
+++ b/docs/Build.md
@@ -28,10 +28,10 @@ See the project's `README` for detailed information about installing `hie`.
 The build script `install.hs` defines several targets using the `shake` build system. The targets are roughly:
 
 * `hie-*`: builds and installs the `hie` binaries. Also renames the binaries to contain the correct version-number.
-* `build-lastest`: builds ad installs `hie` for the last available and supported `ghc` version.
+* `build-lastest`: builds ad installs `hie` for the lastest available and supported `ghc` version.
 * `build-all`: builds and installs `hie` binaries for all supported `ghc` versions. This option may take a long time and computer resources so use it with caution.
 * `build-data`: builds the hoogle-db required by `hie`
-* `build`:  builds ad installs `hie` for the last supported `ghc` version (like `build-lastest`) and the hoogle-db (like `build-data`)
+* `build`:  builds ad installs `hie` for the lastest supported `ghc` version (like `build-lastest`) and the hoogle-db (like `build-data`)
 * `cabal-*`: execute the same task as the original target, but with `cabal` instead of `stack`
 
 Each `stack-*.yaml` contains references to packages in the submodules. Calling `stack` with one of those causes the build to fail if the submodules have not been initialized already. The file `shake.yaml` solves this issue invoking the `git` binary itself to update the submodules. Moreover, it specifies the correct version of `shake` and is used for installing all run-time dependencies such as `cabal` and `hoogle` if necessary.

--- a/install.hs
+++ b/install.hs
@@ -14,6 +14,7 @@ build-depends:
 -- * `stack install.hs <target>`
 
 -- TODO: set `shake.project` in cabal-config above, when supported
+-- (see https://github.com/haskell/cabal/issues/6353)
 
 import HieInstall (defaultMain)
 

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -64,7 +64,7 @@ cabalInstallHie versionNumber = do
     [ "v2-install"
     , "-w", ghcPath
     , "--write-ghc-environment-files=never"
-    , installDirOpt ++ "=" ++ localBin
+    , installDirOpt, localBin
     , "exe:hie"
     , "--overwrite-policy=always"
     ]

--- a/install/src/Env.hs
+++ b/install/src/Env.hs
@@ -17,9 +17,11 @@ import           Data.Function                            ( (&)
                                                           , on
                                                           )
 import           Data.List                                ( sort
+                                                          , sortBy
                                                           , isInfixOf
                                                           , nubBy
                                                           )
+import           Data.Ord                                 ( comparing )
 import           Control.Monad.Extra                      ( mapMaybeM )
 import           Data.Maybe                               ( isNothing
                                                           , mapMaybe
@@ -61,6 +63,8 @@ findInstalledGhcs = do
   -- filter out not supported ghc versions
   availableGhcs <- filter ((`elem` supportedGhcVersions) . fst) <$> getGhcPaths
   return
+    -- sort by version to make it coherent with getHieVersions
+    $ sortBy (comparing fst)
     -- nub by version. knownGhcs takes precedence.
     $ nubBy ((==) `on` fst)
     -- filter out stack provided GHCs (assuming that stack programs path is the default one in linux)

--- a/install/src/Env.hs
+++ b/install/src/Env.hs
@@ -8,7 +8,10 @@ import           Development.Shake.FilePath
 import           System.Info                              ( os
                                                           , arch
                                                           )
-import           Data.Maybe                               ( isJust )
+import           Data.Maybe                               ( isJust
+                                                          , isNothing
+                                                          , mapMaybe
+                                                          )
 import           System.Directory                         ( findExecutable
                                                           , findExecutables
                                                           , listDirectory
@@ -23,9 +26,7 @@ import           Data.List                                ( sort
                                                           )
 import           Data.Ord                                 ( comparing )
 import           Control.Monad.Extra                      ( mapMaybeM )
-import           Data.Maybe                               ( isNothing
-                                                          , mapMaybe
-                                                          )
+
 import qualified Data.Text                     as T
 
 import           Version
@@ -80,8 +81,6 @@ getGhcPathOf ghcVersion =
   liftIO $ findExecutable ("ghc-" ++ ghcVersion <.> exe) >>= \case
     Nothing -> lookup ghcVersion <$> getGhcPaths
     path -> return path
-  where exe | isWindowsSystem = "exe"
-            | otherwise = ""
 
 -- | Get a list of GHCs that are available in $PATH
 getGhcPaths :: MonadIO m => m [(VersionNumber, GhcPath)]

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -148,7 +148,7 @@ buildAllWarning :: String
 buildAllWarning = "WARNING: This command may take a long time and computer resources"
 
 buildAllWarningAlt :: String
-buildAllWarningAlt = "Consider build only the needed ghc versions using:\n"
+buildAllWarningAlt = "Consider building only the ghc versions you need using:\n"
                  ++ "  " ++ buildCommand (hieTarget "<ghc-version>") ++ "\n"
                  ++ "or the latest available one with:\n"
                  ++ "  " ++ buildCommand buildLatestTarget ++ "\n"

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -16,7 +16,7 @@ stackCommand :: TargetDescription -> String
 stackCommand target = "stack install.hs " ++ fst target
 
 cabalCommand :: TargetDescription -> String
-cabalCommand target = "cabal new-run install.hs --project-file install/shake.project " ++ fst target
+cabalCommand target = "cabal v2-run install.hs --project-file install/shake.project " ++ fst target
 
 buildCommand :: TargetDescription -> String
 buildCommand | isRunFromCabal = cabalCommand

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -86,11 +86,12 @@ helpMessage versions@BuildableVersions {..} = do
   -- All targets with their respective help message.
   generalTargets = [helpTarget]
 
-  defaultTargets = [buildTarget, buildLastestTarget, buildAllTarget, buildDataTarget]
+  defaultTargets = [buildTarget, buildLatestTarget, buildAllTarget, buildDataTarget]
     ++ map hieTarget (getDefaultBuildSystemVersions versions)
 
   stackTargets =
     [ stackTarget buildTarget
+      , stackTarget buildLatestTarget
       , stackTarget buildAllTarget
       , stackTarget buildDataTarget
       ]
@@ -100,6 +101,7 @@ helpMessage versions@BuildableVersions {..} = do
   cabalTargets =
     [ cabalGhcsTarget
       , cabalTarget buildTarget
+      , cabalTarget buildLatestTarget
       , cabalTarget buildAllTarget
       , cabalTarget buildDataTarget
       ]
@@ -127,10 +129,10 @@ hieTarget version =
   ("hie-" ++ version, "Builds hie for GHC version " ++ version)
 
 buildTarget :: TargetDescription
-buildTarget = ("build", "Build hie with the lastest available GHC and the data files")
+buildTarget = ("build", "Build hie with the latest available GHC and the data files")
 
-buildLastestTarget :: TargetDescription
-buildLastestTarget = ("build-lastest", "Build hie with the lastest available GHC")
+buildLatestTarget :: TargetDescription
+buildLatestTarget = ("build-latest", "Build hie with the latest available GHC")
 
 buildDataTarget :: TargetDescription
 buildDataTarget =
@@ -148,8 +150,8 @@ buildAllWarning = "WARNING: This command may take a long time and computer resou
 buildAllWarningAlt :: String
 buildAllWarningAlt = "Consider build only the needed ghc versions using:\n"
                  ++ "  " ++ buildCommand (hieTarget "<ghc-version>") ++ "\n"
-                 ++ "or the lastest available one with:\n"
-                 ++ "  " ++ buildCommand buildLastestTarget ++ "\n"
+                 ++ "or the latest available one with:\n"
+                 ++ "  " ++ buildCommand buildLatestTarget ++ "\n"
 
 -- special targets
 

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -45,7 +45,7 @@ shortHelpMessage = do
     [ ("help", "Show help message including all targets")
     , emptyTarget
     , buildTarget
-    , buildAllTarget
+    , buildLatestTarget
     , hieTarget $ last hieVersions
     , buildDataTarget
     , cabalGhcsTarget
@@ -86,13 +86,12 @@ helpMessage versions@BuildableVersions {..} = do
   -- All targets with their respective help message.
   generalTargets = [helpTarget]
 
-  defaultTargets = [buildTarget, buildLatestTarget, buildAllTarget, buildDataTarget]
+  defaultTargets = [buildTarget, buildLatestTarget, buildDataTarget]
     ++ map hieTarget (getDefaultBuildSystemVersions versions)
 
   stackTargets =
     [ stackTarget buildTarget
       , stackTarget buildLatestTarget
-      , stackTarget buildAllTarget
       , stackTarget buildDataTarget
       ]
       ++ (if isRunFromStack then [stackTarget installCabalTarget] else [])
@@ -102,7 +101,6 @@ helpMessage versions@BuildableVersions {..} = do
     [ cabalGhcsTarget
       , cabalTarget buildTarget
       , cabalTarget buildLatestTarget
-      , cabalTarget buildAllTarget
       , cabalTarget buildDataTarget
       ]
       ++ map (cabalTarget . hieTarget) cabalVersions
@@ -138,21 +136,6 @@ buildDataTarget :: TargetDescription
 buildDataTarget =
   ("build-data", "Get the required data-files for `hie` (Hoogle DB)")
 
-buildAllTarget :: TargetDescription
-buildAllTarget =
-  ( "build-all"
-  , "Builds hie for all installed GHC versions and the data files. "
-  ++ buildAllWarning)
-
-buildAllWarning :: String
-buildAllWarning = "WARNING: This command may take a long time and computer resources"
-
-buildAllWarningAlt :: String
-buildAllWarningAlt = "Consider building only the ghc versions you need using:\n"
-                 ++ "  " ++ buildCommand (hieTarget "<ghc-version>") ++ "\n"
-                 ++ "or the latest available one with:\n"
-                 ++ "  " ++ buildCommand buildLatestTarget ++ "\n"
-
 -- special targets
 
 macosIcuTarget :: TargetDescription
@@ -164,7 +147,7 @@ helpTarget = ("help", "Show help message including all targets")
 cabalGhcsTarget :: TargetDescription
 cabalGhcsTarget =
   ( "cabal-ghcs"
-  , "Show all GHC versions that can be installed via `cabal-build` and `cabal-build-all`."
+  , "Show all GHC versions that can be installed via `cabal-build`."
   )
 
 installCabalTarget :: TargetDescription

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -12,13 +12,13 @@ import           Version
 import           BuildSystem
 import           Cabal
 
-stackCommand :: String -> String
-stackCommand target = "stack install.hs " ++ target
+stackCommand :: TargetDescription -> String
+stackCommand target = "stack install.hs " ++ fst target
 
-cabalCommand :: String -> String
-cabalCommand target = "cabal new-run install.hs --project-file install/shake.project " ++ target
+cabalCommand :: TargetDescription -> String
+cabalCommand target = "cabal new-run install.hs --project-file install/shake.project " ++ fst target
 
-buildCommand :: String -> String
+buildCommand :: TargetDescription -> String
 buildCommand | isRunFromCabal = cabalCommand
              | otherwise = stackCommand
 
@@ -26,9 +26,9 @@ printUsage :: Action ()
 printUsage = do
   printLine ""
   printLine "Usage:"
-  printLineIndented (stackCommand "<target>")
+  printLineIndented (stackCommand templateTarget)
   printLineIndented "or"
-  printLineIndented (cabalCommand "<target>")
+  printLineIndented (cabalCommand templateTarget)
 
 -- | short help message is printed by default
 shortHelpMessage :: Action ()
@@ -109,6 +109,9 @@ helpMessage versions@BuildableVersions {..} = do
 emptyTarget :: (String, String)
 emptyTarget = ("", "")
 
+templateTarget :: (String, String)
+templateTarget = ("<target>", "")
+
 targetWithBuildSystem :: String -> TargetDescription -> TargetDescription
 targetWithBuildSystem system (target, description) =
   (system ++ "-" ++ target, description ++ "; with " ++ system)
@@ -144,9 +147,9 @@ buildAllWarning = "WARNING: This command may take a long time and computer resou
 
 buildAllWarningAlt :: String
 buildAllWarningAlt = "Consider build only the needed ghc versions using:\n"
-                 ++ "  " ++ buildCommand "build-${ghcVersion}\n"
+                 ++ "  " ++ buildCommand (hieTarget "<ghc-version>") ++ "\n"
                  ++ "or the lastest available one with:\n"
-                 ++ "  " ++ buildCommand "build-lastest\n"
+                 ++ "  " ++ buildCommand (hieTarget "<ghc-version>") ++ "\n"
 
 -- special targets
 

--- a/install/src/Help.hs
+++ b/install/src/Help.hs
@@ -149,7 +149,7 @@ buildAllWarningAlt :: String
 buildAllWarningAlt = "Consider build only the needed ghc versions using:\n"
                  ++ "  " ++ buildCommand (hieTarget "<ghc-version>") ++ "\n"
                  ++ "or the lastest available one with:\n"
-                 ++ "  " ++ buildCommand (hieTarget "<ghc-version>") ++ "\n"
+                 ++ "  " ++ buildCommand buildLastestTarget ++ "\n"
 
 -- special targets
 

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -85,7 +85,6 @@ defaultMain = do
     -- default-targets
     phony "build" $ need [buildSystem ++ "-build"]
     phony "build-latest" $ need [buildSystem ++ "-build-latest"]
-    phony "build-all" $ need [buildSystem ++ "-build-all"]
     phony "build-data" $ need [buildSystem ++ "-build-data"]
     forM_
       (getDefaultBuildSystemVersions versions)
@@ -97,10 +96,7 @@ defaultMain = do
     when isRunFromStack (phony "stack-install-cabal" (need ["cabal"]))
     phony "stack-build-latest" (need ["stack-hie-" ++ last hieVersions])
     phony "stack-build"  (need ["build-data", "stack-build-latest"])
-    phony "stack-build-all" $ do
-      printInStars (buildAllWarning ++ ".\n" ++ buildAllWarningAlt)
-      need (["build-data"] ++ (reverse $ map ("stack-hie-" ++) hieVersions))
-
+    
     phony "stack-build-data" $ do
       need ["submodules"]
       need ["check-stack"]
@@ -117,10 +113,6 @@ defaultMain = do
     -- cabal specific targets
     phony "cabal-build-latest" (need ["cabal-hie-" ++ last ghcVersions])
     phony "cabal-build"  (need ["build-data", "cabal-build-latest"])
-    phony "cabal-build-all" $ do
-      printInStars (buildAllWarning ++ ".\n" ++ buildAllWarningAlt)
-      need (["cabal-build-data"] ++ (map ("cabal-hie-" ++) ghcVersions))
-
     phony "cabal-build-data" $ do
       need ["submodules"]
       need ["cabal"]

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -57,7 +57,7 @@ defaultMain = do
                                    , cabalVersions = ghcVersions
                                    }
 
-  let lastestVersion = last hieVersions
+  let latestVersion = last hieVersions
 
   putStrLn $ "run from: " ++ buildSystem
 
@@ -84,7 +84,7 @@ defaultMain = do
 
     -- default-targets
     phony "build" $ need [buildSystem ++ "-build"]
-    phony "build-lastest" $ need [buildSystem ++ "-build-lastest"]
+    phony "build-latest" $ need [buildSystem ++ "-build-latest"]
     phony "build-all" $ need [buildSystem ++ "-build-all"]
     phony "build-data" $ need [buildSystem ++ "-build-data"]
     forM_
@@ -95,8 +95,8 @@ defaultMain = do
 
     -- stack specific targets
     when isRunFromStack (phony "stack-install-cabal" (need ["cabal"]))
-    phony "stack-build-lastest" (need ["stack-hie-" ++ last hieVersions])
-    phony "stack-build"  (need ["build-data", "stack-build-lastest"])
+    phony "stack-build-latest" (need ["stack-hie-" ++ last hieVersions])
+    phony "stack-build"  (need ["build-data", "stack-build-latest"])
     phony "stack-build-all" $ do
       printInStars (buildAllWarning ++ ".\n" ++ buildAllWarningAlt)
       need (["build-data"] ++ (reverse $ map ("stack-hie-" ++) hieVersions))
@@ -115,8 +115,8 @@ defaultMain = do
       )
 
     -- cabal specific targets
-    phony "cabal-build-lastest" (need ["cabal-hie-" ++ last ghcVersions])
-    phony "cabal-build"  (need ["build-data", "cabal-build-lastest"])
+    phony "cabal-build-latest" (need ["cabal-hie-" ++ last ghcVersions])
+    phony "cabal-build"  (need ["build-data", "cabal-build-latest"])
     phony "cabal-build-all" $ do
       printInStars (buildAllWarning ++ ".\n" ++ buildAllWarningAlt)
       need (["cabal-build-data"] ++ (map ("cabal-hie-" ++) ghcVersions))

--- a/install/src/Print.hs
+++ b/install/src/Print.hs
@@ -18,7 +18,7 @@ printLineIndented = printLine . ("    " ++)
 
 embedInStars :: String -> String
 embedInStars str =
-  let starsLine = "\n" <> replicate 30 '*' <> "\n"
+  let starsLine = "\n" <> replicate 80 '*' <> "\n"
   in  starsLine <> str <> starsLine
 
 printInStars :: MonadIO m => String -> m ()

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -135,5 +135,5 @@ withoutStackCachedBinaries action = do
         splitPaths s =
           case dropWhile (== searchPathSeparator) s of
                       "" -> []
-                      s' -> w : words s''
+                      s' -> w : splitPaths s''
                             where (w, s'') = break (== searchPathSeparator) s'

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -7,7 +7,7 @@ import           Control.Exception
 import           Control.Monad
 import           Data.List
 import           System.Directory                         ( copyFile )
-import           System.FilePath                          ( searchPathSeparator, (</>) )
+import           System.FilePath                          ( splitSearchPath, searchPathSeparator, (</>) )
 import           System.Environment                       ( lookupEnv, setEnv, getEnvironment )
 import           System.IO.Error                          ( isDoesNotExistError )
 import           BuildSystem
@@ -124,13 +124,7 @@ withoutStackCachedBinaries action = do
     otherwise -> action
 
   where removePathsContaining strs path =
-           joinPaths (filter (not . containsAny) (splitPaths path))
+           joinPaths (filter (not . containsAny) (splitSearchPath path))
            where containsAny p = any (`isInfixOf` p) strs
         
         joinPaths = intercalate [searchPathSeparator]
-        
-        splitPaths s =
-          case dropWhile (== searchPathSeparator) s of
-                      "" -> []
-                      s' -> w : splitPaths s''
-                            where (w, s'') = break (== searchPathSeparator) s'

--- a/install/src/Stack.hs
+++ b/install/src/Stack.hs
@@ -105,10 +105,7 @@ stackBuildFailMsg =
 withoutStackCachedBinaries :: Action a -> Action a
 withoutStackCachedBinaries action = do
 
-  let getEnvErrorHandler e | isDoesNotExistError e = return Nothing
-                           | otherwise = throwIO e
-
-  mbPath <- liftIO (lookupEnv "PATH" `catch` getEnvErrorHandler)
+  mbPath <- liftIO (lookupEnv "PATH")
 
   case (mbPath, isRunFromStack) of
 


### PR DESCRIPTION
* Improvements 
  * ~~Use explicit list of ghc supported versions to filter out targets (stack and cabal).~~
  * Use the list of stack-*.yaml files to filter out unsupported ghc versions of available ones.  Fixes #1445
  * Add new target `build-lastest`to build hie with the lastest supported and available ghc
  * *Change the default `build` target to build the lastest version and data files instead `build-all`*
  * ~~Prints a warning about consumed resources and time when executing `build-all` and when printing the help~~
  * Remove the `build-all` target (see https://github.com/haskell/haskell-ide-engine/pull/1452#discussion_r346941695)
* Bug fixes
  * make `cabal-ghcs` work in windows
  * fix the compiler used in the `cabal v2-install` phase of `cabal-hie-<version>`target
  * fix the `stack-install-cabal` target for posix envs. Hopefully it fixes #1436
    * Thanks @fendor for detecting the offending code (introduced by myself with https://github.com/haskell/haskell-ide-engine/pull/1406/files#diff-707cf6d4db4ff1099736896c9d96a6f8R132)
  * sync docs with recent changes (included this one)

* Unrelated changes
  * Fix the builds of macos in azure