### PR TITLE
Add sample hie.yaml files for stack and cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ shake.yaml.lock
 
 # ignore hie.yaml's for testdata 
 test/**/*.yaml
+/hie.yaml

--- a/README.md
+++ b/README.md
@@ -726,6 +726,15 @@ This project is not started from scratch:
  - Fork this repo and hack as much as you can.
  - Ask @alanz or @hvr to join the project.
 
+### Hacking on haskell-ide-engine
+
+Haskell-ide-engine can be used on its own project.  We have supplied
+preset samples of `hie.yaml` files for stack and cabal, simply copy
+the appropriate template to `hie.yaml` and it shoule work.
+
+- `hie.yaml.cbl` for cabal
+- `hie.yaml.stack` for stack
+
 ## Documentation
 
 All the documentation is in [the docs folder](/docs) at the root of this project.

--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -1,0 +1,28 @@
+cradle:
+  cabal:
+    - path: "./test/dispatcher/"
+      component: "haskell-ide-engine:dispatcher-test"
+
+    - path: "./test/functional/"
+      component: "haskell-ide-engine:func-test"
+
+    - path: "./test/unit/"
+      component: "haskell-ide-engine:unit-test"
+
+    - path: "./test/plugin-dispatcher/"
+      component: "haskell-ide-engine:plugin-dispatcher-test"
+
+    - path: "./test/wrapper/"
+      component: "haskell-ide-engine:wrapper-test"
+
+    - path: "./hie-plugin-api/"
+      component: "lib:hie-plugin-api"
+
+    - path: "./app/MainHie.hs"
+      component: "haskell-ide-engine:hie:exe"
+
+    - path: "./app/HieWrapper.hs"
+      component: "haskell-ide-engine:hie-wrapper:exe"
+
+    - path: "./"
+      component: "lib:haskell-ide-engine"

--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -1,3 +1,7 @@
+# This is a sample hie.yaml file for opening haskell-ide-engine in
+# hie, using cabal as the build system.
+# To use is, copy it to a file called 'hie.yaml'
+
 cradle:
   cabal:
     - path: "./hie-plugin-api/Haskell"

--- a/hie.yaml.cbl
+++ b/hie.yaml.cbl
@@ -1,5 +1,8 @@
 cradle:
   cabal:
+    - path: "./hie-plugin-api/Haskell"
+      component: "lib:hie-plugin-api"
+
     - path: "./test/dispatcher/"
       component: "haskell-ide-engine:dispatcher-test"
 
@@ -15,14 +18,14 @@ cradle:
     - path: "./test/wrapper/"
       component: "haskell-ide-engine:wrapper-test"
 
-    - path: "./hie-plugin-api/"
-      component: "lib:hie-plugin-api"
+    - path: "./test/utils/"
+      component: "haskell-ide-engine:hie-test-utils"
 
     - path: "./app/MainHie.hs"
-      component: "haskell-ide-engine:hie:exe"
+      component: "haskell-ide-engine:hie"
 
     - path: "./app/HieWrapper.hs"
-      component: "haskell-ide-engine:hie-wrapper:exe"
+      component: "haskell-ide-engine:hie-wrapper"
 
     - path: "./"
       component: "lib:haskell-ide-engine"

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -18,6 +18,7 @@ cradle:
     - path: "./test/wrapper/"
       component: "haskell-ide-engine:test:wrapper-test"
 
+    # This target does not currently work (stack 2.1.3)
     - path: "./test/utils/"
       component: "haskell-ide-engine:lib:hie-test-utils"
 

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -1,3 +1,7 @@
+# This is a sample hie.yaml file for opening haskell-ide-engine in
+# hie, using stack as the build system.
+# To use is, copy it to a file called 'hie.yaml'
+
 cradle:
   stack:
     - path: "./hie-plugin-api/"

--- a/hie.yaml.stack
+++ b/hie.yaml.stack
@@ -1,0 +1,31 @@
+cradle:
+  stack:
+    - path: "./hie-plugin-api/"
+      component: "hie-plugin-api:lib"
+
+    - path: "./test/dispatcher/"
+      component: "haskell-ide-engine:test:dispatcher-test"
+
+    - path: "./test/functional/"
+      component: "haskell-ide-engine:test:func-test"
+
+    - path: "./test/unit/"
+      component: "haskell-ide-engine:test:unit-test"
+
+    - path: "./test/plugin-dispatcher/"
+      component: "haskell-ide-engine:test:plugin-dispatcher-test"
+
+    - path: "./test/wrapper/"
+      component: "haskell-ide-engine:test:wrapper-test"
+
+    - path: "./test/utils/"
+      component: "haskell-ide-engine:lib:hie-test-utils"
+
+    - path: "./app/MainHie.hs"
+      component: "haskell-ide-engine:exe:hie"
+
+    - path: "./app/HieWrapper.hs"
+      component: "haskell-ide-engine:exe:hie-wrapper"
+
+    - path: "./"
+      component: "haskell-ide-engine:lib"


### PR DESCRIPTION
The cabal one is tested per component.

The stack one has issues because of the nested library.

Note: the suffix on the cabal one cannot be '.cabal', as that
extension is already used.