### PR TITLE
Make errorm use errorM instead of warningM

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/MonadFunctions.hs
@@ -37,7 +37,7 @@ warningm :: MonadIO m => String -> m ()
 warningm s = liftIO $ warningM "hie" s
 
 errorm :: MonadIO m => String -> m ()
-errorm s = liftIO $ warningM "hie" s
+errorm s = liftIO $ errorM "hie" s
 
 -- ---------------------------------------------------------------------
 -- Extensible state, based on


### PR DESCRIPTION
Hi!

In `MonadFunctions.hs` the function `errorm` lifts a `warningM` in its implementation, as opposed to `errorM` which seems more appropriate. Maybe there is a reason for it or it is a slip?

@fendor 