### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ sudo apt install libicu-dev libtinfo-dev libgmp-dev
 **Fedora**:
 
 ```bash
-sudo dnf install libicu-devel ncurses-devel
+sudo dnf install libicu-devel ncurses-devel # also zlib-devel if not already installed
 ```
 
 #### Windows-specific pre-requirements


### PR DESCRIPTION
I guess in most cases `zlib` is installed by default, but in case it is not, build would failed as `digest` depends on it.