### PR TITLE
[WIP] Append modules to cradle cache if not already in module graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ _build/
 stack*.yaml.lock
 shake.yaml.lock
 
-# ignore hie.yaml's for testdata 
+# ignore hie.yaml's for testdata
 test/**/*.yaml
+!test/testdata/multi-component/hie.yaml
 /hie.yaml

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -299,6 +299,7 @@ test-suite func-test
                      , HieBiosSpec
                      , HighlightSpec
                      , HoverSpec
+                     , ModuleCacheSpec
                      , ProgressSpec
                      , ReferencesSpec
                      , RenameSpec

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -130,11 +130,13 @@ loadCradle :: forall a m . (MonadIde m, HasGhcModuleCache m, GHC.GhcMonad m
 loadCradle _ _ ReuseCradle _def action = do
   -- Since we expect this message to show up often, only show in debug mode
   debugm "Reusing cradle"
+  sendTelemetry $ Aeson.String "loadCradle:ReuseCradle"
   IdeResultOk <$> action
 
 loadCradle _ _iniDynFlags (LoadCradle (CachedCradle crd env co)) _def action = do
   -- Reloading a cradle happens on component switch
   logm $ "Switch to cradle: " ++ show crd
+  sendTelemetry $ Aeson.String "loadCradle:LoadCradle"
   -- Cache the existing cradle
   maybe (return ()) cacheCradle =<< (currentCradle <$> getModuleCache)
   GHC.setSession env
@@ -144,6 +146,7 @@ loadCradle _ _iniDynFlags (LoadCradle (CachedCradle crd env co)) _def action = d
 loadCradle publishDiagnostics iniDynFlags (NewCradle fp) def action = do
   -- If this message shows up a lot in the logs, it is an indicator for a bug
   logm $ "New cradle: " ++ fp
+  sendTelemetry $ Aeson.String $ Text.pack $ "loadCradle:NewCradle:" <> fp
   -- Cache the existing cradle
   -- And append this module (fp) to the cradle if it isn't already in it
   -- This can happen if fp is outside of the module graph of the cradle, but should

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -148,22 +148,7 @@ loadCradle publishDiagnostics iniDynFlags (NewCradle fp) def action = do
   logm $ "New cradle: " ++ fp
   sendTelemetry $ Aeson.String $ Text.pack $ "loadCradle:NewCradle:" <> fp
   -- Cache the existing cradle
-  -- And append this module (fp) to the cradle if it isn't already in it
-  -- This can happen if fp is outside of the module graph of the cradle, but should
-  -- still use that cradle. e.g.
-  --
-  -- Components                         | Modules in component
-  -- -----------------------------------+----------------------
-  -- pkg:lib <-- cradle is set to this  | Lib.hs
-  -- pkg:exe                            | Exe.hs
-  --
-  -- Exe.hs might import across a component Lib.hs. So it *won't* appeari n the module graph
-  -- And so won't appear in the currentCradle. We need to manually append it otherwise the
-  -- cradle will never get cached for it.
-  let appendThisModule (fps, c)
-        | fp `notElem` fps = (fp:fps, c)
-        | otherwise = (fps, c)
-  maybe (return ()) cacheCradle =<< (fmap appendThisModule . currentCradle <$> getModuleCache)
+  maybe (return ()) cacheCradle =<< (currentCradle <$> getModuleCache)
 
   -- Now load the new cradle, accounting for hie.yaml parse errors
   let parseErrorHandler = return . Left . Yaml.prettyPrintParseException

--- a/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/ModuleCache.hs
@@ -145,7 +145,22 @@ loadCradle publishDiagnostics iniDynFlags (NewCradle fp) def action = do
   -- If this message shows up a lot in the logs, it is an indicator for a bug
   logm $ "New cradle: " ++ fp
   -- Cache the existing cradle
-  maybe (return ()) cacheCradle =<< (currentCradle <$> getModuleCache)
+  -- And append this module (fp) to the cradle if it isn't already in it
+  -- This can happen if fp is outside of the module graph of the cradle, but should
+  -- still use that cradle. e.g.
+  --
+  -- Components                         | Modules in component
+  -- -----------------------------------+----------------------
+  -- pkg:lib <-- cradle is set to this  | Lib.hs
+  -- pkg:exe                            | Exe.hs
+  --
+  -- Exe.hs might import across a component Lib.hs. So it *won't* appeari n the module graph
+  -- And so won't appear in the currentCradle. We need to manually append it otherwise the
+  -- cradle will never get cached for it.
+  let appendThisModule (fps, c)
+        | fp `notElem` fps = (fp:fps, c)
+        | otherwise = (fps, c)
+  maybe (return ()) cacheCradle =<< (fmap appendThisModule . currentCradle <$> getModuleCache)
 
   -- Now load the new cradle, accounting for hie.yaml parse errors
   let parseErrorHandler = return . Left . Yaml.prettyPrintParseException

--- a/test/functional/ModuleCacheSpec.hs
+++ b/test/functional/ModuleCacheSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ModuleCacheSpec where
+
+import Control.Applicative.Combinators
+import Control.Monad.IO.Class
+import qualified Data.Aeson as J
+import qualified Data.Text as T
+import Language.Haskell.LSP.Messages
+import Language.Haskell.LSP.Test
+import Language.Haskell.LSP.Types
+import System.Directory
+import System.Environment
+import Test.Hspec
+import TestUtils
+
+spec :: Spec
+spec = describe "module cache" $ do
+  it "caches cradle outside of component" $ do
+    setEnv "HIE_TELEMETRY" "1"
+    runSession hieCommand fullCaps "test/testdata/multiComponent" $ do
+      doc <- openDoc "Main.hs" "haskell"
+      NotTelemetry (NotificationMessage _ _ (J.String v)) <- skipManyTill loggingNotification (satisfy isTelemetry)
+      absPath <- liftIO $ canonicalizePath "test/testdata/multiComponent/Main.hs"
+      liftIO $ v `shouldBe` "loadCradle:NewCradle:" <> T.pack absPath
+      sendNotification TextDocumentDidSave (DidSaveTextDocumentParams doc)
+      NotTelemetry (NotificationMessage _ _ (J.String v')) <- skipManyTill anyMessage (satisfy isTelemetry)
+      liftIO $ v' `shouldBe` "loadCradle:ReuseCradle"
+  where isTelemetry (NotTelemetry _) = True
+        isTelemetry _                = False

--- a/test/testdata/multiComponent/Foo.hs
+++ b/test/testdata/multiComponent/Foo.hs
@@ -1,0 +1,4 @@
+module Foo where
+
+x :: String
+x = "Asdf"

--- a/test/testdata/multiComponent/Main.hs
+++ b/test/testdata/multiComponent/Main.hs
@@ -1,0 +1,6 @@
+import Foo
+import OtherMain
+main = bar x
+
+bar :: String -> IO ()
+bar = print

--- a/test/testdata/multiComponent/OtherMain.hs
+++ b/test/testdata/multiComponent/OtherMain.hs
@@ -1,0 +1,4 @@
+module OtherMain where
+
+adf :: String
+adf = "asdf"

--- a/test/testdata/multiComponent/cabal.project
+++ b/test/testdata/multiComponent/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/test/testdata/multiComponent/multi-component.cabal
+++ b/test/testdata/multiComponent/multi-component.cabal
@@ -1,0 +1,14 @@
+name:                multi-component
+version:             0.1.0.0
+build-type:          Simple
+cabal-version:       >= 1.10
+
+library
+  exposed-modules:     Foo
+  build-depends:       base >= 4
+  default-language:    Haskell2010
+executable exe
+  main-is:             Main.hs
+  other-modules:       OtherMain
+  build-depends:       base >= 4, multi-component
+  default-language:    Haskell2010

--- a/test/testdata/multiComponent/multi-component.cabal
+++ b/test/testdata/multiComponent/multi-component.cabal
@@ -9,6 +9,6 @@ library
   default-language:    Haskell2010
 executable exe
   main-is:             Main.hs
-  other-modules:       OtherMain
+  other-modules:       OtherMain, Foo
   build-depends:       base >= 4, multi-component
   default-language:    Haskell2010

--- a/test/utils/TestUtils.hs
+++ b/test/utils/TestUtils.hs
@@ -153,6 +153,7 @@ files =
    , "./test/testdata/gototest/"
    , "./test/testdata/redundantImportTest/"
    , "./test/testdata/wErrorTest/"
+   , "./test/testdata/multiComponent/"
   ]
 
 data GhcVersion

--- a/test/utils/TestUtils.hs
+++ b/test/utils/TestUtils.hs
@@ -153,7 +153,6 @@ files =
    , "./test/testdata/gototest/"
    , "./test/testdata/redundantImportTest/"
    , "./test/testdata/wErrorTest/"
-   , "./test/testdata/multiComponent/"
   ]
 
 data GhcVersion


### PR DESCRIPTION
This can happen whenever a cradle for a module resolves to something outside of the module graph, i.e. across components. We should still cache the cradle for the module since they will use it.
This fixes the cradle repeatedly being initialized.