### PR TITLE
Ormolu formatter support

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -39,6 +39,7 @@ import           Haskell.Ide.Engine.Plugin.Haddock
 import           Haskell.Ide.Engine.Plugin.HfaAlign
 import           Haskell.Ide.Engine.Plugin.HsImport
 import           Haskell.Ide.Engine.Plugin.Liquid
+import           Haskell.Ide.Engine.Plugin.Ormolu
 import           Haskell.Ide.Engine.Plugin.Package
 import           Haskell.Ide.Engine.Plugin.Pragmas
 
@@ -63,6 +64,7 @@ plugins includeExamples = pluginDescToIdePlugins allPlugins
       , floskellDescriptor    "floskell"
       , genericDescriptor     "generic"
       , ghcmodDescriptor      "ghcmod"
+      , ormoluDescriptor      "ormolu"
       ]
     examplePlugins =
       [example2Descriptor "eg2"

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -33,7 +33,6 @@ library
                        Haskell.Ide.Engine.Plugin.HfaAlign
                        Haskell.Ide.Engine.Plugin.HsImport
                        Haskell.Ide.Engine.Plugin.Liquid
-                       Haskell.Ide.Engine.Plugin.Ormolu
                        Haskell.Ide.Engine.Plugin.Package
                        Haskell.Ide.Engine.Plugin.Package.Compat
                        Haskell.Ide.Engine.Plugin.Pragmas
@@ -47,6 +46,9 @@ library
                        Haskell.Ide.Engine.Server
                        Haskell.Ide.Engine.Types
                        Haskell.Ide.Engine.Version
+  if impl(ghc > 8.4)
+     exposed-modules: Haskell.Ide.Engine.Plugin.Ormolu
+
   other-modules:       Paths_haskell_ide_engine
   build-depends:       Cabal >= 1.22
                      , Diff
@@ -82,7 +84,6 @@ library
                      , monoid-subclasses > 0.4
                      , mtl
                      , optparse-simple >= 0.0.3
-                     , ormolu
                      , parsec
                      , process
                      , safe
@@ -101,6 +102,8 @@ library
                      , bytestring-trie
                      , unliftio
                      , hlint >= 2.2.2
+  if impl(ghc > 8.4)
+     build-depends: ormolu
 
   ghc-options:         -Wall -Wredundant-constraints
   if flag(pedantic)

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -33,6 +33,7 @@ library
                        Haskell.Ide.Engine.Plugin.HfaAlign
                        Haskell.Ide.Engine.Plugin.HsImport
                        Haskell.Ide.Engine.Plugin.Liquid
+                       Haskell.Ide.Engine.Plugin.Ormolu
                        Haskell.Ide.Engine.Plugin.Package
                        Haskell.Ide.Engine.Plugin.Package.Compat
                        Haskell.Ide.Engine.Plugin.Pragmas
@@ -81,6 +82,7 @@ library
                      , monoid-subclasses > 0.4
                      , mtl
                      , optparse-simple >= 0.0.3
+                     , ormolu
                      , parsec
                      , process
                      , safe

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -46,7 +46,7 @@ library
                        Haskell.Ide.Engine.Server
                        Haskell.Ide.Engine.Types
                        Haskell.Ide.Engine.Version
-  if impl(ghc > 8.4)
+  if impl(ghc >= 8.6)
      exposed-modules: Haskell.Ide.Engine.Plugin.Ormolu
 
   other-modules:       Paths_haskell_ide_engine
@@ -102,7 +102,7 @@ library
                      , bytestring-trie
                      , unliftio
                      , hlint >= 2.2.2
-  if impl(ghc > 8.4)
+  if impl(ghc >= 8.6)
      build-depends: ormolu
 
   ghc-options:         -Wall -Wredundant-constraints

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -33,6 +33,7 @@ library
                        Haskell.Ide.Engine.Plugin.HfaAlign
                        Haskell.Ide.Engine.Plugin.HsImport
                        Haskell.Ide.Engine.Plugin.Liquid
+                       Haskell.Ide.Engine.Plugin.Ormolu
                        Haskell.Ide.Engine.Plugin.Package
                        Haskell.Ide.Engine.Plugin.Package.Compat
                        Haskell.Ide.Engine.Plugin.Pragmas
@@ -46,8 +47,6 @@ library
                        Haskell.Ide.Engine.Server
                        Haskell.Ide.Engine.Types
                        Haskell.Ide.Engine.Version
-  if impl(ghc >= 8.6)
-     exposed-modules: Haskell.Ide.Engine.Plugin.Ormolu
 
   other-modules:       Paths_haskell_ide_engine
   build-depends:       Cabal >= 1.22

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -30,12 +30,8 @@ provider :: FormattingProvider
 provider contents uri typ _opts =
   case typ of 
     -- // TODO Adequately throw an error on the following line
-    FormatRange r -> return $ IdeResultFail (IdeError PluginError (T.pack $  "ormoluCmd: " ++ show r) Null)
+    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (T.pack $  "ormoluCmd: Selection formatting not supported.") Null)
     FormatText -> pluginGetFile contents uri $ \file -> do
