### PR TITLE
Bump haskell-lsp et al to 0.18.0.0

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -71,8 +71,8 @@ library
                      , gitrev >= 1.1
                      , haddock-api
                      , haddock-library
-                     , haskell-lsp == 0.17.*
-                     , haskell-lsp-types == 0.17.*
+                     , haskell-lsp == 0.18.*
+                     , haskell-lsp-types == 0.18.*
                      , haskell-src-exts
                      , hie-plugin-api
                      , hoogle >= 5.0.13
@@ -196,7 +196,7 @@ test-suite unit-test
                      , free
                      , ghc
                      , haskell-ide-engine
-                     , haskell-lsp-types == 0.17.*
+                     , haskell-lsp-types == 0.18.*
                      , hie-test-utils
                      , hie-plugin-api
                      , hoogle > 5.0.11
@@ -285,8 +285,8 @@ test-suite func-test
                      , filepath
                      , lsp-test >= 0.8.0.0
                      , haskell-ide-engine
-                     , haskell-lsp-types == 0.17.*
-                     , haskell-lsp == 0.17.*
+                     , haskell-lsp-types == 0.18.*
+                     , haskell-lsp == 0.18.*
                      , hie-test-utils
                      , hie-plugin-api
                      , hspec

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginUtils.hs
@@ -275,7 +275,7 @@ readVFS :: (MonadIde m, MonadIO m) => Uri -> m (Maybe T.Text)
 readVFS uri = do
   mvf <- getVirtualFile uri
   case mvf of
-    Just (VirtualFile _ txt _) -> return $ Just (Rope.toText txt)
+    Just (VirtualFile _ txt) -> return $ Just (Rope.toText txt)
     Nothing -> return Nothing
 
 getRangeFromVFS :: (MonadIde m, MonadIO m) => Uri -> Range -> m (Maybe T.Text)

--- a/hie-plugin-api/hie-plugin-api.cabal
+++ b/hie-plugin-api/hie-plugin-api.cabal
@@ -45,7 +45,7 @@ library
                      , ghc
                      , ghc-mod-core >= 5.9.0.0
                      , ghc-project-types >= 5.9.0.0
-                     , haskell-lsp == 0.17.*
+                     , haskell-lsp == 0.18.*
                      , hslogger
                      , monad-control
                      , mtl

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -19,14 +19,14 @@ extra-deps:
 - ghc-lib-parser-8.8.1
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -19,14 +19,14 @@ extra-deps:
 - ghc-lib-parser-8.8.1
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2
 - pretty-show-1.8.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -18,14 +18,14 @@ extra-deps:
 - ghc-lib-parser-8.8.1
 - haddock-api-2.20.0
 - haddock-library-1.6.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2
 - optparse-simple-0.1.0
 - pretty-show-1.9.5

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -22,14 +22,14 @@ extra-deps:
 - floskell-0.10.1
 - ghc-lib-parser-8.8.1
 - haddock-api-2.21.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - monoid-subclasses-0.4.6.1

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -18,14 +18,14 @@ extra-deps:
 - floskell-0.10.1
 - ghc-lib-parser-8.8.1
 - haddock-api-2.21.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -17,14 +17,14 @@ extra-deps:
 - floskell-0.10.1
 - ghc-lib-parser-8.8.1
 - haddock-api-2.21.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hlint-2.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -17,13 +17,13 @@ extra-deps:
 - floskell-0.10.1
 - ghc-lib-parser-8.8.1
 - haddock-api-2.22.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - hlint-2.2.3
 - hoogle-5.0.17.11
 - hsimport-0.11.0
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -18,12 +18,12 @@ extra-deps:
 - floskell-0.10.1
 - ghc-lib-parser-8.8.1
 - haddock-api-2.22.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - hlint-2.2.3
 - hsimport-0.11.0
 - hoogle-5.0.17.11
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2@rev:1
 - syz-0.2.0.0
 - temporary-1.2.1.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,11 +18,11 @@ extra-deps:
 - floskell-0.10.1
 - ghc-lib-parser-8.8.1
 - haddock-api-2.22.0
-- haskell-lsp-0.17.0.0
-- haskell-lsp-types-0.17.0.0
+- haskell-lsp-0.18.0.0
+- haskell-lsp-types-0.18.0.0
 - hlint-2.2.3
 - hsimport-0.11.0
-- lsp-test-0.8.0.0
+- lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2@rev:1
 - syz-0.2.0.0
 - temporary-1.2.1.1


### PR DESCRIPTION
Supersedes #1446 

@bubba has undertaken to provide a follow-up commit setting the newly structured `hieOptions` appropriately.