### PR TITLE
Avoid building HIE twice

### DIFF
--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -122,7 +122,6 @@ defaultMain = do
       (\version -> phony ("cabal-hie-" ++ version) $ do
         need ["submodules"]
         need ["cabal"]
-        cabalBuildHie version
         cabalInstallHie version
       )
 


### PR DESCRIPTION
cabal install works different than cabal build
and does not re-use its artifacts. Even some
dependencies may be rebuilt.

Future cabal versions may fix that, we don't know.