-        -- INFO: Selection Formatting currently not supported, the below comment is just for temporal information
-        -- let (range, selectedContents) = case typ of
-        --       FormatText    -> (fullRange contents, contents)
-        --       FormatRange r -> (r, extractRange r contents)
         result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (T.unpack contents))
         case result of
           Left  err -> return $ IdeResultFail (IdeError PluginError (T.pack $  "ormoluCmd: " ++ show err) Null)

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Haskell.Ide.Engine.Plugin.Ormolu ( ormoluDescriptor ) where
+
+import Control.Monad.IO.Class ( liftIO, MonadIO(..) )
+import Control.Exception
+import Data.Aeson ( Value ( Null ) )
+import qualified Data.Text as T
+import Ormolu
+import Ormolu.Config (defaultConfig)
+import Ormolu.Exception (OrmoluException)
+import Haskell.Ide.Engine.MonadTypes
+import Haskell.Ide.Engine.PluginUtils
+
+ormoluDescriptor :: PluginId -> PluginDescriptor
+ormoluDescriptor plId = PluginDescriptor
+  { pluginId                 = plId
+  , pluginName               = "Ormolu"
+  , pluginDesc               = "A formatter for Haskell source code."
+  , pluginCommands           = []
+  , pluginCodeActionProvider = Nothing
+  , pluginDiagnosticProvider = Nothing
+  , pluginHoverProvider      = Nothing
+  , pluginSymbolProvider     = Nothing
+  , pluginFormattingProvider = Just provider
+  }
+
+provider :: FormattingProvider
+provider contents uri typ _opts =
+  case typ of 
+    -- // TODO Adequately throw an error on the following line
+    FormatRange r -> return $ IdeResultFail (IdeError PluginError (T.pack $  "ormoluCmd: " ++ show r) Null)
+    FormatText -> pluginGetFile contents uri $ \file -> do
+        -- INFO: Selection Formatting currently not supported, the below comment is just for temporal information
+        -- let (range, selectedContents) = case typ of
+        --       FormatText    -> (fullRange contents, contents)
+        --       FormatRange r -> (r, extractRange r contents)
+        result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (T.unpack contents))
+        case result of
+          Left  err -> return $ IdeResultFail (IdeError PluginError (T.pack $  "ormoluCmd: " ++ show err) Null)
+          Right new -> return $ IdeResultOk [TextEdit (fullRange contents) new]

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -11,7 +11,6 @@ import Control.Exception
 import Control.Monad.IO.Class ( liftIO , MonadIO(..) )
 import Data.Aeson ( Value ( Null ) )
 import Data.Text
-import Haskell.Ide.Engine.MonadFunctions
 import Ormolu
 import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -4,13 +4,12 @@
 
 module Haskell.Ide.Engine.Plugin.Ormolu ( ormoluDescriptor ) where
 
-import Data.Aeson ( Value ( Null ) )
-import Data.Text
-import Haskell.Ide.Engine.MonadTypes
-
 #if __GLASGOW_HASKELL__ >= 806
 import Control.Exception
 import Control.Monad.IO.Class ( liftIO , MonadIO(..) )
+import Data.Aeson ( Value ( Null ) )
+import Data.Text
+import Haskell.Ide.Engine.MonadTypes
 import Ormolu
 import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)
