### PR TITLE
Enable azure releases and some fixes

### DIFF
--- a/.azure/linux-installhs-stack.yml
+++ b/.azure/linux-installhs-stack.yml
@@ -3,10 +3,8 @@ jobs:
   timeoutInMinutes: 0
   pool:
     vmImage: ubuntu-16.04
-  strategy:
-    matrix:
-      shake:
-        YAML_FILE: install/shake.yaml
+  variables:
+    YAML_FILE: install/shake.yaml
   steps:
   - bash: |
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -34,9 +34,9 @@ jobs:
     displayName: "Download cache"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -xzf .azure-cache/stack-root.tar.gz -C /
+      tar -vxzf .azure-cache/stack-root.tar.gz -C /
       mkdir -p .stack-work
-      tar -xzf .azure-cache/stack-work.tar.gz
+      tar -vxzf .azure-cache/stack-work.tar.gz
     displayName: "Unpack cache"
     condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
@@ -45,7 +45,7 @@ jobs:
   - bash: |
       mkdir -p ~/.local/bin
       curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | \
-        tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+        tar vxz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
     displayName: Install stack
   - bash: |
       source .azure/linux.bashrc
@@ -74,7 +74,7 @@ jobs:
         GHC_MINOR_VERSION=nightly
       fi
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-linux-x86_64
-      tar -czf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
+      tar -vczf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 
   - bash: |
       source .azure/linux.bashrc
@@ -104,6 +104,6 @@ jobs:
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   - bash: |
       mkdir -p .azure-cache
-      tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT
-      tar -czf .azure-cache/stack-work.tar.gz .stack-work
+      tar -vczf .azure-cache/stack-root.tar.gz $STACK_ROOT
+      tar -vczf .azure-cache/stack-work.tar.gz .stack-work
     displayName: "Pack cache"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -74,7 +74,7 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      ARTIFACT_NAME=hie-$(hie --numeric-version)-$GHC_MINOR_VERSION-linux-x86_64
+      ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-linux-x86_64
       tar -czf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 
   - bash: |

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -42,7 +42,6 @@ jobs:
   - bash: |
       git submodule sync
       git submodule update --init
-    displayName: Sync submodules
   - bash: |
       mkdir -p ~/.local/bin
       curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | \
@@ -91,7 +90,7 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
       source .azure/linux.bashrc
-      stack install hoogle --stack-yaml=$(YAML_FILE)
+      stack build hoogle --stack-yaml=$(YAML_FILE)
       stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
   # - bash: |

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -73,6 +73,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $tmp
+      mkdir -p data
+      cp $tmp/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-linux-x86_64
       tar -vczf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -26,7 +26,7 @@ jobs:
   variables:
     STACK_ROOT: /home/vsts/.stack
   steps:
-  - task: CacheBeta@0
+  - task: Cache@2
     inputs:
       key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .azure-cache

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -73,9 +73,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $tmp
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $(Agent.TempDirectory)
       mkdir -p data
-      cp $tmp/hlint*/data/hlint.yaml data
+      cp $(Agent.TempDirectory)/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-linux-x86_64
       tar -vczf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -71,8 +71,10 @@ jobs:
         GHC_MAJOR_VERSION=${YAML_FILE:6:3}
         cp hie hie-$GHC_MINOR_VERSION
         cp hie hie-$GHC_MAJOR_VERSION
+      else
+        GHC_MINOR_VERSION=nightly
       fi
-      ARTIFACT_NAME=haskell-ide-engine-$(Agent.OS)-$(Agent.OSArchitecture)
+      ARTIFACT_NAME=hie-$(hie --numeric-version)-$GHC_MINOR_VERSION-linux-x86_64
       tar -czf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 
   - bash: |
@@ -99,7 +101,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: hie-$(Agent.OS)-$(Agent.OSArchitecture)
+      artifactName: hie-$(Agent.OS)-$(YAML_FILE)
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   - bash: |
       mkdir -p .azure-cache

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -28,7 +28,7 @@ jobs:
   steps:
   - task: Cache@2
     inputs:
-      key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
+      key: '"stack-root" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -73,9 +73,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $(Agent.TempDirectory)
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to "$(Agent.TempDirectory)"
       mkdir -p data
-      cp $(Agent.TempDirectory)/hlint*/data/hlint.yaml data
+      cp "$(Agent.TempDirectory)"/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-linux-x86_64
       tar -vczf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -62,8 +62,22 @@ jobs:
     displayName: Build `hie`
   - bash: |
       source .azure/linux.bashrc
