### PR TITLE
Bump versions

### DIFF
--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -14,7 +14,7 @@ extra-deps:
 - base-compat-0.9.3
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-exactprint-0.5.8.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.20.0
@@ -23,7 +23,7 @@ extra-deps:
 - haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hlint-2.2.3
+- hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.8.2.0

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -14,6 +14,7 @@ extra-deps:
 - base-compat-0.9.3
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
+- filepattern-0.1.1
 - floskell-0.10.2
 - ghc-exactprint-0.5.8.2
 - ghc-lib-parser-8.8.1

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -14,6 +14,7 @@ extra-deps:
 - brittany-0.12.1.0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
+- filepattern-0.1.1
 - floskell-0.10.2
 - ghc-exactprint-0.5.8.2
 - ghc-lib-parser-8.8.1

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -14,7 +14,7 @@ extra-deps:
 - brittany-0.12.1.0
 - cabal-plan-0.3.0.0
 - constrained-dynamic-0.1.0.0
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-exactprint-0.5.8.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.20.0
@@ -23,7 +23,7 @@ extra-deps:
 - haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hlint-2.2.3
+- hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.8.2.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -13,6 +13,7 @@ extra-deps:
 - brittany-0.12.1.0
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
+- filepattern-0.1.1
 - floskell-0.10.2
 - ghc-exactprint-0.5.8.2
 - ghc-lib-parser-8.8.1

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -13,7 +13,7 @@ extra-deps:
 - brittany-0.12.1.0
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-exactprint-0.5.8.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.20.0
@@ -22,7 +22,7 @@ extra-deps:
 - haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hlint-2.2.3
+- hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.8.2.0

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -19,6 +19,7 @@ extra-deps:
 - czipwith-1.0.1.1
 - data-tree-print-0.1.0.2
 - deque-0.4.3
+- filepattern-0.1.1
 - floskell-0.10.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.21.0

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -19,14 +19,14 @@ extra-deps:
 - czipwith-1.0.1.1
 - data-tree-print-0.1.0.2
 - deque-0.4.3
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.21.0
 - haskell-lsp-0.18.0.0
 - haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hlint-2.2.3
+- hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.8.2.0

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -15,6 +15,7 @@ extra-deps:
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
 - deque-0.4.3
+- filepattern-0.1.1
 - floskell-0.10.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.21.0

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -15,14 +15,14 @@ extra-deps:
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
 - deque-0.4.3
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.21.0
 - haskell-lsp-0.18.0.0
 - haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hlint-2.2.3
+- hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.8.2.0

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -14,14 +14,14 @@ extra-deps:
 - butcher-1.3.2.1
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.21.0
 - haskell-lsp-0.18.0.0
 - haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
-- hlint-2.2.3
+- hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.8.2.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -14,13 +14,13 @@ extra-deps:
 - butcher-1.3.2.1
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.22.0
 - haskell-lsp-0.18.0.0
 - haskell-lsp-types-0.18.0.0
 - haskell-src-exts-1.21.1
-- hlint-2.2.3
+- hlint-2.2.4
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.8.2.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.11
+resolver: lts-14.16
 packages:
 - .
 - hie-plugin-api
@@ -15,12 +15,12 @@ extra-deps:
 - brittany-0.12.1.0
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.22.0
 - haskell-lsp-0.18.0.0
 - haskell-lsp-types-0.18.0.0
-- hlint-2.2.3
+- hlint-2.2.4
 - hsimport-0.11.0
 - hoogle-5.0.17.11
 - lsp-test-0.8.2.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,12 +15,12 @@ extra-deps:
 - brittany-0.12.1.0
 - cabal-plan-0.4.0.0
 - constrained-dynamic-0.1.0.0
-- floskell-0.10.1
+- floskell-0.10.2
 - ghc-lib-parser-8.8.1
 - haddock-api-2.22.0
 - haskell-lsp-0.18.0.0
 - haskell-lsp-types-0.18.0.0
-- hlint-2.2.3
+- hlint-2.2.4
 - hsimport-0.11.0
 - lsp-test-0.8.2.0
 - monad-dijkstra-0.1.1.2@rev:1


### PR DESCRIPTION
Bump hlint to 2.2.4, floskell to 0.10.2, and GHC 8.6.5 resolver to lts-14.16