@@ -34,16 +33,16 @@ ormoluDescriptor plId = PluginDescriptor
 
 
 provider :: FormattingProvider
-provider contents uri typ _opts =
+provider _contents _uri typ _opts =
   case typ of 
 #if __GLASGOW_HASKELL__ >= 806
     FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
-    FormatText -> pluginGetFile contents uri $ \file -> do
-        result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (unpack contents))
+    FormatText -> pluginGetFile _contents _uri $ \file -> do
+        result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (unpack _contents))
         case result of
           Left  err -> return $ IdeResultFail (IdeError PluginError (pack $  "ormoluCmd: " ++ show err) Null)
-          Right new -> return $ IdeResultOk [TextEdit (fullRange contents) new]
+          Right new -> return $ IdeResultOk [TextEdit (fullRange _contents) new]
 #else
     FormatRange _ -> return $ IdeResultOk []
     FormatText -> return $ IdeResultOk []
-#endif 
+#endif

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -1,17 +1,22 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 
 module Haskell.Ide.Engine.Plugin.Ormolu ( ormoluDescriptor ) where
 
 import Control.Monad.IO.Class ( liftIO, MonadIO(..) )
 import Control.Exception
 import Data.Aeson ( Value ( Null ) )
-import qualified Data.Text as T
+import Data.Text
+import Haskell.Ide.Engine.MonadTypes
+import Haskell.Ide.Engine.PluginUtils
+import System.Log
+
+#if __GLASGOW_HASKELL__ >= 806
 import Ormolu
 import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)
-import Haskell.Ide.Engine.MonadTypes
-import Haskell.Ide.Engine.PluginUtils
+#endif
 
 ormoluDescriptor :: PluginId -> PluginDescriptor
 ormoluDescriptor plId = PluginDescriptor
@@ -26,13 +31,22 @@ ormoluDescriptor plId = PluginDescriptor
   , pluginFormattingProvider = Just provider
   }
 
+#if __GLASGOW_HASKELL__ >= 806
 provider :: FormattingProvider
 provider contents uri typ _opts =
   case typ of 
-    -- // TODO Adequately throw an error on the following line
-    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (T.pack "Selection formatting for Ormolu is not currently supported.") Null)
+    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
     FormatText -> pluginGetFile contents uri $ \file -> do
-        result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (T.unpack contents))
+        result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (unpack contents))
         case result of
-          Left  err -> return $ IdeResultFail (IdeError PluginError (T.pack $  "ormoluCmd: " ++ show err) Null)
+          Left  err -> return $ IdeResultFail (IdeError PluginError (pack $  "ormoluCmd: " ++ show err) Null)
           Right new -> return $ IdeResultOk [TextEdit (fullRange contents) new]
+#else
+-- Work in progress
+provider :: FormattingProvider
+provider contents _uri typ _opts = do
+  errorM "hie" "This version of HIE does not support Ormolu as a formatter"
+  case typ of 
+    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
+    FormatText -> return $ IdeResultOk [TextEdit (fullRange contents) contents]
+#endif

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -16,7 +16,7 @@ import Ormolu
 import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)
 #else
-import System.Log.Logger
+import Haskell.Ide.Engine.MonadFunctions
 #endif
 
 ormoluDescriptor :: PluginId -> PluginDescriptor
@@ -45,9 +45,9 @@ provider contents uri typ _opts =
 #else
 -- Work in progress
 provider :: FormattingProvider
-provider contents _uri typ _opts = do
-  errorM "hie" "This version of HIE does not support Ormolu as a formatter"
+provider _contents _uri typ _opts = do
+  errorm "This version of HIE does not support Ormolu as a formatter"
   case typ of 
     FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
     FormatText -> return $ IdeResultOk []
-#endif
+#endif 

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -32,9 +32,9 @@ ormoluDescriptor plId = PluginDescriptor
 
 
 provider :: FormattingProvider
-provider _contents _uri typ _opts =
-  case typ of 
+provider _contents _uri _typ _opts =
 #if __GLASGOW_HASKELL__ >= 806