+      stack install --stack-yaml $(YAML_FILE) # `hie` binary required locally for tests
+      mkdir .azure-deploy
+      stack install --stack-yaml $(YAML_FILE) --local-bin-path .azure-deploy 
+      cd .azure-deploy
+      if [ $YAML_FILE != "stack.yaml" ]; then
+        GHC_MINOR_VERSION=${YAML_FILE:6:5}
+        GHC_MAJOR_VERSION=${YAML_FILE:6:3}
+        cp hie hie-$GHC_MINOR_VERSION
+        cp hie hie-$GHC_MAJOR_VERSION
+      fi
+      ARTIFACT_NAME=haskell-ide-engine-$(Agent.OS)-$(Agent.OSArchitecture)
+      tar -czf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
+    displayName: Install `hie` 
+  - bash: |
+      source .azure/linux.bashrc
       stack build --stack-yaml $(YAML_FILE) --test --bench --only-dependencies
-      stack install --stack-yaml $(YAML_FILE) # `hie` binary required for tests
     displayName: Build Test-dependencies
   - bash: |
       sudo apt update
@@ -73,10 +87,20 @@ jobs:
       source .azure/linux.bashrc
       stack install --resolver=lts-11.18 liquid-fixpoint-0.7.0.7 dotgen-0.4.2 fgl-visualize-0.1.0.1 located-base-0.1.1.1 liquidhaskell-0.8.2.4
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
+  - bash: |
+      source .azure/linux.bashrc
+      stack install hoogle --stack-yaml=$(STACK_FILE)
+      stack exec hoogle generate --stack-yaml=$(STACK_FILE)
+    displayName: "Install Runtime Test-Dependencies: hoogle database"
   # - bash: |
   #     source .azure/linux.bashrc
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: hie-$(Agent.OS)-$(Agent.OSArchitecture)
+    condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   - bash: |
       mkdir -p .azure-cache
       tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -28,7 +28,7 @@ jobs:
   steps:
   - task: CacheBeta@0
     inputs:
-      key: stack-root | $(Agent.OS) | $(Build.SourcesDirectory)/$(YAML_FILE)
+      key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -89,8 +89,8 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
       source .azure/linux.bashrc
-      stack install hoogle --stack-yaml=$(STACK_FILE)
-      stack exec hoogle generate --stack-yaml=$(STACK_FILE)
+      stack install hoogle --stack-yaml=$(YAML_FILE)
+      stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
   # - bash: |
   #     source .azure/linux.bashrc

--- a/.azure/macos-installhs-stack.yml
+++ b/.azure/macos-installhs-stack.yml
@@ -3,10 +3,8 @@ jobs:
   timeoutInMinutes: 0
   pool:
     vmImage: macOS-10.13
-  strategy:
-    matrix:
-      shake:
-        YAML_FILE: install/shake.yaml
+  variables:
+    YAML_FILE: install/shake.yaml
   steps:
   - bash: |
       export STACK_ROOT="$(Build.SourcesDirectory)"/.stack-root

--- a/.azure/macos-installhs-stack.yml
+++ b/.azure/macos-installhs-stack.yml
@@ -30,9 +30,5 @@ jobs:
     displayName: Run help of `install.hs`
   - bash: |
       source .azure/macos.bashrc
-      stack install.hs stack-install-cabal
-    displayName: Run stack-install-cabal target of `install.hs`
-  - bash: |
-      source .azure/macos.bashrc
-      stack install.hs build-latest
-    displayName: Run build-latest target of `install.hs`
+      stack install.hs latest
+    displayName: Run latest target of `install.hs`

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -56,7 +56,7 @@ jobs:
       source .azure/macos.bashrc
       stack build --stack-yaml $(YAML_FILE)
     displayName: Build `hie`
-- bash: |
+  - bash: |
       source .azure/macos.bashrc
       stack install --stack-yaml $(YAML_FILE) # `hie` binary required locally for tests
       mkdir .azure-deploy

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -70,9 +70,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $(Agent.TempDirectory)
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to "$(Agent.TempDirectory)"
       mkdir -p data
-      cp $(Agent.TempDirectory)/hlint*/data/hlint.yaml data
+      cp "$(Agent.TempDirectory)"/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-macos-x86_64
       tar -vczf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -89,7 +89,7 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
       source .azure/macos.bashrc
-      stack install hoogle --stack-yaml=$(YAML_FILE)
+      stack build hoogle --stack-yaml=$(YAML_FILE)
       stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
   # - bash: |

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -80,6 +80,7 @@ jobs:
   - bash: |
       ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
       brew update
+      brew unlink python@2
       brew install z3
     displayName: "Install Runtime Test-Dependencies: z3"
   - bash: |

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -70,6 +70,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $tmp
+      mkdir -p data
+      cp $tmp/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-macos-x86_64
       tar -vczf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -24,7 +24,7 @@ jobs:
   steps:
   - task: CacheBeta@0
     inputs:
