### PR TITLE
Load all possible haskell source files

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -180,15 +180,15 @@ run opts = do
           cliOut ""
 
           unless (optDryRun opts) $ do
+            cliOut "\nLoad them all now. This may take a very long time.\n"
             loadDiagnostics <- runServer mlibdir plugins' targets
 
             cliOut ""
             cliOut "###################################################"
             cliOut "###################################################"
-            cliOut "\nLoad them all now. This may take a very long time.\n"
             cliOut "\nDumping diagnostics:\n\n"
             mapM_ (cliOut' . uncurry prettyPrintDiags) loadDiagnostics
-            cliOut "\n\n\nNote: loading of 'Setup.hs' is not supported."
+            cliOut "\n\nNote: loading of 'Setup.hs' is not supported."
 
 
 -- ---------------------------------------------------------------------

--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -6,9 +6,11 @@ import qualified Control.Exception                     as E
 import           Control.Monad
 import           Data.Monoid                           ((<>))
 import           Data.Version                          (showVersion)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
 import qualified Data.Yaml as Yaml
 import           HIE.Bios.Types
-import           Haskell.Ide.Engine.Cradle (findLocalCradle, cradleDisplay)
+import           Haskell.Ide.Engine.Cradle (findLocalCradle, cradleDisplay, getProjectGhcLibDir)
 import           Haskell.Ide.Engine.MonadFunctions
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.Options
@@ -20,10 +22,14 @@ import           Options.Applicative.Simple
 import qualified Paths_haskell_ide_engine              as Meta
 import           System.Directory
 import           System.Environment
-import           System.FilePath ((</>))
+import           System.FilePath
 import           System.Info
 import           System.IO
 import qualified System.Log.Logger                     as L
+
+-- ---------------------------------------------------------------------
+
+import           RunTest
 
 -- ---------------------------------------------------------------------
 -- plugins
@@ -117,6 +123,8 @@ run opts = do
   progName <- getProgName
   args <- getArgs
 
+  let plugins' = plugins (optExamplePlugin opts)
+
   if optLsp opts
     then do
       -- Start up in LSP mode
@@ -136,8 +144,6 @@ run opts = do
       when (optExamplePlugin opts) $
         logm "Enabling Example2 plugin, will insert constant diagnostics etc."
 
-      let plugins' = plugins (optExamplePlugin opts)
-
       -- launch the dispatcher.
       scheduler <- newScheduler plugins' initOpts
       server scheduler origDir plugins' (optCaptureFile opts)
@@ -155,7 +161,39 @@ run opts = do
       ecradle <- getCradleInfo origDir
       case ecradle of
         Left e       -> cliOut $ "Could not get cradle:" ++ show e
-        Right cradle -> cliOut $ "Cradle:" ++ cradleDisplay cradle
+        Right cradle -> do
+          projGhc <- getProjectGhcVersion cradle
+          mlibdir <- getProjectGhcLibDir cradle
+          cliOut ""
+          cliOut ""
+          cliOut "###################################################"
+          cliOut ""
+          cliOut $ "Cradle: " ++ cradleDisplay cradle
+          cliOut $ "Project Ghc version: " ++ projGhc
+          cliOut $ "Libdir: " ++ show mlibdir
+          cliOut "Searching for Haskell source files..."
+          targets <- findAllSourceFiles origDir
+          cliOut $ "Found " ++ show (length targets) ++ " Haskell source files."
+          cliOut "Load them all now. This may take a very long time."
+          cliOut ""
+          cliOut "###################################################"
+          cliOut ""
+          cliOut ""
+          loadDiagnostics <- runServer plugins' targets
+
+          cliOut ""
+          cliOut "###################################################"
+          cliOut "###################################################"
+          cliOut ""
+          cliOut "Dumping diagnostics:"
+          cliOut ""
+          cliOut ""
+          mapM_ (cliOut' . uncurry prettyPrintDiags) loadDiagnostics
+          cliOut ""
+          cliOut ""
+          cliOut ""
+          cliOut "Note: loading of 'Setup.hs' is not supported."
+
 
 -- ---------------------------------------------------------------------
 
@@ -169,5 +207,8 @@ getCradleInfo currentDir = do
 
 cliOut :: String -> IO ()
 cliOut = putStrLn
+
+cliOut' :: T.Text -> IO ()
+cliOut' = T.putStrLn
 
 -- ---------------------------------------------------------------------

--- a/app/RunTest.hs
+++ b/app/RunTest.hs
@@ -10,7 +10,7 @@ module RunTest
 where
 
 import           GhcMonad
-import           GHC
+import qualified GHC
 import           Control.Monad
 import qualified Control.Concurrent.STM        as STM
 import           Data.List                      ( isPrefixOf )
@@ -69,7 +69,7 @@ findFilesRecursively p exclude dir = do
 -- ---------------------------------------------------------------------
 
 compileTarget
-  :: DynFlags
+  :: GHC.DynFlags
   -> FilePath
   -> IdeGhcM (IdeResult (Ghc.Diagnostics, Ghc.AdditionalErrs))
 compileTarget dynFlags fp = do

--- a/app/RunTest.hs
+++ b/app/RunTest.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE OverloadedStrings #-}
+module RunTest
+  ( findAllSourceFiles
+  , compileTarget
+  , runServer
+  , prettyPrintDiags
+  )
+where
+
+import           GhcMonad
+import           GHC
+import qualified Data.Text                     as T
+import           System.Directory               ( doesDirectoryExist
+                                                , listDirectory
+                                                , canonicalizePath
+                                                , getCurrentDirectory
+                                                )
+import           Haskell.Ide.Engine.PluginsIdeMonads
+import qualified Haskell.Ide.Engine.ModuleCache
+                                               as MC
+import qualified Haskell.Ide.Engine.Ghc        as Ghc
+import           System.FilePath
+import           Control.Monad
+import           Data.List                      ( isPrefixOf )
+import           TestUtils                      ( runIGM )
+
+findAllSourceFiles :: FilePath -> IO [FilePath]
+findAllSourceFiles dir = do
+  absDir <- canonicalizePath dir
+  findFilesRecursively isHaskellSource
+                       (\fp -> any (\p -> p fp) [isHidden, isSpecialDir])
+                       absDir
+ where
+  isHaskellSource = (== ".hs") . takeExtension
+  isHidden        = ("." `isPrefixOf`) . takeFileName
+  isSpecialDir    = (== "dist-newstyle") . takeFileName
+
+findFilesRecursively
+  :: (FilePath -> Bool) -> (FilePath -> Bool) -> FilePath -> IO [FilePath]
+findFilesRecursively p exclude dir = do
+  dirContents' <- listDirectory dir
+  let dirContents = map (dir </>) dirContents'
+
+  files <- forM dirContents $ \fp -> do
+    isDirectory <- doesDirectoryExist fp
+    if isDirectory
+      then if not $ exclude fp
+        then findFilesRecursively p exclude fp
+        else return []
+      else if p fp then return [fp] else return []
+
+  return $ concat files
+
+
+-- ---------------------------------------------------------------------
+
+compileTarget
+  :: DynFlags
+  -> FilePath
+  -> IdeGhcM (IdeResult (Ghc.Diagnostics, Ghc.AdditionalErrs))
+compileTarget dynFlags fp = do
+  let pubDiags _ _ _ = return ()
+  let defAction = return (mempty, mempty)
+  let action    = Ghc.setTypecheckedModule (filePathToUri fp)
+  actionResult <- MC.runActionWithContext pubDiags
+                                          dynFlags
+                                          (Just fp)
+                                          defAction
+                                          action
+  return $ join actionResult
+
+-- ---------------------------------------------------------------------
+
+runServer
+  :: IdePlugins
+  -> [FilePath]
+  -> IO [(FilePath, IdeResult (Ghc.Diagnostics, Ghc.AdditionalErrs))]
+runServer ideplugins targets = do
+  cwd <- getCurrentDirectory
+  runIGM ideplugins (cwd </> "File.hs") $ do
+    dynFlags <- getSessionDynFlags
+    mapM (\fp -> (fp, ) <$> compileTarget dynFlags fp) targets
+
+-- ---------------------------------------------------------------------
+
+prettyPrintDiags
+  :: FilePath -> IdeResult (Ghc.Diagnostics, Ghc.AdditionalErrs) -> T.Text
+prettyPrintDiags fp diags =
+    T.pack fp <> ": " <>
+      case diags of
+        IdeResultFail IdeError { ideMessage }  -> "FAILED\n\t" <> ideMessage
+        IdeResultOk (_diags, errs) ->
+          if null errs
+            then "OK"
+            else T.unlines (map (T.append "\t") errs)

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -110,18 +110,23 @@ library
 executable hie
   hs-source-dirs:      app
   main-is:             MainHie.hs
-  other-modules:       Paths_haskell_ide_engine
+  other-modules:       Paths_haskell_ide_engine, RunTest
   autogen-modules:     Paths_haskell_ide_engine
   build-depends:       base
+                     , containers
                      , directory
                      , filepath
+                     , ghc
                      , hie-bios
                      , haskell-ide-engine
                      , haskell-lsp
                      , hie-plugin-api
                      , hslogger
                      , optparse-simple
+                     , text
                      , yaml
+                     -- TODO: this is horrible
+                     , hie-test-utils
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wredundant-constraints
                        -with-rtsopts=-T
   if flag(pedantic)

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -114,19 +114,20 @@ executable hie
   autogen-modules:     Paths_haskell_ide_engine
   build-depends:       base
                      , containers
+                     , data-default
                      , directory
                      , filepath
                      , ghc
                      , hie-bios
                      , haskell-ide-engine
                      , haskell-lsp
+                     , haskell-lsp-types
                      , hie-plugin-api
                      , hslogger
                      , optparse-simple
+                     , stm
                      , text
                      , yaml
-                     -- TODO: this is horrible
-                     , hie-test-utils
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Wredundant-constraints
                        -with-rtsopts=-T
   if flag(pedantic)

--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -57,11 +57,11 @@ globalOptsParser = GlobalOpts
        <> help "Enable Example2 plugin. Useful for developers only")
   <*> flag False True
      (  long "dry-run"
-     <> help "Perform a dry-run of loading files. Only searches for Haskell source files to load."
+     <> help "Perform a dry-run of loading files. Only searches for Haskell source files to load. Does nothing if run as LSP server."
      )
   <*> many
      ( argument str
        (  metavar "FILES..."
-       <> help "Directories and Filepaths to load.")
+       <> help "Directories and Filepaths to load. Does nothing if run as LSP server.")
      )
 