+  case _typ of 
     FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
     FormatText -> pluginGetFile _contents _uri $ \file -> do
         result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (unpack _contents))
@@ -42,6 +42,5 @@ provider _contents _uri typ _opts =
           Left  err -> return $ IdeResultFail (IdeError PluginError (pack $  "ormoluCmd: " ++ show err) Null)
           Right new -> return $ IdeResultOk [TextEdit (fullRange _contents) new]
 #else
-    FormatRange _ -> return $ IdeResultOk []
-    FormatText -> return $ IdeResultOk []
+  return $ IdeResultOk [] -- NOP formatter
 #endif

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -4,17 +4,17 @@
 
 module Haskell.Ide.Engine.Plugin.Ormolu ( ormoluDescriptor ) where
 
-import Control.Monad.IO.Class ( liftIO, MonadIO(..) )
-import Control.Exception
 import Data.Aeson ( Value ( Null ) )
 import Data.Text
 import Haskell.Ide.Engine.MonadTypes
-import Haskell.Ide.Engine.PluginUtils
 
 #if __GLASGOW_HASKELL__ >= 806
+import Control.Exception
+import Control.Monad.IO.Class ( liftIO , MonadIO(..) )
 import Ormolu
 import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)
+import Haskell.Ide.Engine.PluginUtils
 #else
 import Haskell.Ide.Engine.MonadFunctions
 #endif

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -49,5 +49,5 @@ provider contents _uri typ _opts = do
   errorM "hie" "This version of HIE does not support Ormolu as a formatter"
   case typ of 
     FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
-    FormatText -> return $ IdeResultOk [TextEdit (fullRange contents) contents]
+    FormatText -> return $ IdeResultOk []
 #endif

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -10,12 +10,13 @@ import Data.Aeson ( Value ( Null ) )
 import Data.Text
 import Haskell.Ide.Engine.MonadTypes
 import Haskell.Ide.Engine.PluginUtils
-import System.Log
 
 #if __GLASGOW_HASKELL__ >= 806
 import Ormolu
 import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)
+#else
+import System.Log.Logger
 #endif
 
 ormoluDescriptor :: PluginId -> PluginDescriptor

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -30,7 +30,7 @@ provider :: FormattingProvider
 provider contents uri typ _opts =
   case typ of 
     -- // TODO Adequately throw an error on the following line
-    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (T.pack $  "Selection formatting for Ormolu is not currently supported.") Null)
+    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (T.pack "Selection formatting for Ormolu is not currently supported.") Null)
     FormatText -> pluginGetFile contents uri $ \file -> do
         result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (T.unpack contents))
         case result of

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -4,18 +4,18 @@
 
 module Haskell.Ide.Engine.Plugin.Ormolu ( ormoluDescriptor ) where
 
+import Haskell.Ide.Engine.MonadTypes
+
 #if __GLASGOW_HASKELL__ >= 806
 import Control.Exception
 import Control.Monad.IO.Class ( liftIO , MonadIO(..) )
 import Data.Aeson ( Value ( Null ) )
 import Data.Text
-import Haskell.Ide.Engine.MonadTypes
+import Haskell.Ide.Engine.MonadFunctions
 import Ormolu
 import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)
 import Haskell.Ide.Engine.PluginUtils
-#else
-import Haskell.Ide.Engine.MonadFunctions
 #endif
 
 ormoluDescriptor :: PluginId -> PluginDescriptor

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -32,10 +32,11 @@ ormoluDescriptor plId = PluginDescriptor
   , pluginFormattingProvider = Just provider
   }
 
-#if __GLASGOW_HASKELL__ >= 806
+
 provider :: FormattingProvider
 provider contents uri typ _opts =
   case typ of 
+#if __GLASGOW_HASKELL__ >= 806
     FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
     FormatText -> pluginGetFile contents uri $ \file -> do
         result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (unpack contents))
@@ -43,11 +44,6 @@ provider contents uri typ _opts =
           Left  err -> return $ IdeResultFail (IdeError PluginError (pack $  "ormoluCmd: " ++ show err) Null)
           Right new -> return $ IdeResultOk [TextEdit (fullRange contents) new]
 #else