-      key: stack-root | $(Agent.OS) | $(Build.SourcesDirectory)/$(YAML_FILE)
+      key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -70,7 +70,7 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      ARTIFACT_NAME=hie-$(hie --numeric-version)-$GHC_MINOR_VERSION-macos-x86_64
+      ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-macos-x86_64
       tar -czf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 
   - bash: |

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -30,9 +30,9 @@ jobs:
     displayName: "Download cache"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -xzf .azure-cache/stack-root.tar.gz -C /
+      tar -vxzf .azure-cache/stack-root.tar.gz -C /
       mkdir -p .stack-work
-      tar -xzf .azure-cache/stack-work.tar.gz
+      tar -vxzf .azure-cache/stack-work.tar.gz
     displayName: "Unpack cache"
     condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
@@ -42,7 +42,7 @@ jobs:
   - bash: |
       mkdir -p ~/.local/bin
       curl -skL https://get.haskellstack.org/stable/osx-x86_64.tar.gz | \
-        tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin;
+        tar vxz --strip-components=1 --include '*/stack' -C ~/.local/bin;
     displayName: Install stack
   - bash: |
       source .azure/macos.bashrc
@@ -71,7 +71,7 @@ jobs:
         GHC_MINOR_VERSION=nightly
       fi
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-macos-x86_64
-      tar -czf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
+      tar -vczf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 
   - bash: |
       source .azure/macos.bashrc
@@ -103,6 +103,6 @@ jobs:
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   - bash: |
       mkdir -p .azure-cache
-      tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT
-      tar -czf .azure-cache/stack-work.tar.gz .stack-work
+      tar -vczf .azure-cache/stack-root.tar.gz $STACK_ROOT
+      tar -vczf .azure-cache/stack-work.tar.gz .stack-work
     displayName: "Pack cache"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -67,8 +67,10 @@ jobs:
         GHC_MAJOR_VERSION=${YAML_FILE:6:3}
         cp hie hie-$GHC_MINOR_VERSION
         cp hie hie-$GHC_MAJOR_VERSION
+      else
+        GHC_MINOR_VERSION=nightly
       fi
-      ARTIFACT_NAME=haskell-ide-engine-$(Agent.OS)-$(Agent.OSArchitecture)
+      ARTIFACT_NAME=hie-$(hie --numeric-version)-$GHC_MINOR_VERSION-macos-x86_64
       tar -czf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 
   - bash: |
@@ -96,7 +98,7 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: hie-$(Agent.OS)-$(Agent.OSArchitecture)
+      artifactName: hie-$(Agent.OS)-$(YAML_FILE)
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   - bash: |
       mkdir -p .azure-cache

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -70,9 +70,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $tmp
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $(Agent.TempDirectory)
       mkdir -p data
-      cp $tmp/hlint*/data/hlint.yaml data
+      cp $(Agent.TempDirectory)/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-macos-x86_64
       tar -vczf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
     displayName: Install `hie` 

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -24,7 +24,7 @@ jobs:
   steps:
   - task: Cache@2
     inputs:
-      key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
+      key: '"stack-root" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -22,7 +22,7 @@ jobs:
   variables:
     STACK_ROOT: $(Build.SourcesDirectory)/.stack
   steps:
-  - task: CacheBeta@0
+  - task: Cache@2
     inputs:
       key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .azure-cache

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -56,10 +56,24 @@ jobs:
       source .azure/macos.bashrc
       stack build --stack-yaml $(YAML_FILE)
     displayName: Build `hie`
+- bash: |
+      source .azure/macos.bashrc
+      stack install --stack-yaml $(YAML_FILE) # `hie` binary required locally for tests
+      mkdir .azure-deploy
+      stack install --stack-yaml $(YAML_FILE) --local-bin-path .azure-deploy 
+      cd .azure-deploy
+      if [ $YAML_FILE != "stack.yaml" ]; then
+        GHC_MINOR_VERSION=${YAML_FILE:6:5}
+        GHC_MAJOR_VERSION=${YAML_FILE:6:3}
+        cp hie hie-$GHC_MINOR_VERSION
+        cp hie hie-$GHC_MAJOR_VERSION
+      fi
+      ARTIFACT_NAME=haskell-ide-engine-$(Agent.OS)-$(Agent.OSArchitecture)
+      tar -czf $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.tar.xz *
+    displayName: Install `hie` 
   - bash: |
       source .azure/macos.bashrc
       stack build --stack-yaml $(YAML_FILE) --test --bench --only-dependencies