--- a/src/Haskell/Ide/Engine/Options.hs
+++ b/src/Haskell/Ide/Engine/Options.hs
@@ -6,11 +6,13 @@ import           Options.Applicative.Simple
 data GlobalOpts = GlobalOpts
   { optDebugOn       :: Bool
   , optLogFile       :: Maybe String
-  , optLsp           :: Bool -- Kept for a while, to not break legacy clients
+  , optLsp           :: Bool
   , projectRoot      :: Maybe String
   , optBiosVerbose   :: Bool
   , optCaptureFile   :: Maybe FilePath
   , optExamplePlugin :: Bool
+  , optDryRun        :: Bool
+  , optFiles         :: [FilePath]
   } deriving (Show)
 
 globalOptsParser :: Parser GlobalOpts
@@ -53,3 +55,13 @@ globalOptsParser = GlobalOpts
   <*> switch
        ( long "example"
        <> help "Enable Example2 plugin. Useful for developers only")
+  <*> flag False True
+     (  long "dry-run"
+     <> help "Perform a dry-run of loading files. Only searches for Haskell source files to load."
+     )
+  <*> many
+     ( argument str
+       (  metavar "FILES..."
+       <> help "Directories and Filepaths to load.")
+     )
+


### PR DESCRIPTION
Extends PR #1538 

<details>
<summary>
Whole log run (this is huge)
</summary>