--- Work in progress
-provider :: FormattingProvider
-provider _contents _uri typ _opts = do
-  errorm "This version of HIE does not support Ormolu as a formatter"
-  case typ of 
-    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
+    FormatRange _ -> return $ IdeResultOk []
     FormatText -> return $ IdeResultOk []
 #endif 

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -30,7 +30,7 @@ provider :: FormattingProvider
 provider contents uri typ _opts =
   case typ of 
     -- // TODO Adequately throw an error on the following line
-    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (T.pack $  "ormoluCmd: Selection formatting not supported.") Null)
+    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (T.pack $  "Selection formatting for Ormolu is not currently supported.") Null)
     FormatText -> pluginGetFile contents uri $ \file -> do
         result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (T.unpack contents))
         case result of

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -36,7 +36,6 @@ extra-deps:
 - network-bsd-2.8.1.0 # for hslogger
 - optparse-simple-0.1.0
 - parser-combinators-1.2.1
-- ormolu-0.0.2.0
 - pretty-show-1.9.5
 - rope-utf16-splay-0.3.1.0
 - simple-sendfile-0.2.30 # for network and network-bsd

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -36,6 +36,7 @@ extra-deps:
 - network-bsd-2.8.1.0 # for hslogger
 - optparse-simple-0.1.0
 - parser-combinators-1.2.1
+- ormolu-0.0.2.0
 - pretty-show-1.9.5
 - rope-utf16-splay-0.3.1.0
 - simple-sendfile-0.2.30 # for network and network-bsd

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -38,6 +38,7 @@ extra-deps:
 - monoid-subclasses-0.4.6.1
 - multistate-0.8.0.1
 - parser-combinators-1.2.1
+- ormolu-0.0.2.0
 - primes-0.2.1.0
 - resolv-0.1.1.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -33,6 +33,7 @@ extra-deps:
 - monad-memo-0.4.1
 - multistate-0.8.0.1
 - parser-combinators-1.2.1
+- ormolu-0.0.2.0
 - rope-utf16-splay-0.3.1.0
 - strict-list-0.1.5
 - syz-0.2.0.0

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -31,6 +31,7 @@ extra-deps:
 - multistate-0.8.0.1
 - optparse-simple-0.1.0
 - parser-combinators-1.2.1
+- ormolu-0.0.2.0
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -29,6 +29,7 @@ extra-deps:
 - monad-memo-0.4.1
 - multistate-0.8.0.1
 - parser-combinators-1.2.1
+- ormolu-0.0.2.0
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -27,6 +27,7 @@ extra-deps:
 - lsp-test-0.10.0.0
 - monad-dijkstra-0.1.1.2@rev:1
 - parser-combinators-1.2.1
+- ormolu-0.0.2.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -28,6 +28,7 @@ extra-deps:
 - lsp-test-0.10.0.0
 - monad-dijkstra-0.1.1.2@rev:1
 - parser-combinators-1.2.1
+- ormolu-0.0.2.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - unix-compat-0.5.2

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -94,6 +94,10 @@ spec = do
 
 -- Work in progress
   describe "ormolu" $ do
+    let formatLspConfig provider =
+          object [ "languageServerHaskell" .= object ["formattingProvider" .= (provider :: Value)] ]
+        formatConfig provider = defaultConfig { lspConfig = Just (formatLspConfig provider) }
+        
     it "formats correctly" $ runSession hieCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))
       doc <- openDoc "Format.hs" "haskell"

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -92,7 +92,6 @@ spec = do
       liftIO $ edits `shouldBe` [TextEdit (Range (Position 1 0) (Position 3 0))
                                     "foo x y = do\n    print x\n    return 42\n"]
 
--- Work in progress
   describe "ormolu" $ do
     let formatLspConfig provider =
           object [ "languageServerHaskell" .= object ["formattingProvider" .= (provider :: Value)] ]

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -92,6 +92,13 @@ spec = do
       liftIO $ edits `shouldBe` [TextEdit (Range (Position 1 0) (Position 3 0))
                                     "foo x y = do\n    print x\n    return 42\n"]
 