-      stack install --stack-yaml $(YAML_FILE) # `hie` binary required for tests
     displayName: Build Test-dependencies
   - bash: |
       ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -70,10 +84,20 @@ jobs:
       source .azure/macos.bashrc
       stack install --resolver=lts-11.18 liquid-fixpoint-0.7.0.7 dotgen-0.4.2 fgl-visualize-0.1.0.1 located-base-0.1.1.1 liquidhaskell-0.8.2.4
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
+  - bash: |
+      source .azure/macos.bashrc
+      stack install hoogle --stack-yaml=$(STACK_FILE)
+      stack exec hoogle generate --stack-yaml=$(STACK_FILE)
+    displayName: "Install Runtime Test-Dependencies: hoogle database"
   # - bash: |
   #     source .azure/macos.bashrc
   #     stack test --stack-yaml $(YAML_FILE)
   #   displayName: Run Test
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: hie-$(Agent.OS)-$(Agent.OSArchitecture)
+    condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   - bash: |
       mkdir -p .azure-cache
       tar -czf .azure-cache/stack-root.tar.gz $STACK_ROOT

--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -86,8 +86,8 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
       source .azure/macos.bashrc
-      stack install hoogle --stack-yaml=$(STACK_FILE)
-      stack exec hoogle generate --stack-yaml=$(STACK_FILE)
+      stack install hoogle --stack-yaml=$(YAML_FILE)
+      stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
   # - bash: |
   #     source .azure/macos.bashrc

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -32,6 +32,7 @@ jobs:
   - bash: |
       source .azure/windows.bashrc
       GHC_PATH=$(stack path --stack-yaml $YAML_FILE --compiler-exe)
-      export PATH=$(cygpath $GHC_PATH):$PATH
+      GHC_DIR=$(dirname $GHC_PATH)
+      export PATH=$(cygpath $GHC_DIR):$PATH
       cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) build-latest
     displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -26,12 +26,12 @@ jobs:
     displayName: update cabal
   - bash: |
       source .azure/windows.bashrc
-      GHC_PATH = $(stack path --stack-yaml $YAML_FILE --compiler-exe)
+      GHC_PATH=$(stack path --stack-yaml $YAML_FILE --compiler-exe)
       cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) help
     displayName: Run help of `install.hs`
   - bash: |
       source .azure/windows.bashrc
-      GHC_PATH = $(stack path --stack-yaml $YAML_FILE --compiler-exe)
+      GHC_PATH=$(stack path --stack-yaml $YAML_FILE --compiler-exe)
       export PATH=$(cygpath $GHC_PATH):$PATH
       cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) build-latest
     displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -26,9 +26,9 @@ jobs:
     displayName: update cabal
   - bash: |
       source .azure/windows.bashrc
-      cabal v2-run install.hs -w $(stack path --stack-yaml $(YAML_FILE) --compiler-exe) --project-file $(PROJECT_FILE) help
+      cabal v2-run install.hs -w $(stack path --stack-yaml $YAML_FILE --compiler-exe) --project-file $(PROJECT_FILE) help
     displayName: Run help of `install.hs`
   - bash: |
       source .azure/windows.bashrc
-      cabal v2-run install.hs -w $(stack path --stack-yaml $(YAML_FILE) --compiler-exe) --project-file $(PROJECT_FILE) build-latest
+      cabal v2-run install.hs -w $(stack path --stack-yaml $YAML_FILE --compiler-exe) --project-file $(PROJECT_FILE) build-latest
     displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -34,5 +34,8 @@ jobs:
       GHC_PATH=$(stack path --stack-yaml $YAML_FILE --compiler-exe)
       GHC_DIR=$(dirname $GHC_PATH)
       export PATH=$(cygpath $GHC_DIR):$PATH
+      # running the script with cabal uses stack to get its local-bin-path (for now)
+      # so we have to ensure it exists
+      mkdir -p $(stack path --stack-yaml $YAML_FILE --local-bin)
       cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) build-latest
     displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -6,6 +6,7 @@ jobs:
   variables:
     YAML_FILE: install/shake.yaml
     PROJECT_FILE: install/shake.project
+    STACK_ROOT: "C:\\sr"
   steps:
   - bash: |
       curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
@@ -17,21 +18,17 @@ jobs:
     displayName: Install GHC
   - bash: |
       source .azure/windows.bashrc
-      stack install cabal-install --stack-yaml $(YAML_FILE)
+      stack install.hs stack-install-cabal
     displayName: Install `cabal-install`
   - bash: |
       source .azure/windows.bashrc
       cabal update
     displayName: update cabal
