### PR TITLE
Readme lsp flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ into `~/.vim/pack/XXX/start/`, where `XXX` is just a name for your "plugin suite
 
 ```vim
 set rtp+=~/.vim/pack/XXX/start/LanguageClient-neovim
-let g:LanguageClient_serverCommands = { 'haskell': ['hie-wrapper'] }
+let g:LanguageClient_serverCommands = { 'haskell': ['hie-wrapper', '--lsp'] }
 ```
 
 You'll probably want to add some mappings for common commands:

--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Then issue `:CocConfig` and add the following to your Coc config file.
 "languageserver": {
   "haskell": {
     "command": "hie-wrapper",
+    "args": ["--lsp"],
     "rootPatterns": [
       "*.cabal",
       "stack.yaml",


### PR DESCRIPTION
Adds --lsp flag to integration instructions for vim+coc and vim+languageclient
Part of #1558 