### PR TITLE
First pass at printing out debug info if started without --lsp

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -2,9 +2,13 @@
 {-# LANGUAGE RankNTypes   #-}
 module Main where
 
+import qualified Control.Exception                     as E
 import           Control.Monad
 import           Data.Monoid                           ((<>))
 import           Data.Version                          (showVersion)
+import qualified Data.Yaml as Yaml
+import           HIE.Bios.Types
+import           Haskell.Ide.Engine.Cradle (findLocalCradle, cradleDisplay)
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Options
@@ -16,9 +20,9 @@ import           Options.Applicative.Simple
 import qualified Paths_haskell_ide_engine              as Meta
 import           System.Directory
 import           System.Environment
-import qualified System.Log.Logger                     as L
-import           HIE.Bios.Types
+import           System.FilePath ((</>))
 import           System.IO
+import qualified System.Log.Logger                     as L
 
 -- ---------------------------------------------------------------------
 -- plugins
@@ -26,6 +30,9 @@ import           System.IO
 import           Haskell.Ide.Engine.Plugin.ApplyRefact
 import           Haskell.Ide.Engine.Plugin.Brittany
 import           Haskell.Ide.Engine.Plugin.Example2
+import           Haskell.Ide.Engine.Plugin.Floskell
+import           Haskell.Ide.Engine.Plugin.Generic
+import           Haskell.Ide.Engine.Plugin.GhcMod
 -- import           Haskell.Ide.Engine.Plugin.HaRe
 import           Haskell.Ide.Engine.Plugin.Haddock
 import           Haskell.Ide.Engine.Plugin.HfaAlign
@@ -33,9 +40,6 @@ import           Haskell.Ide.Engine.Plugin.HsImport
 import           Haskell.Ide.Engine.Plugin.Liquid
 import           Haskell.Ide.Engine.Plugin.Package
 import           Haskell.Ide.Engine.Plugin.Pragmas
-import           Haskell.Ide.Engine.Plugin.Floskell
-import           Haskell.Ide.Engine.Plugin.Generic
-import           Haskell.Ide.Engine.Plugin.GhcMod
 
 -- ---------------------------------------------------------------------
 
@@ -110,23 +114,56 @@ run opts = do
   maybe (pure ()) setCurrentDirectory $ projectRoot opts
 
   progName <- getProgName
-  logm $  "Run entered for HIE(" ++ progName ++ ") " ++ hieVersion
-  logm $ "Current directory:" ++ origDir
   args <- getArgs
-  logm $ "args:" ++ show args
 
-  let initOpts = defaultCradleOpts { cradleOptsVerbosity = verbosity }
-      verbosity = if optBiosVerbose opts then Verbose else Silent
+  if optLsp opts
+    then do
+      -- Start up in LSP mode
+      logm $  "Run entered for HIE(" ++ progName ++ ") " ++ hieVersion
+      logm $ "Current directory:" ++ origDir
+      logm $ "args:" ++ show args
+
+      let initOpts = defaultCradleOpts { cradleOptsVerbosity = verbosity }
+          verbosity = if optBiosVerbose opts then Verbose else Silent
 
 
-  when (optBiosVerbose opts) $
-    logm "Enabling verbose mode for hie-bios. This option currently doesn't do anything."
+      when (optBiosVerbose opts) $
+        logm "Enabling verbose mode for hie-bios. This option currently doesn't do anything."
 
-  when (optExamplePlugin opts) $
-    logm "Enabling Example2 plugin, will insert constant diagnostics etc."
+      when (optExamplePlugin opts) $
+        logm "Enabling Example2 plugin, will insert constant diagnostics etc."
 
-  let plugins' = plugins (optExamplePlugin opts)
+      let plugins' = plugins (optExamplePlugin opts)
 
-  -- launch the dispatcher.
-  scheduler <- newScheduler plugins' initOpts
-  server scheduler origDir plugins' (optCaptureFile opts)
+      -- launch the dispatcher.
+      scheduler <- newScheduler plugins' initOpts
+      server scheduler origDir plugins' (optCaptureFile opts)
+    else do
+      -- Provide debug info
+      cliOut $  "Running HIE(" ++ progName ++ ")"
+      cliOut $  "  " ++ hieVersion
+      cliOut $ "Current directory:" ++ origDir
+      -- args <- getArgs
+      cliOut $ "\nargs:" ++ show args
+
+      cliOut $ "\nLooking for project config cradle...\n"
+
+      ecradle <- getCradleInfo origDir
+      case ecradle of
+        Left e       -> cliOut $ "Could not get cradle:" ++ show e
+        Right cradle -> cliOut $ "Cradle:" ++ cradleDisplay cradle
+
+-- ---------------------------------------------------------------------
+
+getCradleInfo :: FilePath -> IO (Either Yaml.ParseException Cradle)
+getCradleInfo currentDir = do
+        let dummyCradleFile = currentDir </> "File.hs"
+        cradleRes <- E.try (findLocalCradle dummyCradleFile)
+        return cradleRes
+
+-- ---------------------------------------------------------------------
+
+cliOut :: String -> IO ()
+cliOut = putStrLn
+
+-- ---------------------------------------------------------------------

--- a/cabal.project
+++ b/cabal.project
@@ -9,4 +9,9 @@ tests: true
 package haskell-ide-engine
   test-show-details: direct
 
+-- Match the flag settings we use in stac builds
+constraints:
+        haskell-ide-engine +pedantic
+        hie-plugin-api     +pedantic
+
 write-ghc-environment-files: never

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -118,6 +118,7 @@ executable hie
                      , hie-plugin-api
                      , hslogger
                      , optparse-simple
+                     , yaml
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wredundant-constraints
                        -with-rtsopts=-T
   if flag(pedantic)

--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -6,7 +6,7 @@ import           Options.Applicative.Simple
 data GlobalOpts = GlobalOpts
   { optDebugOn       :: Bool
   , optLogFile       :: Maybe String
-  , _optLsp          :: Bool -- Kept for a while, to not break legacy clients
+  , optLsp           :: Bool -- Kept for a while, to not break legacy clients
   , projectRoot      :: Maybe String
   , optBiosVerbose   :: Bool
   , optCaptureFile   :: Maybe FilePath
@@ -26,9 +26,9 @@ globalOptsParser = GlobalOpts
       <> metavar "LOGFILE"
       <> help "File to log to, defaults to stdout"
        ))