-  # - bash: |
-  #     source .azure/windows.bashrc
-  #     stack --stack-yaml $(YAML_FILE) build --only-dependencies
-  #   displayName: Build dependencies
-  - bash: |
-      source .azure/windows.bashrc
-      cabal v2-build hie-install -w $(stack path --stack-yaml $(YAML_FILE) --compiler-exe) --project-file $(PROJECT_FILE)
-    displayName: Build `hie-install`
   - bash: |
       source .azure/windows.bashrc
       cabal v2-run install.hs -w $(stack path --stack-yaml $(YAML_FILE) --compiler-exe) --project-file $(PROJECT_FILE) help
     displayName: Run help of `install.hs`
+  - bash: |
+      source .azure/windows.bashrc
+      cabal v2-run install.hs -w $(stack path --stack-yaml $(YAML_FILE) --compiler-exe) --project-file $(PROJECT_FILE) build-latest
+    displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -18,7 +18,7 @@ jobs:
     displayName: Install GHC
   - bash: |
       source .azure/windows.bashrc
-      stack install.hs stack-install-cabal
+      stack install Cabal-3.0.0.0 cabal-install-3.0.0.0 --stack-yaml $(YAML_FILE)
     displayName: Install `cabal-install`
   - bash: |
       source .azure/windows.bashrc

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -29,10 +29,10 @@ jobs:
       GHC_PATH=$(stack path --stack-yaml $YAML_FILE --compiler-exe)
       cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) help
     displayName: Run help of `install.hs`
-  - bash: |
-      source .azure/windows.bashrc
-      GHC_PATH=$(stack path --stack-yaml $YAML_FILE --compiler-exe)
-      GHC_DIR=$(dirname $GHC_PATH)
-      export PATH=$(cygpath $GHC_DIR):$PATH
-      cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) build-latest
-    displayName: Run build-latest target of `install.hs`
+  # - bash: |
+  #    source .azure/windows.bashrc
+  #    GHC_PATH=$(stack path --stack-yaml $YAML_FILE --compiler-exe)
+  #    GHC_DIR=$(dirname $GHC_PATH)
+  #    export PATH=$(cygpath $GHC_DIR):$PATH
+  #    cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) build-latest
+  #  displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -7,6 +7,7 @@ jobs:
     YAML_FILE: install/shake.yaml
     PROJECT_FILE: install/shake.project
     STACK_ROOT: "C:\\sr"
+  # TODO: Replace stack with chocolatey for installing ghc and cabal
   steps:
   - bash: |
       curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -22,13 +22,16 @@ jobs:
     displayName: Install `cabal-install`
   - bash: |
       source .azure/windows.bashrc
-      cabal update
+      cabal v2-update
     displayName: update cabal
   - bash: |
       source .azure/windows.bashrc
-      cabal v2-run install.hs -w $(stack path --stack-yaml $YAML_FILE --compiler-exe) --project-file $(PROJECT_FILE) help
+      GHC_PATH = $(stack path --stack-yaml $YAML_FILE --compiler-exe)
+      cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) help
     displayName: Run help of `install.hs`
   - bash: |
       source .azure/windows.bashrc
-      cabal v2-run install.hs -w $(stack path --stack-yaml $YAML_FILE --compiler-exe) --project-file $(PROJECT_FILE) build-latest
+      GHC_PATH = $(stack path --stack-yaml $YAML_FILE --compiler-exe)
+      export PATH=$(cygpath $GHC_PATH):$PATH
+      cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) build-latest
     displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -34,8 +34,5 @@ jobs:
       GHC_PATH=$(stack path --stack-yaml $YAML_FILE --compiler-exe)
       GHC_DIR=$(dirname $GHC_PATH)
       export PATH=$(cygpath $GHC_DIR):$PATH
-      # running the script with cabal uses stack to get its local-bin-path (for now)
-      # so we have to ensure it exists
-      mkdir -p $(stack path --stack-yaml $YAML_FILE --local-bin)
       cabal v2-run install.hs -w $GHC_PATH --project-file $(PROJECT_FILE) build-latest
     displayName: Run build-latest target of `install.hs`

--- a/.azure/windows-installhs-stack.yml
+++ b/.azure/windows-installhs-stack.yml
@@ -3,10 +3,9 @@ jobs:
   timeoutInMinutes: 0
   pool:
     vmImage: windows-2019
-  strategy:
-    matrix:
-      shake:
-        YAML_FILE: install/shake.yaml
+  variables:
+    YAML_FILE: install/shake.yaml
+    STACK_ROOT: "C:\\sr"
   steps:
   - bash: |
       curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip

--- a/.azure/windows-installhs-stack.yml
+++ b/.azure/windows-installhs-stack.yml
@@ -17,7 +17,7 @@ jobs:
     displayName: Install GHC
   - bash: |
       source .azure/windows.bashrc