+-- Work in progress
+  describe "ormolu" $ do
+    it "formats correctly" $ runSession hieCommand fullCaps "test/testdata" $ do
+      doc <- openDoc "Format.hs" "haskell"
+      formatDoc doc (FormattingOptions 2 True)
+      documentContents doc >>= liftIO . (`shouldBe` formattedOrmolu)
+
 
 formattedDocTabSize2 :: T.Text
 formattedDocTabSize2 =
@@ -165,3 +172,16 @@ formattedBrittanyPostFloskell =
   \bar s = do\n\
   \  x <- return \"hello\"\n\
   \  return \"asdf\"\n\n"
+
+formattedOrmolu :: T.Text
+formattedOrmolu =
+  "module Format where\n\
+  \\n\
+  \foo :: Int -> Int\n\
+  \foo 3 = 2\n\
+  \foo x = x\n\
+  \\n\
+  \bar :: String -> IO String\n\
+  \bar s = do\n\
+  \  x <- return \"hello\"\n\
+  \  return \"asdf\"\n"

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -95,9 +95,13 @@ spec = do
 -- Work in progress
   describe "ormolu" $ do
     it "formats correctly" $ runSession hieCommand fullCaps "test/testdata" $ do
+      sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))
       doc <- openDoc "Format.hs" "haskell"
       formatDoc doc (FormattingOptions 2 True)
-      documentContents doc >>= liftIO . (`shouldBe` formattedOrmolu)
+      docContent <- documentContents doc
+      case ghcVersion of
+        GHC86 -> liftIO $ docContent `shouldBe` formattedOrmolu
+        _ -> liftIO $ docContent `shouldBe` unchangedOrmolu
 
 
 formattedDocTabSize2 :: T.Text
@@ -185,3 +189,15 @@ formattedOrmolu =
   \bar s = do\n\
   \  x <- return \"hello\"\n\
   \  return \"asdf\"\n"
+
+unchangedOrmolu :: T.Text
+unchangedOrmolu = 
+  "module    Format where\n\
+  \foo   :: Int ->  Int\n\
+  \foo  3 = 2\n\
+  \foo    x  = x\n\
+  \bar   :: String ->   IO String\n\
+  \bar s =  do\n\
+  \      x <- return \"hello\"\n\
+  \      return \"asdf\"\n\
+  \      \n"

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -96,7 +96,6 @@ spec = do
   describe "ormolu" $ do
     let formatLspConfig provider =
           object [ "languageServerHaskell" .= object ["formattingProvider" .= (provider :: Value)] ]
-        formatConfig provider = defaultConfig { lspConfig = Just (formatLspConfig provider) }
         
     it "formats correctly" $ runSession hieCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -218,7 +218,8 @@ spec = describe "code actions" $ do
         , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
         ]
       ]
-    describe "formats with ormolu" $ hsImportSpec "ormolu"
+#if __GLASGOW_HASKELL__ >= 806
+    describe "formats with ormolu" $ hsImportSpec "ormolu" -- Ormolu only works with GHC 8.6.x
       [ -- Expected output for simple format.
         [ "import Control.Monad"
         , "import qualified Data.Maybe"
@@ -232,7 +233,6 @@ spec = describe "code actions" $ do
         , "main = when True $ putStrLn \"hello\""
         ]
       , -- Multiple import lists, should not introduce multiple newlines.
-      -- WIP (Haddock issues) ;TODO
         [ "import System.IO (hPutStrLn, stdout)"
         , "import Control.Monad (when)"
         , "import Data.Maybe (fromMaybe)"
@@ -244,7 +244,6 @@ spec = describe "code actions" $ do
         , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
         ]
       ,  -- Complex imports for Constructos and functions
-      -- WIP (Haddock issues) ;TODO
         [ "{-# LANGUAGE NoImplicitPrelude #-}"
         , "import System.IO (IO, hPutStrLn, stderr)"
         , "import Prelude (Bool (..))"
@@ -259,7 +258,7 @@ spec = describe "code actions" $ do
         , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
         ]
       ]
-
+#endif
   describe "add package suggestions" $ do
     it "adds to .cabal files" $ do
       flushStackEnvironment

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -260,8 +260,9 @@ spec = describe "code actions" $ do
         ]
       ]
 #else 
