### PR TITLE
Fallback to direct cradle if no project context can be found

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
@@ -437,7 +437,7 @@ cabalHelperCradle file = do
                                       return
                                       $ CradleSuccess
                                         ComponentOptions
-                                          { componentOptions = []
+                                          { componentOptions = [file]
                                           , componentDependencies = []
                                           }
                                 }

--- a/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
@@ -432,8 +432,14 @@ cabalHelperCradle file = do
       return
         Cradle { cradleRootDir = cwd
                , cradleOptsProg =
-                   CradleAction { actionName = "Cabal-Helper-None"
-                                , runCradle = \_ _ -> return CradleNone
+                   CradleAction { actionName = "Direct"
+                                , runCradle = \_ _ ->
+                                      return
+                                      $ CradleSuccess
+                                        ComponentOptions
+                                          { componentOptions = []
+                                          , componentDependencies = []
+                                          }
                                 }
                }
     Just (Ex proj) -> do

--- a/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
@@ -437,7 +437,7 @@ cabalHelperCradle file = do
                                       return
                                       $ CradleSuccess
                                         ComponentOptions
-                                          { componentOptions = [file]
+                                          { componentOptions = [file, fixImportDirs cwd "-i."]
                                           , componentDependencies = []
                                           }
                                 }


### PR DESCRIPTION
Closes #1550 

No `*.cabal`, `cabal.project`, `stack.yaml` or `hie.yaml` must be in any of the ancestor directories of the file to open. Does not support any packages.