### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ sudo dnf install libicu-devel ncurses-devel
 In order to avoid problems with long paths on Windows you can do either one of the following:
 
 1. Clone the `haskell-ide-engine` to a short path, for example the root of your logical drive (e.g. to
-   `C:\hie`). If this doesn't work try the second option.
+   `C:\hie`). If this doesn't work or you want to use a longer path, try the second option.
 
 2. If the `Local Group Policy Editor` is available on your system, go to: `Local Computer Policy -> Computer Configuration -> Administrative Templates -> System -> Filesystem` set `Enable Win32 long paths` to `Enabled`. If you don't have the policy editor you can use regedit by using the following instructions [here](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later). You also need to configure git to allow longer paths by using unicode paths. To set this for all your git repositories use `git config --system core.longpaths true` (you probably need an administrative shell for this) or for just this one repository use `git config core.longpaths true`.
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,10 @@ sudo dnf install libicu-devel ncurses-devel
 
 In order to avoid problems with long paths on Windows you can do either one of the following:
 
-1. Clone the `haskell-ide-engine` to the root of your logical drive (e.g. to
+1. Clone the `haskell-ide-engine` to a short path, for example the root of your logical drive (e.g. to
    `C:\hie`). If this doesn't work try the second option.
 
-2. In the `Local Group Policy Editor`: `Local Computer Policy -> Computer Configuration -> Administrative Templates -> System -> Filesystem` set `Enable Win32 long paths` to `Enabled` (Works
-   only for Windows 10). Also you need to configure git to allow longer paths by using unicode paths. To set this for all your git repositories use `git config --system core.longpaths true` (you probably need an administrative shell for this) or for just this one repository use `git config core.longpaths true`.
+2. If the `Local Group Policy Editor` is available on your system, go to: `Local Computer Policy -> Computer Configuration -> Administrative Templates -> System -> Filesystem` set `Enable Win32 long paths` to `Enabled`. If you don't have the policy editor you can use regedit by using the following instructions [here](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later). You also need to configure git to allow longer paths by using unicode paths. To set this for all your git repositories use `git config --system core.longpaths true` (you probably need an administrative shell for this) or for just this one repository use `git config core.longpaths true`.
 
 #### Download the source code
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ we talk to clients.__
     - [Installation from source](#installation-from-source)
       - [Common pre-requirements](#common-pre-requirements)
       - [Linux-specific pre-requirements](#linux-specific-pre-requirements)
-      - [Windows-specific pre-requirements (optional)](#windows-specific-pre-requirements-optional)
+      - [Windows-specific pre-requirements](#windows-specific-pre-requirements)
       - [Download the source code](#download-the-source-code)
       - [Building](#building)
         - [Install specific GHC Version](#install-specific-ghc-version)
@@ -172,15 +172,15 @@ sudo apt install libicu-dev libtinfo-dev libgmp-dev
 sudo dnf install libicu-devel ncurses-devel
 ```
 
-#### Windows-specific pre-requirements (optional)
+#### Windows-specific pre-requirements
 
-In order to avoid problems with long paths on Windows you can do the following:
+In order to avoid problems with long paths on Windows you can do either one of the following:
 
-1. In the `Local Group Policy Editor`: `Local Computer Policy -> Computer Configuration -> Administrative Templates -> System -> Filesystem` set `Enable Win32 long paths` to `Enabled` (Works
-   only for Windows 10).
+1. Clone the `haskell-ide-engine` to the root of your logical drive (e.g. to
+   `C:\hie`). If this doesn't work try the second option.
 
-2. Clone the `haskell-ide-engine` to the root of your logical drive (e.g. to
-   `C:\hie`)
+2. In the `Local Group Policy Editor`: `Local Computer Policy -> Computer Configuration -> Administrative Templates -> System -> Filesystem` set `Enable Win32 long paths` to `Enabled` (Works
+   only for Windows 10). Also you need to configure git to allow longer paths by using unicode paths. To set this for all your git repositories use `git config --system core.longpaths true` (you probably need an administrative shell for this) or for just this one repository use `git config core.longpaths true`.
 
 #### Download the source code
 


### PR DESCRIPTION
The windows pre-requirements are not optional but an absolute must when cloning. Well if you already have the right settings it will be a no-op just like installing `sudo apt install libicu-dev libtinfo-dev libgmp-dev` on linux will be a no-op when you already have them.

Setting the windows path limitation was not enough. Git also needs to be configured.