### PR TITLE
[WIP] Download hlint data-files if they cant be found.

### DIFF
--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -88,6 +88,7 @@ library
                      , stm
                      , syb
                      , tagsoup
+                     , temporary
                      , text
                      , transformers
                      , unix-time >= 0.4.7


### PR DESCRIPTION
Closes #1143
Changes the behaviour in the following way:
* Introduces a `initializeHlint` function
* Introduce `HIE_HLINT_DATADIR` env variable for the location of the data-files.
* Download missing data-files with `stack` or `cabal`, whatever is available.
* Copy data-files into `XDG_DATA_HOME/hie/hlint`
* Write the data-dir location into the extensible state.

Missing stuff:
* [ ] After downloading stuff, set the data-dir location in the extensible state.
* [ ] Use a https://microsoft.github.io/language-server-protocol/specifications/specification-3-14/#window_showMessageRequest to ask if we should download stuff.
* [ ] Add a test to prove the code does what we want.
* [ ] Update `install.hs` to do this stuff for us, cc @jneira. 
* [ ] Check if at least one file is in the data-dir.

To check it out, open a project wait for typecheck, then reopen the project again. Now no data-files should be downloaded and hlint should produce diagnostics. On the first try, it definitely does not produce diagnostics, since I didnt implement `After downloading stuff, set the data-dir location in the extensible state.` yet.