-      stack --stack-yaml $(YAML_FILE) --install-ghc build --only-dependencies
+      stack --stack-yaml $(YAML_FILE) build --only-dependencies
     displayName: Build dependencies
   - bash: |
       source .azure/windows.bashrc

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -32,10 +32,7 @@ jobs:
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
-      key: |
-        "stack-work"
-        $(Agent.OS)
-        $(Build.SourcesDirectory)/$(YAML_FILE)
+      key: stack-work | $(Agent.OS) | $(Build.SourcesDirectory)/$(YAML_FILE)
       path: .stack-work
     displayName: "Cache stack-work"
   - bash: |
@@ -60,8 +57,22 @@ jobs:
     displayName: Build `hie`
   - bash: |
       source .azure/windows.bashrc
+      stack install --stack-yaml $(YAML_FILE) # `hie` binary required locally for tests
+      mkdir .azure-deploy
+      stack install --stack-yaml $(YAML_FILE) --local-bin-path .azure-deploy 
+      cd .azure-deploy
+      if [ $YAML_FILE != "stack.yaml" ]; then
+        GHC_MINOR_VERSION=${YAML_FILE:6:5}
+        GHC_MAJOR_VERSION=${YAML_FILE:6:3}
+        cp hie.exe hie-$GHC_MINOR_VERSION.exe
+        cp hie.exe hie-$GHC_MAJOR_VERSION.exe
+      fi
+      ARTIFACT_NAME=haskell-ide-engine-$(Agent.OS)-$(Agent.OSArchitecture)
+      zip -r $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip .
+    displayName: Install `hie` 
+  - bash: |
+      source .azure/windows.bashrc
       stack build --stack-yaml $(YAML_FILE) --test --bench --only-dependencies
-      stack install --stack-yaml $(YAML_FILE) # `hie` binary required for tests
     displayName: Build Test-dependencies
   - bash: |
       # TODO: try to install automatically (`choco install z3` fails and pacman is not installed)
@@ -74,7 +85,18 @@ jobs:
       stack install --resolver=lts-11.18 liquid-fixpoint-0.7.0.7 dotgen-0.4.2 fgl-visualize-0.1.0.1 located-base-0.1.1.1 liquidhaskell-0.8.2.4
       liquid -v
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
+  - bash: |
+      source .azure/windows.bashrc
+      stack install hoogle --stack-yaml=$(STACK_FILE)
+      stack exec hoogle generate --stack-yaml=$(STACK_FILE)
+    displayName: "Install Runtime Test-Dependencies: hoogle database"
   # - bash: |
   #     source .azure/windows.bashrc
   #     stack test --stack-yaml $(YAML_FILE) :unit-test
   #   displayName: Run Test
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: hie-$(Agent.OS)-$(Agent.OSArchitecture)
+    condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+  

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -72,6 +72,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $tmp
+      mkdir -p data
+      cp $(cygpath $tmp)/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-windows-x86_64
       7z a "$(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip" *
     displayName: Install `hie` 

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -72,9 +72,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $tmp
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $(Agent.TempDirectory)
       mkdir -p data
-      cp $(cygpath $tmp)/hlint*/data/hlint.yaml data
+      cp $(Agent.TempDirectory)/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-windows-x86_64
       7z a "$(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip" *
     displayName: Install `hie` 

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -66,9 +66,11 @@ jobs:
         GHC_MAJOR_VERSION=${YAML_FILE:6:3}
         cp hie.exe hie-$GHC_MINOR_VERSION.exe
         cp hie.exe hie-$GHC_MAJOR_VERSION.exe
+      else
+        GHC_MINOR_VERSION=nightly
       fi
-      ARTIFACT_NAME=haskell-ide-engine-$(Agent.OS)-$(Agent.OSArchitecture)
-      zip -r $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip .
+      ARTIFACT_NAME=hie-$(hie --numeric-version)-$GHC_MINOR_VERSION-windows-x86_64
+      7z -a $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip *
     displayName: Install `hie` 
   - bash: |
       source .azure/windows.bashrc
@@ -97,6 +99,6 @@ jobs:
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: hie-$(Agent.OS)-$(Agent.OSArchitecture)
+      artifactName: hie-$(Agent.OS)-$(YAML_FILE)
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -27,12 +27,12 @@ jobs:
   steps:
   - task: Cache@2
     inputs:
-      key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
+      key: '"stack-root" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: $(STACK_ROOT)
     displayName: "Cache stack-root"
   - task: Cache@2
     inputs:
-      key: 'stack-work | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
+      key: '"stack-work" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .stack-work
     displayName: "Cache stack-work"
   - bash: |

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -92,13 +92,13 @@ jobs:
       stack install hoogle --stack-yaml=$(YAML_FILE)
       stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
-  # - bash: |
-  #     source .azure/windows.bashrc
-  #     stack test --stack-yaml $(YAML_FILE) :unit-test
-  #   displayName: Run Test
-  # - task: PublishBuildArtifacts@1
-  #  inputs:
-  #    pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-  #    artifactName: hie-$(Agent.OS)-$(YAML_FILE)
-  #  condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+  - bash: |
+      source .azure/windows.bashrc
+      stack test --stack-yaml $(YAML_FILE) :unit-test
+    displayName: Run Test
+  - task: PublishBuildArtifacts@1
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: hie-$(Agent.OS)-$(YAML_FILE)
+    condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -72,9 +72,9 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to $(Agent.TempDirectory)
+      stack unpack hlint --stack-yaml ../$(YAML_FILE) --to "$(Agent.TempDirectory)"
       mkdir -p data
-      cp $(Agent.TempDirectory)/hlint*/data/hlint.yaml data
+      cp "$(Agent.TempDirectory)"/hlint*/data/hlint.yaml data
       ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-windows-x86_64
       7z a "$(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip" *
     displayName: Install `hie` 

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -70,7 +70,7 @@ jobs:
         GHC_MINOR_VERSION=nightly
       fi
       ARTIFACT_NAME=hie-$(hie --numeric-version)-$GHC_MINOR_VERSION-windows-x86_64
-      7z -a $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip *
+      7z a $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip *
     displayName: Install `hie` 
   - bash: |
       source .azure/windows.bashrc

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -69,8 +69,8 @@ jobs:
       else
         GHC_MINOR_VERSION=nightly
       fi
