### PR TITLE
Relax bounds of shake and use latest hie resolver

### DIFF
--- a/install/hie-install.cabal
+++ b/install/hie-install.cabal
@@ -19,7 +19,7 @@ library
                      , Env
                      , Help
   build-depends:       base >= 4.9 && < 5
-                     , shake == 0.17.8
+                     , shake >= 0.16.4 && < 0.19
                      , directory
                      , filepath
                      , extra

--- a/install/shake.yaml
+++ b/install/shake.yaml
@@ -1,5 +1,5 @@
 # Used to provide a different environment for the shake build script
-resolver: lts-13.18 # GHC 8.6.4
+resolver: lts-14.11 # GHC 8.6.5
 packages:
 - .
 


### PR DESCRIPTION
* The new bounds of shake let install it with all supported resolvers of hie so if users want to change `shake.yaml` to match the resolver of hie itself they will be able to do it
  * I still have kept the upper bound cause a new release of shake could break the script
* I've changed the actual resolver to match the latest hie cause i think it will be the most common scenario and this way run the script and install hie will use the same ghc.
* Tested with all `stack-*.yaml` resolvers and `lts-14.14`
* Fixes #1460