-  <*> flag True True
+  <*> flag False True
        ( long "lsp"
-       <> help "Legacy flag, no longer used, to enable LSP mode. Not required.")
+       <> help "Start HIE as an LSP server. Otherwise it dumps debug info to stdout")
   <*> optional (strOption
        ( long "project-root"
       <> short 'r'

--- a/test/utils/TestUtils.hs
+++ b/test/utils/TestUtils.hs
@@ -185,7 +185,7 @@ logFilePath = "hie-" ++ stackYaml ++ ".log"
 -- on PATH. Cabal seems to respond to @build-tool-depends@ specifically while
 -- stack just puts all project executables on PATH.
 hieCommand :: String
-hieCommand = "hie --bios-verbose -d -l test-logs/" ++ logFilePath
+hieCommand = "hie --lsp --bios-verbose -d -l test-logs/" ++ logFilePath
 
 hieCommandVomit :: String
 hieCommandVomit = hieCommand ++ " --vomit"


### PR DESCRIPTION
Closes #1412 

Example output

```
Running HIE(hie)
  Version 1.0.0.0, Git revision 666626ede0e0bf5f1c876bd04f2a8a0cc68e7bb1 (dirty) (3534 commits) x86_64 ghc-8.6.5
Current directory:/home/alanz/mysrc/github/alanz/haskell-ide-engine/app

args:[]

Looking for project config cradle...

2020-01-01 22:41:46.396914848 [ThreadId 4] - Cabal-Helper dirs: ["/home/alanz/mysrc/github/alanz/haskell-ide-engine","/home/alanz/mysrc/github/alanz/haskell-ide-engine/app/File.hs"]
Resolving dependencies...
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - hie-plugin-api-0.14.0.0 (lib) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (lib) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (test:wrapper-test) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (exe:hie-wrapper) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (lib:hie-test-utils) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (exe:hie) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (test:unit-test) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (test:plugin-dispatcher-test) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (test:dispatcher-test) (configuration changed)
 - haskell-ide-engine-1.0.0.0 (test:func-test) (configuration changed)
Cradle:Cabal project
```