### PR TITLE
README.md: do not hardcode ghc version in example command given in 'I…

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,14 +231,14 @@ stack ./install.hs stack-install-cabal
 Install **Nightly** (and hoogle docs):
 
 ```bash
-stack ./install.hs hie-8.6.4
+stack ./install.hs hie-$(stack exec ghc -- --version | sed 's/.*version //')
 stack ./install.hs build-data
 ```
 
 Install **LTS** (and hoogle docs):
 
 ```bash
-stack ./install.hs hie-8.4.4
+stack ./install.hs hie-$(stack exec ghc -- --version | sed 's/.*version //')
 stack ./install.hs build-data
 ```
 

--- a/README.md
+++ b/README.md
@@ -231,14 +231,14 @@ stack ./install.hs stack-install-cabal
 Install **Nightly** (and hoogle docs):
 
 ```bash
-stack ./install.hs hie-$(stack exec ghc -- --version | sed 's/.*version //')
+stack ./install.hs hie-$(stack exec ghc -- --numeric-version)
 stack ./install.hs build-data
 ```
 
 Install **LTS** (and hoogle docs):
 
 ```bash
-stack ./install.hs hie-$(stack exec ghc -- --version | sed 's/.*version //')
+stack ./install.hs hie-$(stack exec ghc -- --numeric-version)
 stack ./install.hs build-data
 ```
 


### PR DESCRIPTION
…nstall specific GHC Version' subsection, to be more beginner friendly

I'm a fresh haskeller and this is the only change needed to get haskell-ide-engine to work flawlessly using the given install procedure (I use stack). Maybe the $(...) command can be made more Windows friendly ? Or maybe you just wanna add a comment, instead of having this full-fledged command ? In any case, I think the concerned example can be enhanced.

And thanks for you hard work on haskell-ide-engine, greatly appreciated!