-    describe "formats with ormolu" $ do
-      pendingWith "Ormolu only supported by GHC >= 8.6. Need to restore this."
+    describe "formats with ormolu" $
+      it "is NOP formatter" $
+        pendingWith "Ormolu only supported by GHC >= 8.6. Need to restore this."
 #endif
   describe "add package suggestions" $ do
     it "adds to .cabal files" $ do

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 
 module FunctionalCodeActionsSpec where
 
@@ -219,7 +220,7 @@ spec = describe "code actions" $ do
         ]
       ]
 #if __GLASGOW_HASKELL__ >= 806
-    describe "formats with ormolu" $ hsImportSpec "ormolu" -- Ormolu only works with GHC 8.6.x
+    describe "formats with ormolu" $ hsImportSpec "ormolu"
       [ -- Expected output for simple format.
         [ "import Control.Monad"
         , "import qualified Data.Maybe"
@@ -258,6 +259,8 @@ spec = describe "code actions" $ do
         , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
         ]
       ]
+#else 
+    describe "formats with ormolu" $ pendingWith "Ormolu only works with GHC >= 8.6. Need to restore this."
 #endif
   describe "add package suggestions" $ do
     it "adds to .cabal files" $ do

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 
 module FunctionalCodeActionsSpec where
 
@@ -219,51 +218,50 @@ spec = describe "code actions" $ do
         , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
         ]
       ]
-#if __GLASGOW_HASKELL__ >= 806
-    describe "formats with ormolu" $ hsImportSpec "ormolu"
-      [ -- Expected output for simple format.
-        [ "import Control.Monad"
-        , "import qualified Data.Maybe"
-        , "main :: IO ()"
-        , "main = when True $ putStrLn \"hello\""
-        ]
-      , -- Use an import list and format the output.
-        [ "import Control.Monad (when)"
-        , "import qualified Data.Maybe"
-        , "main :: IO ()"
-        , "main = when True $ putStrLn \"hello\""
-        ]
-      , -- Multiple import lists, should not introduce multiple newlines.
-        [ "import System.IO (hPutStrLn, stdout)"
-        , "import Control.Monad (when)"
-        , "import Data.Maybe (fromMaybe)"
-        , "-- | Main entry point to the program"
-        , "main :: IO ()"
-        , "main ="
-        , "    when True"
-        , "        $ hPutStrLn stdout"
-        , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
-        ]
-      ,  -- Complex imports for Constructos and functions
-        [ "{-# LANGUAGE NoImplicitPrelude #-}"
-        , "import System.IO (IO, hPutStrLn, stderr)"
-        , "import Prelude (Bool (..))"
-        , "import Control.Monad (when)"
-        , "import Data.Function (($))"
-        , "import Data.Maybe (Maybe (Just), fromMaybe)"
-        , "-- | Main entry point to the program"
-        , "main :: IO ()"
-        , "main ="
-        , "    when True"
-        , "        $ hPutStrLn stderr"
-        , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
-        ]
-      ]
-#else 
-    describe "formats with ormolu" $
-      it "is NOP formatter" $
-        pendingWith "Ormolu only supported by GHC >= 8.6. Need to restore this."
-#endif
+    describe "formats with ormolu" $ 
+      case ghcVersion of
+        GHC86 -> hsImportSpec "ormolu"
+          [ -- Expected output for simple format.
+            [ "import Control.Monad"
+            , "import qualified Data.Maybe"
+            , "main :: IO ()"
+            , "main = when True $ putStrLn \"hello\""
+            ]
+          , -- Use an import list and format the output.
+            [ "import Control.Monad (when)"
+            , "import qualified Data.Maybe"
+            , "main :: IO ()"
+            , "main = when True $ putStrLn \"hello\""
+            ]
+          , -- Multiple import lists, should not introduce multiple newlines.
+            [ "import System.IO (hPutStrLn, stdout)"
+            , "import Control.Monad (when)"
+            , "import Data.Maybe (fromMaybe)"
+            , "-- | Main entry point to the program"
+            , "main :: IO ()"
+            , "main ="
+            , "    when True"
+            , "        $ hPutStrLn stdout"
+            , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
+            ]
+          ,  -- Complex imports for Constructos and functions
+            [ "{-# LANGUAGE NoImplicitPrelude #-}"
+            , "import System.IO (IO, hPutStrLn, stderr)"
+            , "import Prelude (Bool (..))"
+            , "import Control.Monad (when)"
+            , "import Data.Function (($))"
+            , "import Data.Maybe (Maybe (Just), fromMaybe)"
+            , "-- | Main entry point to the program"
+            , "main :: IO ()"
+            , "main ="
+            , "    when True"
+            , "        $ hPutStrLn stderr"
+            , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
+            ]
+          ]
+        _ -> it "is NOP formatter" $
+          pendingWith "Ormolu only supported by GHC >= 8.6. Need to restore this."
+          
   describe "add package suggestions" $ do
     it "adds to .cabal files" $ do
       flushStackEnvironment

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -260,7 +260,8 @@ spec = describe "code actions" $ do
         ]
       ]
 #else 