```
Running HIE(hie)
  Version 1.0.0.0 x86_64 ghc-8.6.5
To run as a LSP server on stdio, provide the '--lsp' argument
Current directory:/home/baldr/Documents/haskell/fprog

args:["--debug"]

Looking for project config cradle...

2020-01-10 18:58:28.457769468 [ThreadId 4] - Cabal-Helper found these projects: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:28.550718757 [ThreadId 4] - These projects have the build tools installed: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:28.550888573 [ThreadId 4] - Cabal-Helper decided to use: ProjLocV2File {plCabalProjectFile = "/home/baldr/Documents/haskell/fprog/cabal.project", plProjectDirV2 = "/home/baldr/Documents/haskell/fprog"}
2020-01-10 18:58:28.550975131 [ThreadId 4] - Cabal-Helper dirs: ["/home/baldr/Documents/haskell/fprog","/home/baldr/Documents/haskell/fprog/File.hs"]
Resolving dependencies...
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
2020-01-10 18:58:30.413604249 [ThreadId 4] - Cabal-Helper cradle package: Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "intcode"], uiV2Components = ["fprog:exe:intcode"], uiV2OnlyDependencies = False}} :| [Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test", uImpl = UnitImplV2 {uiV2ComponentNames = [ChTestName "fprog-test"], uiV2Components = ["fprog:test:fprog-test"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "fprog"], uiV2Components = ["fprog:exe:fprog"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0", uImpl = UnitImplV2 {uiV2ComponentNames = [ChLibName ChMainLibName], uiV2Components = ["fprog:lib:fprog"], uiV2OnlyDependencies = False}}]}
2020-01-10 18:58:30.413835256 [ThreadId 4] - Cabal-Helper normalisedPackageLocation: /home/baldr/Documents/haskell/fprog
2020-01-10 18:58:30.413886069 [ThreadId 4] - Module "/home/baldr/Documents/haskell/fprog/File.hs" is loaded by Cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:30.414403489 [ThreadId 4] - Use Plain GHC
2020-01-10 18:58:30.45109657 [ThreadId 4] - GHC Output: "Just "8.6.5""
2020-01-10 18:58:30.451686448 [ThreadId 4] - Use Plain GHC
2020-01-10 18:58:30.50581787 [ThreadId 4] - GHC Output: "Just "/nix/store/hg3na12737n7wws1kndxvs95ai88fgn8-ghc-8.6.5/lib/ghc-8.6.5""


###################################################

Cradle: Cabal project
Project Ghc version: 8.6.5
Libdir: Just "/nix/store/hg3na12737n7wws1kndxvs95ai88fgn8-ghc-8.6.5/lib/ghc-8.6.5"
Searching for Haskell source files...
Found 7 Haskell source files.
Load them all now. This may take a very long time.

###################################################


2020-01-10 18:58:30.507041278 [ThreadId 4] - Cabal-Helper found these projects: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:30.507683957 [ThreadId 4] - These projects have the build tools installed: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:30.507786523 [ThreadId 4] - Cabal-Helper decided to use: ProjLocV2File {plCabalProjectFile = "/home/baldr/Documents/haskell/fprog/cabal.project", plProjectDirV2 = "/home/baldr/Documents/haskell/fprog"}
2020-01-10 18:58:30.507835274 [ThreadId 4] - Cabal-Helper dirs: ["/home/baldr/Documents/haskell/fprog","/home/baldr/Documents/haskell/fprog/File.hs"]
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
2020-01-10 18:58:30.752599953 [ThreadId 4] - Cabal-Helper cradle package: Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "intcode"], uiV2Components = ["fprog:exe:intcode"], uiV2OnlyDependencies = False}} :| [Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test", uImpl = UnitImplV2 {uiV2ComponentNames = [ChTestName "fprog-test"], uiV2Components = ["fprog:test:fprog-test"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "fprog"], uiV2Components = ["fprog:exe:fprog"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0", uImpl = UnitImplV2 {uiV2ComponentNames = [ChLibName ChMainLibName], uiV2Components = ["fprog:lib:fprog"], uiV2OnlyDependencies = False}}]}
2020-01-10 18:58:30.752904258 [ThreadId 4] - Cabal-Helper normalisedPackageLocation: /home/baldr/Documents/haskell/fprog
2020-01-10 18:58:30.752959661 [ThreadId 4] - Module "/home/baldr/Documents/haskell/fprog/File.hs" is loaded by Cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:30.753782681 [ThreadId 4] - Use Plain GHC
2020-01-10 18:58:30.803799592 [ThreadId 4] - GHC Output: "Just "/nix/store/hg3na12737n7wws1kndxvs95ai88fgn8-ghc-8.6.5/lib/ghc-8.6.5""
2020-01-10 18:58:30.807877206 [ThreadId 4] - New cradle: /home/baldr/Documents/haskell/fprog/app/Main.hs
2020-01-10 18:58:30.808754127 [ThreadId 4] - Cabal-Helper found these projects: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:30.809444973 [ThreadId 4] - These projects have the build tools installed: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:30.809510649 [ThreadId 4] - Cabal-Helper decided to use: ProjLocV2File {plCabalProjectFile = "/home/baldr/Documents/haskell/fprog/cabal.project", plProjectDirV2 = "/home/baldr/Documents/haskell/fprog"}
2020-01-10 18:58:30.809548957 [ThreadId 4] - Cabal-Helper dirs: ["/home/baldr/Documents/haskell/fprog","/home/baldr/Documents/haskell/fprog/app/Main.hs"]
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
2020-01-10 18:58:31.03522076 [ThreadId 4] - Cabal-Helper cradle package: Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "intcode"], uiV2Components = ["fprog:exe:intcode"], uiV2OnlyDependencies = False}} :| [Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test", uImpl = UnitImplV2 {uiV2ComponentNames = [ChTestName "fprog-test"], uiV2Components = ["fprog:test:fprog-test"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "fprog"], uiV2Components = ["fprog:exe:fprog"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0", uImpl = UnitImplV2 {uiV2ComponentNames = [ChLibName ChMainLibName], uiV2Components = ["fprog:lib:fprog"], uiV2OnlyDependencies = False}}]}
2020-01-10 18:58:31.035441984 [ThreadId 4] - Cabal-Helper normalisedPackageLocation: /home/baldr/Documents/haskell/fprog
2020-01-10 18:58:31.035489714 [ThreadId 4] - Module "/home/baldr/Documents/haskell/fprog/app/Main.hs" is loaded by Cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:31.035531779 [ThreadId 4] - Found cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:31.03558035 [ThreadId 4] - Relative Module FilePath: app/Main.hs
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
Configuring executable 'intcode' for fprog-0.1.0.0..
2020-01-10 18:58:32.554845575 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "intcode",ChComponentInfo {ciComponentName = ChExeName "intcode", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "IntCode.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/setup-config",1578677927)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
 - fprog-0.1.0.0 (test:fprog-test) (first run)
Configuring library for fprog-0.1.0.0..
Preprocessing library for fprog-0.1.0.0..
Building library for fprog-0.1.0.0..
Configuring test suite 'fprog-test' for fprog-0.1.0.0..
2020-01-10 18:58:36.013155703 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChTestName "fprog-test",ChComponentInfo {ciComponentName = ChTestName "fprog-test", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-itest","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["test"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Spec.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Nothing}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
Configuring executable 'fprog' for fprog-0.1.0.0..
2020-01-10 18:58:37.380189923 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "fprog",ChComponentInfo {ciComponentName = ChExeName "fprog", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Main.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/setup-config",1578677933)}}
2020-01-10 18:58:37.38040742 [ThreadId 4] - Flags for "/home/baldr/Documents/haskell/fprog/app/Main.hs": ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-i/home/baldr/Documents/haskell/fprog/app","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N","app/Main.hs"]
2020-01-10 18:58:37.380521503 [ThreadId 4] - Component Infos: ChComponentInfo {ciComponentName = ChExeName "fprog", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Main.hs", chOtherModules = []}}
2020-01-10 18:58:37.594847564 [ThreadId 4] - Modules in the cradle: ["app/Main.hs"]
2020-01-10 18:58:37.594973922 [ThreadId 4] - Cradle set succesfully
2020-01-10 18:58:37.595082052 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:37.595116225 [ThreadId 4] - Loading file
2020-01-10 18:58:37.595163188 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:37.595191662 [ThreadId 4] - Loading file
2020-01-10 18:58:37.60758635 [ThreadId 4] - setTargets: [("/home/baldr/Documents/haskell/fprog/app/Main.hs","/home/baldr/Documents/haskell/fprog/app/Main.hs")]
2020-01-10 18:58:37.608943999 [ThreadId 4] - modGraph: [ModLocation {ml_hs_file = Just "/home/baldr/Documents/haskell/fprog/app/Main.hs", ml_hi_file = "/home/baldr/.cache/hie-bios/da439e9ec6db9b509778fb530230d79379ba87ab/Main.hi", ml_obj_file = "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp/Main.o"}]
2020-01-10 18:58:37.609096614 [ThreadId 4] - init-plugins(loaded):0
2020-01-10 18:58:37.609133005 [ThreadId 4] - init-plugins(specified):0
2020-01-10 18:58:37.612531283 [ThreadId 4] - loaded /home/baldr/Documents/haskell/fprog/app/Main.hs - /home/baldr/Documents/haskell/fprog/app/Main.hs
2020-01-10 18:58:37.612637306 [ThreadId 4] - Typechecked modules for: Just "/home/baldr/Documents/haskell/fprog/app/Main.hs"

2020-01-10 18:58:37.661939954 [ThreadId 4] - File, loaded
2020-01-10 18:58:37.662108996 [ThreadId 4] - setTypecheckedModule: after ghc-mod
2020-01-10 18:58:37.662531627 [ThreadId 4] - Diags: fromList []
2020-01-10 18:58:37.662577587 [ThreadId 4] - setTypecheckedModule: Did get typechecked module for: "/home/baldr/Documents/haskell/fprog/app/Main.hs"
2020-01-10 18:58:37.662803791 [ThreadId 4] - setTypecheckedModule: done
2020-01-10 18:58:37.66288997 [ThreadId 4] - New cradle: /home/baldr/Documents/haskell/fprog/app/IntCode.hs
2020-01-10 18:58:37.663875656 [ThreadId 4] - Cabal-Helper found these projects: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:37.664764176 [ThreadId 4] - These projects have the build tools installed: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:37.664837269 [ThreadId 4] - Cabal-Helper decided to use: ProjLocV2File {plCabalProjectFile = "/home/baldr/Documents/haskell/fprog/cabal.project", plProjectDirV2 = "/home/baldr/Documents/haskell/fprog"}
2020-01-10 18:58:37.664875424 [ThreadId 4] - Cabal-Helper dirs: ["/home/baldr/Documents/haskell/fprog","/home/baldr/Documents/haskell/fprog/app/IntCode.hs"]
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
2020-01-10 18:58:37.871552293 [ThreadId 4] - Cabal-Helper cradle package: Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "intcode"], uiV2Components = ["fprog:exe:intcode"], uiV2OnlyDependencies = False}} :| [Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test", uImpl = UnitImplV2 {uiV2ComponentNames = [ChTestName "fprog-test"], uiV2Components = ["fprog:test:fprog-test"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "fprog"], uiV2Components = ["fprog:exe:fprog"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0", uImpl = UnitImplV2 {uiV2ComponentNames = [ChLibName ChMainLibName], uiV2Components = ["fprog:lib:fprog"], uiV2OnlyDependencies = False}}]}
2020-01-10 18:58:37.871767295 [ThreadId 4] - Cabal-Helper normalisedPackageLocation: /home/baldr/Documents/haskell/fprog
2020-01-10 18:58:37.871810584 [ThreadId 4] - Module "/home/baldr/Documents/haskell/fprog/app/IntCode.hs" is loaded by Cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:37.871852547 [ThreadId 4] - Found cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:37.871892285 [ThreadId 4] - Relative Module FilePath: app/IntCode.hs
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:intcode) (first run)
2020-01-10 18:58:37.966174456 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "intcode",ChComponentInfo {ciComponentName = ChExeName "intcode", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "IntCode.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/setup-config",1578679112)}}
2020-01-10 18:58:37.966386302 [ThreadId 4] - Flags for "/home/baldr/Documents/haskell/fprog/app/IntCode.hs": ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i/home/baldr/Documents/haskell/fprog/app","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N","app/IntCode.hs"]
2020-01-10 18:58:37.966613791 [ThreadId 4] - Component Infos: ChComponentInfo {ciComponentName = ChExeName "intcode", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "IntCode.hs", chOtherModules = []}}
2020-01-10 18:58:38.10525527 [ThreadId 4] - Modules in the cradle: ["app/IntCode.hs"]
2020-01-10 18:58:38.105373398 [ThreadId 4] - Cradle set succesfully
2020-01-10 18:58:38.10547325 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:38.105511468 [ThreadId 4] - Loading file
2020-01-10 18:58:38.105560581 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:38.105595276 [ThreadId 4] - Loading file
2020-01-10 18:58:38.118069678 [ThreadId 4] - setTargets: [("/home/baldr/Documents/haskell/fprog/app/IntCode.hs","/home/baldr/Documents/haskell/fprog/app/IntCode.hs")]
2020-01-10 18:58:38.119712232 [ThreadId 4] - modGraph: [ModLocation {ml_hs_file = Just "/home/baldr/Documents/haskell/fprog/app/IntCode.hs", ml_hi_file = "/home/baldr/.cache/hie-bios/9ef973b6c18a276228376b656cee99672b5c9649/Main.hi", ml_obj_file = "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp/Main.o"}]
2020-01-10 18:58:38.119862135 [ThreadId 4] - init-plugins(loaded):0
2020-01-10 18:58:38.119896313 [ThreadId 4] - init-plugins(specified):0
2020-01-10 18:58:38.132579313 [ThreadId 4] - loaded /home/baldr/Documents/haskell/fprog/app/IntCode.hs - /home/baldr/Documents/haskell/fprog/app/IntCode.hs
2020-01-10 18:58:38.132672501 [ThreadId 4] - Typechecked modules for: Just "/home/baldr/Documents/haskell/fprog/app/IntCode.hs"

2020-01-10 18:58:38.145290875 [ThreadId 4] - File, loaded
2020-01-10 18:58:38.145460278 [ThreadId 4] - setTypecheckedModule: after ghc-mod
2020-01-10 18:58:38.145492293 [ThreadId 4] - Diags: fromList []
2020-01-10 18:58:38.145520209 [ThreadId 4] - setTypecheckedModule: Did get typechecked module for: "/home/baldr/Documents/haskell/fprog/app/IntCode.hs"
2020-01-10 18:58:38.1576353 [ThreadId 4] - setTypecheckedModule: done
2020-01-10 18:58:38.157948287 [ThreadId 4] - New cradle: /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:38.158616922 [ThreadId 4] - Cabal-Helper found these projects: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:38.159630565 [ThreadId 4] - These projects have the build tools installed: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:38.159735063 [ThreadId 4] - Cabal-Helper decided to use: ProjLocV2File {plCabalProjectFile = "/home/baldr/Documents/haskell/fprog/cabal.project", plProjectDirV2 = "/home/baldr/Documents/haskell/fprog"}
2020-01-10 18:58:38.159774682 [ThreadId 4] - Cabal-Helper dirs: ["/home/baldr/Documents/haskell/fprog","/home/baldr/Documents/haskell/fprog/src/Angabe6.hs"]
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
2020-01-10 18:58:38.364916956 [ThreadId 4] - Cabal-Helper cradle package: Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "intcode"], uiV2Components = ["fprog:exe:intcode"], uiV2OnlyDependencies = False}} :| [Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test", uImpl = UnitImplV2 {uiV2ComponentNames = [ChTestName "fprog-test"], uiV2Components = ["fprog:test:fprog-test"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "fprog"], uiV2Components = ["fprog:exe:fprog"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0", uImpl = UnitImplV2 {uiV2ComponentNames = [ChLibName ChMainLibName], uiV2Components = ["fprog:lib:fprog"], uiV2OnlyDependencies = False}}]}
2020-01-10 18:58:38.365127826 [ThreadId 4] - Cabal-Helper normalisedPackageLocation: /home/baldr/Documents/haskell/fprog
2020-01-10 18:58:38.365173012 [ThreadId 4] - Module "/home/baldr/Documents/haskell/fprog/src/Angabe6.hs" is loaded by Cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:38.365211818 [ThreadId 4] - Found cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:38.365249736 [ThreadId 4] - Relative Module FilePath: src/Angabe6.hs
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:intcode) (first run)
2020-01-10 18:58:38.45787588 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "intcode",ChComponentInfo {ciComponentName = ChExeName "intcode", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "IntCode.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/setup-config",1578679112)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (test:fprog-test) (first run)
2020-01-10 18:58:38.554983384 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChTestName "fprog-test",ChComponentInfo {ciComponentName = ChTestName "fprog-test", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-itest","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["test"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Spec.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/setup-config",1578679115)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:fprog) (first run)
2020-01-10 18:58:38.651680784 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "fprog",ChComponentInfo {ciComponentName = ChExeName "fprog", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Main.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/setup-config",1578679117)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
Configuring library for fprog-0.1.0.0..
2020-01-10 18:58:40.026636872 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChLibName ChMainLibName,ChComponentInfo {ciComponentName = ChLibName ChMainLibName, ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-isrc","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen/cabal_macros.h","-this-unit-id","fprog-0.1.0.0-inplace","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","containers-0.6.0.1","-package-id","data-ordlist-0.4.7.0-edfad0a73e8bb2e547e8229677ac705f4953307bfef71cc34e9f4922f7597bc2","-package-id","unordered-containers-0.2.10.0-50457b032495e76b370911744967d8e1b4ca7d2db037d25f830c43e5bb3280e7","-XHaskell2010","-XNamedFieldPuns"], ciSourceDirs = ["src"], ciEntrypoints = ChLibEntrypoint {chExposedModules = [ChModuleName {unChModuleName = "Lib"},ChModuleName {unChModuleName = "Angabe6"}], chOtherModules = [], chSignatures = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/setup-config",1578679113)}}
2020-01-10 18:58:40.026948098 [ThreadId 4] - Flags for "/home/baldr/Documents/haskell/fprog/src/Angabe6.hs": ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-i/home/baldr/Documents/haskell/fprog/src","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen/cabal_macros.h","-this-unit-id","fprog-0.1.0.0-inplace","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","containers-0.6.0.1","-package-id","data-ordlist-0.4.7.0-edfad0a73e8bb2e547e8229677ac705f4953307bfef71cc34e9f4922f7597bc2","-package-id","unordered-containers-0.2.10.0-50457b032495e76b370911744967d8e1b4ca7d2db037d25f830c43e5bb3280e7","-XHaskell2010","-XNamedFieldPuns","Lib","Angabe6"]
2020-01-10 18:58:40.027258033 [ThreadId 4] - Component Infos: ChComponentInfo {ciComponentName = ChLibName ChMainLibName, ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-isrc","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen/cabal_macros.h","-this-unit-id","fprog-0.1.0.0-inplace","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","containers-0.6.0.1","-package-id","data-ordlist-0.4.7.0-edfad0a73e8bb2e547e8229677ac705f4953307bfef71cc34e9f4922f7597bc2","-package-id","unordered-containers-0.2.10.0-50457b032495e76b370911744967d8e1b4ca7d2db037d25f830c43e5bb3280e7","-XHaskell2010","-XNamedFieldPuns"], ciSourceDirs = ["src"], ciEntrypoints = ChLibEntrypoint {chExposedModules = [ChModuleName {unChModuleName = "Lib"},ChModuleName {unChModuleName = "Angabe6"}], chOtherModules = [], chSignatures = []}}
2020-01-10 18:58:40.12531783 [ThreadId 4] - Modules in the cradle: ["/home/baldr/Documents/haskell/fprog/src/Angabe6.hs","/home/baldr/Documents/haskell/fprog/src/Lib.hs"]
2020-01-10 18:58:40.125476419 [ThreadId 4] - Cradle set succesfully
2020-01-10 18:58:40.125590625 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:40.12562655 [ThreadId 4] - Loading file
2020-01-10 18:58:40.125677693 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:40.125713433 [ThreadId 4] - Loading file
2020-01-10 18:58:40.139102764 [ThreadId 4] - setTargets: [("/home/baldr/Documents/haskell/fprog/src/Angabe6.hs","/home/baldr/Documents/haskell/fprog/src/Angabe6.hs")]
2020-01-10 18:58:40.140101049 [ThreadId 4] - modGraph: [ModLocation {ml_hs_file = Just "/home/baldr/Documents/haskell/fprog/src/Angabe6.hs", ml_hi_file = "/home/baldr/.cache/hie-bios/9f3ed281538579a9c0becae632e5bca259b38476/Angabe6.hi", ml_obj_file = "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/Angabe6.o"}]
2020-01-10 18:58:40.140230229 [ThreadId 4] - init-plugins(loaded):0
2020-01-10 18:58:40.140263445 [ThreadId 4] - init-plugins(specified):0
2020-01-10 18:58:40.150320224 [ThreadId 4] - srcSpan2Loc: mapped file is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.150457469 [ThreadId 4] - reverseMapFile: mapped file is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.150497491 [ThreadId 4] - reverseMapFile: original is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.150554829 [ThreadId 4] - reverseMapFile: Canonicalized original is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.150585276 [ThreadId 4] - srcSpan2Loc: Original file is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.150617888 [ThreadId 4] - Diagnostics at Location: (RealSrcSpan SrcSpanOneLine "/home/baldr/Documents/haskell/fprog/src/Angabe6.hs" 31 1 29,Right (Location {_uri = Uri {getUri = "file:///home/baldr/Documents/haskell/fprog/src/Angabe6.hs"}, _range = Range {_start = Position {_line = 30, _character = 0}, _end = Position {_line = 30, _character = 28}}}))
2020-01-10 18:58:40.150682946 [ThreadId 4] - Writing diag Diagnostic {_range = Range {_start = Position {_line = 30, _character = 0}, _end = Position {_line = 30, _character = 28}}, _severity = Just DsWarning, _code = Nothing, _source = Just "bios", _message = "Pattern match is redundant\nIn an equation for \8216p\8217: p (a : b : l) = ...", _relatedInformation = Nothing}
2020-01-10 18:58:40.151083032 [ThreadId 4] - srcSpan2Loc: mapped file is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.151150923 [ThreadId 4] - reverseMapFile: mapped file is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.151186917 [ThreadId 4] - reverseMapFile: original is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.151241318 [ThreadId 4] - reverseMapFile: Canonicalized original is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.151270416 [ThreadId 4] - srcSpan2Loc: Original file is /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.15130208 [ThreadId 4] - Diagnostics at Location: (RealSrcSpan SrcSpanOneLine "/home/baldr/Documents/haskell/fprog/src/Angabe6.hs" 32 1 15,Right (Location {_uri = Uri {getUri = "file:///home/baldr/Documents/haskell/fprog/src/Angabe6.hs"}, _range = Range {_start = Position {_line = 31, _character = 0}, _end = Position {_line = 31, _character = 14}}}))
2020-01-10 18:58:40.151357031 [ThreadId 4] - Writing diag Diagnostic {_range = Range {_start = Position {_line = 31, _character = 0}, _end = Position {_line = 31, _character = 14}}, _severity = Just DsWarning, _code = Nothing, _source = Just "bios", _message = "Pattern match is redundant\nIn an equation for \8216p\8217: p [e] = ...", _relatedInformation = Nothing}
2020-01-10 18:58:40.152028887 [ThreadId 4] - loaded /home/baldr/Documents/haskell/fprog/src/Angabe6.hs - /home/baldr/Documents/haskell/fprog/src/Angabe6.hs
2020-01-10 18:58:40.15207566 [ThreadId 4] - Typechecked modules for: Just "/home/baldr/Documents/haskell/fprog/src/Angabe6.hs"

2020-01-10 18:58:40.166307729 [ThreadId 4] - File, loaded
2020-01-10 18:58:40.16647688 [ThreadId 4] - setTypecheckedModule: after ghc-mod
2020-01-10 18:58:40.166511745 [ThreadId 4] - Diags: fromList [(NormalizedUri "file:///home/baldr/Documents/haskell/fprog/src/Angabe6.hs",fromList [Diagnostic {_range = Range {_start = Position {_line = 30, _character = 0}, _end = Position {_line = 30, _character = 28}}, _severity = Just DsWarning, _code = Nothing, _source = Just "bios", _message = "Pattern match is redundant\nIn an equation for \8216p\8217: p (a : b : l) = ...", _relatedInformation = Nothing},Diagnostic {_range = Range {_start = Position {_line = 31, _character = 0}, _end = Position {_line = 31, _character = 14}}, _severity = Just DsWarning, _code = Nothing, _source = Just "bios", _message = "Pattern match is redundant\nIn an equation for \8216p\8217: p [e] = ...", _relatedInformation = Nothing}])]
2020-01-10 18:58:40.166580587 [ThreadId 4] - setTypecheckedModule: Did get typechecked module for: "/home/baldr/Documents/haskell/fprog/src/Angabe6.hs"
2020-01-10 18:58:40.174703335 [ThreadId 4] - setTypecheckedModule: done
2020-01-10 18:58:40.174875277 [ThreadId 4] - Reusing cradle
2020-01-10 18:58:40.17514434 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:40.175180515 [ThreadId 4] - Loading file
2020-01-10 18:58:40.175221265 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:40.175248273 [ThreadId 4] - Loading file
2020-01-10 18:58:40.187565697 [ThreadId 4] - setTargets: [("/home/baldr/Documents/haskell/fprog/src/Lib.hs","/home/baldr/Documents/haskell/fprog/src/Lib.hs")]
2020-01-10 18:58:40.189522238 [ThreadId 4] - modGraph: [ModLocation {ml_hs_file = Just "/home/baldr/Documents/haskell/fprog/src/Angabe6.hs", ml_hi_file = "/home/baldr/.cache/hie-bios/9f3ed281538579a9c0becae632e5bca259b38476/Angabe6.hi", ml_obj_file = "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/Angabe6.o"},ModLocation {ml_hs_file = Just "/home/baldr/Documents/haskell/fprog/src/Lib.hs", ml_hi_file = "/home/baldr/.cache/hie-bios/9f3ed281538579a9c0becae632e5bca259b38476/Lib.hi", ml_obj_file = "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/Lib.o"}]
2020-01-10 18:58:40.189685078 [ThreadId 4] - init-plugins(loaded):0
2020-01-10 18:58:40.189721901 [ThreadId 4] - init-plugins(specified):0
2020-01-10 18:58:40.198809943 [ThreadId 4] - loaded /home/baldr/Documents/haskell/fprog/src/Lib.hs - /home/baldr/Documents/haskell/fprog/src/Lib.hs
2020-01-10 18:58:40.198902261 [ThreadId 4] - Typechecked modules for: Just "/home/baldr/Documents/haskell/fprog/src/Lib.hs"

2020-01-10 18:58:40.211201796 [ThreadId 4] - File, loaded
2020-01-10 18:58:40.211875713 [ThreadId 4] - setTypecheckedModule: after ghc-mod
2020-01-10 18:58:40.211912867 [ThreadId 4] - Diags: fromList []
2020-01-10 18:58:40.211944184 [ThreadId 4] - setTypecheckedModule: Did get typechecked module for: "/home/baldr/Documents/haskell/fprog/src/Lib.hs"
2020-01-10 18:58:40.215688879 [ThreadId 4] - setTypecheckedModule: done
2020-01-10 18:58:40.215811462 [ThreadId 4] - New cradle: /home/baldr/Documents/haskell/fprog/install.hs
2020-01-10 18:58:40.216519412 [ThreadId 4] - Cabal-Helper found these projects: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:40.217132038 [ThreadId 4] - These projects have the build tools installed: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:40.217215677 [ThreadId 4] - Cabal-Helper decided to use: ProjLocV2File {plCabalProjectFile = "/home/baldr/Documents/haskell/fprog/cabal.project", plProjectDirV2 = "/home/baldr/Documents/haskell/fprog"}
2020-01-10 18:58:40.217244562 [ThreadId 4] - Cabal-Helper dirs: ["/home/baldr/Documents/haskell/fprog","/home/baldr/Documents/haskell/fprog/install.hs"]
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
2020-01-10 18:58:40.426543598 [ThreadId 4] - Cabal-Helper cradle package: Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "intcode"], uiV2Components = ["fprog:exe:intcode"], uiV2OnlyDependencies = False}} :| [Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test", uImpl = UnitImplV2 {uiV2ComponentNames = [ChTestName "fprog-test"], uiV2Components = ["fprog:test:fprog-test"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "fprog"], uiV2Components = ["fprog:exe:fprog"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0", uImpl = UnitImplV2 {uiV2ComponentNames = [ChLibName ChMainLibName], uiV2Components = ["fprog:lib:fprog"], uiV2OnlyDependencies = False}}]}
2020-01-10 18:58:40.426834211 [ThreadId 4] - Cabal-Helper normalisedPackageLocation: /home/baldr/Documents/haskell/fprog
2020-01-10 18:58:40.426890854 [ThreadId 4] - Module "/home/baldr/Documents/haskell/fprog/install.hs" is loaded by Cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:40.42695376 [ThreadId 4] - Found cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:40.427017027 [ThreadId 4] - Relative Module FilePath: install.hs
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:intcode) (first run)
2020-01-10 18:58:40.522273771 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "intcode",ChComponentInfo {ciComponentName = ChExeName "intcode", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "IntCode.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/setup-config",1578679112)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
 - fprog-0.1.0.0 (test:fprog-test) (dependency rebuilt)
Configuring library for fprog-0.1.0.0..
Preprocessing library for fprog-0.1.0.0..
Building library for fprog-0.1.0.0..
2020-01-10 18:58:42.698674287 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChTestName "fprog-test",ChComponentInfo {ciComponentName = ChTestName "fprog-test", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-itest","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["test"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Spec.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/setup-config",1578679115)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:fprog) (first run)
2020-01-10 18:58:42.797551453 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "fprog",ChComponentInfo {ciComponentName = ChExeName "fprog", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Main.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/setup-config",1578679117)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
Configuring library for fprog-0.1.0.0..
2020-01-10 18:58:44.184874374 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChLibName ChMainLibName,ChComponentInfo {ciComponentName = ChLibName ChMainLibName, ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-isrc","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen/cabal_macros.h","-this-unit-id","fprog-0.1.0.0-inplace","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","containers-0.6.0.1","-package-id","data-ordlist-0.4.7.0-edfad0a73e8bb2e547e8229677ac705f4953307bfef71cc34e9f4922f7597bc2","-package-id","unordered-containers-0.2.10.0-50457b032495e76b370911744967d8e1b4ca7d2db037d25f830c43e5bb3280e7","-XHaskell2010","-XNamedFieldPuns"], ciSourceDirs = ["src"], ciEntrypoints = ChLibEntrypoint {chExposedModules = [ChModuleName {unChModuleName = "Lib"},ChModuleName {unChModuleName = "Angabe6"}], chOtherModules = [], chSignatures = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/setup-config",1578679121)}}
2020-01-10 18:58:44.18509419 [ThreadId 4] - Fail on cradle initialisation: (ExitFailure 2)["Could not obtain flags for: \"install.hs\".","","This module was not part of any component we are aware of.","","Component: ChLibName ChMainLibName with source directory: [\"src\"]","Component: ChExeName \"fprog\" with source directory: [\"app\"]","Component: ChTestName \"fprog-test\" with source directory: [\"test\"]","Component: ChExeName \"intcode\" with source directory: [\"app\"]","","","To expose a module, refer to:","https://www.haskell.org/cabal/users-guide/developing-packages.html",""]
2020-01-10 18:58:44.185230384 [ThreadId 4] - New cradle: /home/baldr/Documents/haskell/fprog/test/Spec.hs
2020-01-10 18:58:44.186048613 [ThreadId 4] - Cabal-Helper found these projects: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:44.186797885 [ThreadId 4] - These projects have the build tools installed: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:44.186858585 [ThreadId 4] - Cabal-Helper decided to use: ProjLocV2File {plCabalProjectFile = "/home/baldr/Documents/haskell/fprog/cabal.project", plProjectDirV2 = "/home/baldr/Documents/haskell/fprog"}
2020-01-10 18:58:44.186890384 [ThreadId 4] - Cabal-Helper dirs: ["/home/baldr/Documents/haskell/fprog","/home/baldr/Documents/haskell/fprog/test/Spec.hs"]
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
2020-01-10 18:58:44.391453147 [ThreadId 4] - Cabal-Helper cradle package: Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "intcode"], uiV2Components = ["fprog:exe:intcode"], uiV2OnlyDependencies = False}} :| [Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test", uImpl = UnitImplV2 {uiV2ComponentNames = [ChTestName "fprog-test"], uiV2Components = ["fprog:test:fprog-test"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "fprog"], uiV2Components = ["fprog:exe:fprog"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0", uImpl = UnitImplV2 {uiV2ComponentNames = [ChLibName ChMainLibName], uiV2Components = ["fprog:lib:fprog"], uiV2OnlyDependencies = False}}]}
2020-01-10 18:58:44.391702545 [ThreadId 4] - Cabal-Helper normalisedPackageLocation: /home/baldr/Documents/haskell/fprog
2020-01-10 18:58:44.391750795 [ThreadId 4] - Module "/home/baldr/Documents/haskell/fprog/test/Spec.hs" is loaded by Cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:44.391793385 [ThreadId 4] - Found cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:44.391834579 [ThreadId 4] - Relative Module FilePath: test/Spec.hs
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:intcode) (first run)
2020-01-10 18:58:44.488999646 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "intcode",ChComponentInfo {ciComponentName = ChExeName "intcode", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "IntCode.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/setup-config",1578679112)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
 - fprog-0.1.0.0 (test:fprog-test) (dependency rebuilt)
Configuring library for fprog-0.1.0.0..
Preprocessing library for fprog-0.1.0.0..
Building library for fprog-0.1.0.0..
2020-01-10 18:58:46.674914612 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChTestName "fprog-test",ChComponentInfo {ciComponentName = ChTestName "fprog-test", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-itest","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["test"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Spec.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/setup-config",1578679115)}}
2020-01-10 18:58:46.675236976 [ThreadId 4] - Flags for "/home/baldr/Documents/haskell/fprog/test/Spec.hs": ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-i/home/baldr/Documents/haskell/fprog/test","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N","test/Spec.hs"]
2020-01-10 18:58:46.675621255 [ThreadId 4] - Component Infos: ChComponentInfo {ciComponentName = ChTestName "fprog-test", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-itest","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["test"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Spec.hs", chOtherModules = []}}
2020-01-10 18:58:46.725670484 [ThreadId 4] - Modules in the cradle: ["test/Spec.hs"]
2020-01-10 18:58:46.725785183 [ThreadId 4] - Cradle set succesfully
2020-01-10 18:58:46.725894513 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:46.725932378 [ThreadId 4] - Loading file
2020-01-10 18:58:46.725987342 [ThreadId 4] - setTypecheckedModule: before ghc-mod
2020-01-10 18:58:46.726026777 [ThreadId 4] - Loading file
2020-01-10 18:58:46.740185897 [ThreadId 4] - setTargets: [("/home/baldr/Documents/haskell/fprog/test/Spec.hs","/home/baldr/Documents/haskell/fprog/test/Spec.hs")]
2020-01-10 18:58:46.741097268 [ThreadId 4] - modGraph: [ModLocation {ml_hs_file = Just "/home/baldr/Documents/haskell/fprog/test/Spec.hs", ml_hi_file = "/home/baldr/.cache/hie-bios/6d2ef039accc33e25d732c1d3680bfa220874eb4/Main.hi", ml_obj_file = "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp/Main.o"}]
2020-01-10 18:58:46.741245086 [ThreadId 4] - init-plugins(loaded):0
2020-01-10 18:58:46.741279262 [ThreadId 4] - init-plugins(specified):0
2020-01-10 18:58:46.743745315 [ThreadId 4] - loaded /home/baldr/Documents/haskell/fprog/test/Spec.hs - /home/baldr/Documents/haskell/fprog/test/Spec.hs
2020-01-10 18:58:46.743841309 [ThreadId 4] - Typechecked modules for: Just "/home/baldr/Documents/haskell/fprog/test/Spec.hs"

2020-01-10 18:58:46.757327789 [ThreadId 4] - File, loaded
2020-01-10 18:58:46.757858017 [ThreadId 4] - setTypecheckedModule: after ghc-mod
2020-01-10 18:58:46.757898233 [ThreadId 4] - Diags: fromList []
2020-01-10 18:58:46.75792803 [ThreadId 4] - setTypecheckedModule: Did get typechecked module for: "/home/baldr/Documents/haskell/fprog/test/Spec.hs"
2020-01-10 18:58:46.758164519 [ThreadId 4] - setTypecheckedModule: done
2020-01-10 18:58:46.758249459 [ThreadId 4] - New cradle: /home/baldr/Documents/haskell/fprog/Setup.hs
2020-01-10 18:58:46.759263605 [ThreadId 4] - Cabal-Helper found these projects: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:46.760075567 [ThreadId 4] - These projects have the build tools installed: ["ProjLocV2File {plCabalProjectFile = \"/home/baldr/Documents/haskell/fprog/cabal.project\", plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocStackYaml {plStackYaml = \"/home/baldr/Documents/haskell/fprog/stack.yaml\"}","ProjLocV2Dir {plProjectDirV2 = \"/home/baldr/Documents/haskell/fprog\"}","ProjLocV1Dir {plProjectDirV1 = \"/home/baldr/Documents/haskell/fprog\"}"]
2020-01-10 18:58:46.760139798 [ThreadId 4] - Cabal-Helper decided to use: ProjLocV2File {plCabalProjectFile = "/home/baldr/Documents/haskell/fprog/cabal.project", plProjectDirV2 = "/home/baldr/Documents/haskell/fprog"}
2020-01-10 18:58:46.760174569 [ThreadId 4] - Cabal-Helper dirs: ["/home/baldr/Documents/haskell/fprog","/home/baldr/Documents/haskell/fprog/Setup.hs"]
Build profile: -w ghc-8.6.5 -O1
In order, the following would be built (use -v for more details):
 - fprog-0.1.0.0 (exe:fprog) (configuration changed)
 - fprog-0.1.0.0 (exe:intcode) (configuration changed)
2020-01-10 18:58:46.963827457 [ThreadId 4] - Cabal-Helper cradle package: Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "intcode"], uiV2Components = ["fprog:exe:intcode"], uiV2OnlyDependencies = False}} :| [Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test", uImpl = UnitImplV2 {uiV2ComponentNames = [ChTestName "fprog-test"], uiV2Components = ["fprog:test:fprog-test"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog", uImpl = UnitImplV2 {uiV2ComponentNames = [ChExeName "fprog"], uiV2Components = ["fprog:exe:fprog"], uiV2OnlyDependencies = False}},Unit {uUnitId = UnitId "fprog-0.1.0.0-inplace", uPackage = Package {pPackageName = "fprog", pSourceDir = "/home/baldr/Documents/haskell/fprog/.", pCabalFile = CabalFile "/home/baldr/Documents/haskell/fprog/./fprog.cabal", pFlags = [], pUnits = ()}, uDistDir = DistDirLib "/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0", uImpl = UnitImplV2 {uiV2ComponentNames = [ChLibName ChMainLibName], uiV2Components = ["fprog:lib:fprog"], uiV2OnlyDependencies = False}}]}
2020-01-10 18:58:46.9640431 [ThreadId 4] - Cabal-Helper normalisedPackageLocation: /home/baldr/Documents/haskell/fprog
2020-01-10 18:58:46.964086645 [ThreadId 4] - Module "/home/baldr/Documents/haskell/fprog/Setup.hs" is loaded by Cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:46.964129136 [ThreadId 4] - Found cradle: Cradle {cradleRootDir = "/home/baldr/Documents/haskell/fprog", cradleOptsProg = CradleAction: Cabal-Helper-Cabal-V2}
2020-01-10 18:58:46.964165234 [ThreadId 4] - Relative Module FilePath: Setup.hs
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:intcode) (first run)
2020-01-10 18:58:47.058202448 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-intcode", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "intcode",ChComponentInfo {ciComponentName = ChExeName "intcode", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/intcode-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/build/intcode/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "IntCode.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/intcode/setup-config",1578679112)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (test:fprog-test) (first run)
2020-01-10 18:58:47.156270073 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog-test", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChTestName "fprog-test",ChComponentInfo {ciComponentName = ChTestName "fprog-test", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-itest","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/fprog-test-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/build/fprog-test/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["test"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Spec.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/t/fprog-test/setup-config",1578679115)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (exe:fprog) (first run)
2020-01-10 18:58:47.252604729 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace-fprog", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChExeName "fprog",ChComponentInfo {ciComponentName = ChExeName "fprog", ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-iapp","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/fprog-tmp","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/build/fprog/autogen/cabal_macros.h","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","fprog-0.1.0.0-inplace","-XHaskell2010","-threaded","-rtsopts","-with-rtsopts=-N"], ciSourceDirs = ["app"], ciEntrypoints = ChExeEntrypoint {chMainIs = "Main.hs", chOtherModules = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/x/fprog/setup-config",1578679117)}}
Build profile: -w ghc-8.6.5 -O1
In order, the following will be built (use -v for more details):
 - fprog-0.1.0.0 (lib) (configuration changed)
Configuring library for fprog-0.1.0.0..
2020-01-10 18:58:48.649470217 [ThreadId 4] - Unit Info: UnitInfo {uiUnitId = UnitId "fprog-0.1.0.0-inplace", uiPackageId = ("fprog",Version {versionBranch = [0,1,0,0], versionTags = []}), uiComponents = fromList [(ChLibName ChMainLibName,ChComponentInfo {ciComponentName = ChLibName ChMainLibName, ciGhcOptions = ["-fbuilding-cabal-package","-O","-outputdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-odir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-hidir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-stubdir","/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-i","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-isrc","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-i/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/global-autogen","-I/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build","-optP-include","-optP/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/build/autogen/cabal_macros.h","-this-unit-id","fprog-0.1.0.0-inplace","-hide-all-packages","-Wmissing-home-modules","-no-user-package-db","-package-db","/home/baldr/.cabal/store/ghc-8.6.5/package.db","-package-db","/home/baldr/Documents/haskell/fprog/dist-newstyle/packagedb/ghc-8.6.5","-package-id","base-4.12.0.0","-package-id","containers-0.6.0.1","-package-id","data-ordlist-0.4.7.0-edfad0a73e8bb2e547e8229677ac705f4953307bfef71cc34e9f4922f7597bc2","-package-id","unordered-containers-0.2.10.0-50457b032495e76b370911744967d8e1b4ca7d2db037d25f830c43e5bb3280e7","-XHaskell2010","-XNamedFieldPuns"], ciSourceDirs = ["src"], ciEntrypoints = ChLibEntrypoint {chExposedModules = [ChModuleName {unChModuleName = "Lib"},ChModuleName {unChModuleName = "Angabe6"}], chOtherModules = [], chSignatures = []}})], uiCompilerId = ("GHC",Version {versionBranch = [8,6,5], versionTags = []}), uiPackageFlags = [], uiConfigFlags = [], uiNonDefaultConfigFlags = [], uiModTimes = UnitModTimes {umtPkgYaml = Nothing, umtCabalFile = ("/home/baldr/Documents/haskell/fprog/./fprog.cabal",1578678630), umtSetupConfig = Just ("/home/baldr/Documents/haskell/fprog/dist-newstyle/build/x86_64-linux/ghc-8.6.5/fprog-0.1.0.0/setup-config",1578679125)}}
2020-01-10 18:58:48.649681707 [ThreadId 4] - Fail on cradle initialisation: (ExitFailure 2)["Could not obtain flags for: \"Setup.hs\".","","This module was not part of any component we are aware of.","","Component: ChLibName ChMainLibName with source directory: [\"src\"]","Component: ChExeName \"fprog\" with source directory: [\"app\"]","Component: ChTestName \"fprog-test\" with source directory: [\"test\"]","Component: ChExeName \"intcode\" with source directory: [\"app\"]","","","To expose a module, refer to:","https://www.haskell.org/cabal/users-guide/developing-packages.html",""]

###################################################
###################################################

Dumping diagnostics:


/home/baldr/Documents/haskell/fprog/app/Main.hs: OK
/home/baldr/Documents/haskell/fprog/app/IntCode.hs: OK
/home/baldr/Documents/haskell/fprog/src/Angabe6.hs: OK
/home/baldr/Documents/haskell/fprog/src/Lib.hs: OK
/home/baldr/Documents/haskell/fprog/install.hs: FAILED
	Fail on initialisation for "/home/baldr/Documents/haskell/fprog/install.hs". Could not obtain flags for: "install.hs".
/home/baldr/Documents/haskell/fprog/test/Spec.hs: OK
/home/baldr/Documents/haskell/fprog/Setup.hs: FAILED
	Fail on initialisation for "/home/baldr/Documents/haskell/fprog/Setup.hs". Could not obtain flags for: "Setup.hs".



Note: loading of 'Setup.hs' is not supported.
```