-      ARTIFACT_NAME=hie-$(hie --numeric-version)-$GHC_MINOR_VERSION-windows-x86_64
-      7z a $(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip *
+      ARTIFACT_NAME=hie-$(hie --numeric-version)-ghc-$GHC_MINOR_VERSION-windows-x86_64
+      7z a "$(Build.ArtifactStagingDirectory)/$ARTIFACT_NAME.zip" *
     displayName: Install `hie` 
   - bash: |
       source .azure/windows.bashrc

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -28,13 +28,16 @@ jobs:
   - task: Cache@2
     inputs:
       key: '"stack-root" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
-      path: $(STACK_ROOT)
+      path: .azure-cache
+      cacheHitVar: CACHE_RESTORED
     displayName: "Cache stack-root"
-  - task: Cache@2
-    inputs:
-      key: '"stack-work" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
-      path: .stack-work
-    displayName: "Cache stack-work"
+  - bash: |
+      mkdir -p $STACK_ROOT
+      tar -xzf .azure-cache/stack-root.tar.gz -C /
+      mkdir -p .stack-work
+      tar -xzf .azure-cache/stack-work.tar.gz
+    displayName: "Unpack cache"
+    condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
       git submodule sync
       git submodule update --init
@@ -101,4 +104,9 @@ jobs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: hie-$(Agent.OS)-$(YAML_FILE)
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+  - bash: |
+      mkdir -p .azure-cache
+      tar -czf .azure-cache/stack-root.tar.gz $(cygpath $STACK_ROOT)
+      tar -czf .azure-cache/stack-work.tar.gz .stack-work
+    displayName: "Pack cache"
   

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -92,10 +92,10 @@ jobs:
       stack install hoogle --stack-yaml=$(YAML_FILE)
       stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
-  - bash: |
-      source .azure/windows.bashrc
-      stack test --stack-yaml $(YAML_FILE) :unit-test
-    displayName: Run Test
+#  - bash: |
+#      source .azure/windows.bashrc
+#      stack test --stack-yaml $(YAML_FILE) :unit-test
+#    displayName: Run Test
   - task: PublishBuildArtifacts@1
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -30,7 +30,7 @@ jobs:
       key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: $(STACK_ROOT)
     displayName: "Cache stack-root"
-  - task: CacheBeta@0
+  - task: Cache@2
     inputs:
       key: 'stack-work | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .stack-work

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -87,8 +87,8 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
       source .azure/windows.bashrc
-      stack install hoogle --stack-yaml=$(STACK_FILE)
-      stack exec hoogle generate --stack-yaml=$(STACK_FILE)
+      stack install hoogle --stack-yaml=$(YAML_FILE)
+      stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
   # - bash: |
   #     source .azure/windows.bashrc

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -27,12 +27,12 @@ jobs:
   steps:
   - task: CacheBeta@0
     inputs:
-      key: stack-root | $(Agent.OS) | $(Build.SourcesDirectory)/$(YAML_FILE)
+      key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: $(STACK_ROOT)
     displayName: "Cache stack-root"
   - task: CacheBeta@0
     inputs:
-      key: stack-work | $(Agent.OS) | $(Build.SourcesDirectory)/$(YAML_FILE)
+      key: 'stack-work | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .stack-work
     displayName: "Cache stack-work"
   - bash: |

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -25,7 +25,7 @@ jobs:
     STACK_ROOT: "C:\\sr"
 
   steps:
-  - task: CacheBeta@0
+  - task: Cache@2
     inputs:
       key: 'stack-root | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: $(STACK_ROOT)

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -33,9 +33,9 @@ jobs:
     displayName: "Cache stack-root"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -xzf .azure-cache/stack-root.tar.gz -C /
+      tar -vxzf .azure-cache/stack-root.tar.gz -C /
       mkdir -p .stack-work
-      tar -xzf .azure-cache/stack-work.tar.gz
+      tar -vxzf .azure-cache/stack-work.tar.gz
     displayName: "Unpack cache"
     condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
@@ -106,7 +106,7 @@ jobs:
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   - bash: |
       mkdir -p .azure-cache
-      tar -czf .azure-cache/stack-root.tar.gz $(cygpath $STACK_ROOT)
-      tar -czf .azure-cache/stack-work.tar.gz .stack-work
+      tar -vczf .azure-cache/stack-root.tar.gz $(cygpath $STACK_ROOT)
+      tar -vczf .azure-cache/stack-work.tar.gz .stack-work
     displayName: "Pack cache"
   

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -92,7 +92,7 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
       source .azure/windows.bashrc
-      stack install hoogle --stack-yaml=$(YAML_FILE)
+      stack build hoogle --stack-yaml=$(YAML_FILE)
       stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
 #  - bash: |

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -96,9 +96,9 @@ jobs:
   #     source .azure/windows.bashrc
   #     stack test --stack-yaml $(YAML_FILE) :unit-test
   #   displayName: Run Test
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: hie-$(Agent.OS)-$(YAML_FILE)
-    condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
+  # - task: PublishBuildArtifacts@1
+  #  inputs:
+  #    pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+  #    artifactName: hie-$(Agent.OS)-$(YAML_FILE)
+  #  condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues')
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,5 +30,5 @@ jobs:
 - template: ./.azure/macos-stack.yml
 - template: ./.azure/linux-installhs-stack.yml
 - template: ./.azure/windows-installhs-stack.yml
-- template: ./.azure/windows-installhs-cabal.yml
+# - template: ./.azure/windows-installhs-cabal.yml
 - template: ./.azure/macos-installhs-stack.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,29 @@
+# Build master, branches starting with `azure` and tags commits
+trigger:
+  batch: false
+  branches:
+    include:
+      - master
+      - azure*
+  tags:
+    include:
+      - '*'
+  paths:
+    exclude:
+      - .circleci
+      - docs
+      - licenses
+      - logos
+      - LICENSE
+      - '*.md'
+
+# Enable PR triggers that target the master branch
+pr:
+  autoCancel: true # cancel previous builds on push
+  branches:
+    include:
+      - master
+
 jobs:
 - template: ./.azure/linux-stack.yml
 - template: ./.azure/windows-stack.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,4 +4,5 @@ jobs:
 - template: ./.azure/macos-stack.yml
 - template: ./.azure/linux-installhs-stack.yml
 - template: ./.azure/windows-installhs-stack.yml
+- template: ./.azure/windows-installhs-cabal.yml
 - template: ./.azure/macos-installhs-stack.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,5 +30,5 @@ jobs:
 - template: ./.azure/macos-stack.yml
 - template: ./.azure/linux-installhs-stack.yml
 - template: ./.azure/windows-installhs-stack.yml
-# - template: ./.azure/windows-installhs-cabal.yml
+- template: ./.azure/windows-installhs-cabal.yml
 - template: ./.azure/macos-installhs-stack.yml


### PR DESCRIPTION
* It makes release for all jobs (total 24), example: https://dev.azure.com/jneira/haskell-ide-engine/_build/results?buildId=371&view=artifacts&type=publishedArtifacts
* It fixes the z3 installation for macos
* It adds the hoogle databse generation, needed for tests
* It fixes the cache for windows, make it like the unix and macos ones
  * I've open an issue upstream: https://github.com/microsoft/azure-pipelines-tasks/issues/12070
* I've make some advancesin the task that uses cabal to run the install.hs script but it still fails trying to install hie
* It adds specific triggers

The history is a liitle bit hairy, maybe it should be squashed.