### PR TITLE
Retain the --lsp option, to not break existing clients

### DIFF
--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -6,6 +6,7 @@ import           Options.Applicative.Simple
 data GlobalOpts = GlobalOpts
   { optDebugOn       :: Bool
   , optLogFile       :: Maybe String
+  , _optLsp          :: Bool -- Kept for a while, to not break legacy clients
   , projectRoot      :: Maybe String
   , optBiosVerbose   :: Bool
   , optCaptureFile   :: Maybe FilePath
@@ -25,6 +26,9 @@ globalOptsParser = GlobalOpts
       <> metavar "LOGFILE"
       <> help "File to log to, defaults to stdout"
        ))
+  <*> flag True True
+       ( long "lsp"
+       <> help "Legacy flag, no longer used, to enable LSP mode. Not required.")
   <*> optional (strOption
        ( long "project-root"
       <> short 'r'


### PR DESCRIPTION
PR #1489 removed the `--lsp` option, resulting in a hard failure if a
client uses it to start up the server.

Parse it, but ignore it, as an interim measure.