</details>

Example Output in short:
```
Running HIE(hie)
  Version 1.0.0.0 x86_64 ghc-8.6.5
To run as a LSP server on stdio, provide the '--lsp' argument
Current directory:/home/baldr/Documents/haskell/fprog

args:["--debug"]

Looking for project config cradle...

###################################################

Cradle: Cabal project
Project Ghc version: 8.6.5
Libdir: Just "/nix/store/hg3na12737n7wws1kndxvs95ai88fgn8-ghc-8.6.5/lib/ghc-8.6.5"
Searching for Haskell source files...
Found 7 Haskell source files.
Load them all now. This may take a very long time.

###################################################

<Massive amount of logs>

###################################################
###################################################

Dumping diagnostics:


/home/baldr/Documents/haskell/fprog/app/Main.hs: OK
/home/baldr/Documents/haskell/fprog/app/IntCode.hs: OK
/home/baldr/Documents/haskell/fprog/src/Angabe6.hs: OK
/home/baldr/Documents/haskell/fprog/src/Lib.hs: OK
/home/baldr/Documents/haskell/fprog/install.hs: FAILED
	Fail on initialisation for "/home/baldr/Documents/haskell/fprog/install.hs". Could not obtain flags for: "install.hs".
/home/baldr/Documents/haskell/fprog/test/Spec.hs: OK
/home/baldr/Documents/haskell/fprog/Setup.hs: FAILED
	Fail on initialisation for "/home/baldr/Documents/haskell/fprog/Setup.hs". Could not obtain flags for: "Setup.hs".



Note: loading of 'Setup.hs' is not supported.
```

TODO:
* [x] Dont depend on `hie-test-utils`
* [x] Allow optional filepath argument to only load a certain file or directory.
* [x] ~~Grouping of modules into components.~~ Will not make sense if a module is not correctly matched to a component and has a doubtful use.

To discuss:
~~Do we want colour? (possible with Windows?)~~ Maybe follow-up PR.
Extra exposed module ok, or should everything be inline in `MainHie.hs`?

Adds:
* Extends Debug functionality.
* Dry-Run flag to only search for filepaths to load.
* Actually loading all source files in the current directory or in one of the given directories.