-    describe "formats with ormolu" $ pendingWith "Ormolu only works with GHC >= 8.6. Need to restore this."
+    describe "formats with ormolu" $ do
+      pendingWith "Ormolu only supported by GHC >= 8.6. Need to restore this."
 #endif
   describe "add package suggestions" $ do
     it "adds to .cabal files" $ do

--- a/test/functional/FunctionalCodeActionsSpec.hs
+++ b/test/functional/FunctionalCodeActionsSpec.hs
@@ -218,6 +218,48 @@ spec = describe "code actions" $ do
         , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
         ]
       ]
+    describe "formats with ormolu" $ hsImportSpec "ormolu"
+      [ -- Expected output for simple format.
+        [ "import Control.Monad"
+        , "import qualified Data.Maybe"
+        , "main :: IO ()"
+        , "main = when True $ putStrLn \"hello\""
+        ]
+      , -- Use an import list and format the output.
+        [ "import Control.Monad (when)"
+        , "import qualified Data.Maybe"
+        , "main :: IO ()"
+        , "main = when True $ putStrLn \"hello\""
+        ]
+      , -- Multiple import lists, should not introduce multiple newlines.
+      -- WIP (Haddock issues) ;TODO
+        [ "import System.IO (hPutStrLn, stdout)"
+        , "import Control.Monad (when)"
+        , "import Data.Maybe (fromMaybe)"
+        , "-- | Main entry point to the program"
+        , "main :: IO ()"
+        , "main ="
+        , "    when True"
+        , "        $ hPutStrLn stdout"
+        , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
+        ]
+      ,  -- Complex imports for Constructos and functions
+      -- WIP (Haddock issues) ;TODO
+        [ "{-# LANGUAGE NoImplicitPrelude #-}"
+        , "import System.IO (IO, hPutStrLn, stderr)"
+        , "import Prelude (Bool (..))"
+        , "import Control.Monad (when)"
+        , "import Data.Function (($))"
+        , "import Data.Maybe (Maybe (Just), fromMaybe)"
+        , "-- | Main entry point to the program"
+        , "main :: IO ()"
+        , "main ="
+        , "    when True"
+        , "        $ hPutStrLn stderr"
+        , "        $ fromMaybe \"Good night, World!\" (Just \"Hello, World!\")"
+        ]
+      ]
+
   describe "add package suggestions" $ do
     it "adds to .cabal files" $ do
       flushStackEnvironment


### PR DESCRIPTION
Hi! This addresses https://github.com/haskell/haskell-ide-engine/issues/1410 for the [Ormolu formatter](https://hackage.haskell.org/package/ormolu)

I still have some work to do, that is sending a warning if the Format Selection option is used (in lines 31-33 of the committed `Ormolu.hs`), as this function is [not yet supported by Ormolu](https://github.com/tweag/ormolu/issues/480#issuecomment-562966292), but I don't know exactly the best way to proceed. I was pointed to `LspStdio.hs` and about throwing a warning on the right thread, but I'm still interpreting the file and how to make use of the functions in it.

Feel free to provide any suggestions.

Also, I think I should put up some tests in `FormatSpec.hs` when `Ormolu.hs` is done, to let everyone check that everything works 😃 