### PR TITLE
Pass Ormolu cradle flags & default-extensions

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcModuleCache.hs
@@ -100,10 +100,16 @@ data LookupCradleResult = ReuseCradle | LoadCradle CachedCradle | NewCradle File
 lookupCradle :: FilePath -> GhcModuleCache -> LookupCradleResult
 lookupCradle fp gmc =
   case currentCradle gmc of
-    Just (dirs, _c) | (any (\d -> d `isPrefixOf` fp) dirs) -> ReuseCradle
+    Just (dirs, _c) | any (`isPrefixOf` fp) dirs -> ReuseCradle
     _ -> case T.match (cradleCache gmc) (B.pack fp) of
            Just (_k, c, _suf) -> LoadCradle c
            Nothing  -> NewCradle fp
+
+getCachedCradle :: GhcModuleCache -> FilePath -> Maybe BIOS.Cradle
+getCachedCradle gmc fp = case lookupCradle fp gmc of
+                     ReuseCradle -> snd <$> currentCradle gmc
+                     LoadCradle (CachedCradle c _) -> Just c
+                     NewCradle _ -> Nothing
 
 data CachedCradle = CachedCradle BIOS.Cradle HscEnv
 

--- a/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/PluginsIdeMonads.hs
@@ -134,6 +134,8 @@ import           Haskell.Ide.Engine.Config
 import           Haskell.Ide.Engine.GhcModuleCache
 import           Haskell.Ide.Engine.MultiThreadState
 
+import           HIE.Bios
+
 import qualified Language.Haskell.LSP.Core     as Core
 import           Language.Haskell.LSP.Types.Capabilities
 import           Language.Haskell.LSP.Types     ( Command(..)
@@ -261,6 +263,7 @@ data FormattingType = FormatText
 -- and file uri, does not suffice.
 type FormattingProvider = T.Text -- ^ Text to format
         -> Uri -- ^ Uri of the file being formatted
+        -> Maybe Cradle -- ^ HIE.Bios Cradle containing the file being formatted
         -> FormattingType  -- ^ How much to format
         -> FormattingOptions -- ^ Options for the formatter
         -> IdeM (IdeResult [TextEdit]) -- ^ Result of the formatting or the unchanged text.

--- a/src/Haskell/Ide/Engine/Plugin/Brittany.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Brittany.hs
@@ -35,14 +35,8 @@ brittanyDescriptor plId = PluginDescriptor
 -- | Formatter provider of Brittany.
 -- Formats the given source in either a given Range or the whole Document.
 -- If the provider fails an error is returned that can be displayed to the user.
-provider
-  :: MonadIO m
-  => Text
-  -> Uri
-  -> FormattingType
-  -> FormattingOptions
-  -> m (IdeResult [TextEdit])
-provider text uri formatType opts = pluginGetFile "brittanyCmd: " uri $ \fp -> do
+provider :: FormattingProvider
+provider text uri _ formatType opts = pluginGetFile "brittanyCmd: " uri $ \fp -> do
   confFile <- liftIO $ getConfFile fp
   let (range, selectedContents) = case formatType of
         FormatText    -> (fullRange text, text)

--- a/src/Haskell/Ide/Engine/Plugin/Floskell.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Floskell.hs
@@ -32,7 +32,7 @@ floskellDescriptor plId = PluginDescriptor
 -- Formats the given source in either a given Range or the whole Document.
 -- If the provider fails an error is returned that can be displayed to the user.
 provider :: FormattingProvider
-provider contents uri typ _opts =
+provider contents uri _ typ _opts =
   pluginGetFile "Floskell: " uri $ \file -> do
     config <- liftIO $ findConfigOrDefault file
     let (range, selectedContents) = case typ of

--- a/src/Haskell/Ide/Engine/Plugin/HsImport.hs
+++ b/src/Haskell/Ide/Engine/Plugin/HsImport.hs
@@ -22,6 +22,7 @@ import qualified Data.Text.IO                  as T
 import qualified GHC.Generics                  as Generics
 import qualified HsImport
 import           Haskell.Ide.Engine.Config
+import           Haskell.Ide.Engine.GhcModuleCache
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.MonadFunctions (debugm)
 import qualified Haskell.Ide.Engine.Support.HieExtras as Hie
@@ -197,8 +198,10 @@ importModule (ImportParams uri impStyle modName) =
                       formatEdit :: J.TextEdit -> IdeGhcM J.TextEdit
                       formatEdit origEdit@(J.TextEdit r t) = do
                         -- TODO: are these default FormattingOptions ok?
+                        mc <- getModuleCache
+                        let cc = getCachedCradle mc <$> uriToFilePath uri
                         formatEdits <-
-                          liftToGhc $ provider t uri FormatText (FormattingOptions 2 True) >>= \case
+                          liftToGhc $ provider t uri (join cc) FormatText (FormattingOptions 2 True) >>= \case
                             IdeResultOk xs -> return xs
                             _              -> return [origEdit]
                         -- let edits = foldl' J.editTextEdit origEdit formatEdits -- TODO: this seems broken.

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -10,11 +10,13 @@ import Haskell.Ide.Engine.MonadTypes
 import Control.Exception
 import Control.Monad.IO.Class ( liftIO , MonadIO(..) )
 import Data.Aeson ( Value ( Null ) )
-import Data.Text
+import Data.List
+import qualified Data.Text as T
 import Ormolu
-import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)
 import Haskell.Ide.Engine.PluginUtils
+import HIE.Bios.Flags
+import HIE.Bios.Types
 #endif
 
 ormoluDescriptor :: PluginId -> PluginDescriptor
@@ -32,15 +34,26 @@ ormoluDescriptor plId = PluginDescriptor
 
 
 provider :: FormattingProvider
-provider _contents _uri _ _typ _opts =
+provider _contents _uri _mcradle _typ _opts =
 #if __GLASGOW_HASKELL__ >= 806
-  case _typ of 
-    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
+  case _typ of
+    FormatRange _ -> return $ IdeResultFail (IdeError PluginError (T.pack "Selection formatting for Ormolu is not currently supported.") Null)
     FormatText -> pluginGetFile _contents _uri $ \file -> do
-        result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (unpack _contents))
+        result <- do
+          res <- liftIO $ sequenceA $ getCompilerOptions file <$> _mcradle
+          let opts = case res of
+                      Just (CradleSuccess o) -> fmap DynOption $ filter exop $ componentOptions o
+                      _ -> []
+              conf = Config opts False False True False
+          liftIO $ try @OrmoluException (ormolu conf file (T.unpack _contents))
         case result of
-          Left  err -> return $ IdeResultFail (IdeError PluginError (pack $  "ormoluCmd: " ++ show err) Null)
+          Left  err -> return $ IdeResultFail (IdeError PluginError (T.pack $  "ormoluCmd: " ++ show err) Null)
           Right new -> return $ IdeResultOk [TextEdit (fullRange _contents) new]
+  where
+    exop s =
+      "-X" `isPrefixOf` s
+      || "-fplugin=" `isPrefixOf` s
+      || "-pgmF=" `isPrefixOf` s
 #else
   return $ IdeResultOk [] -- NOP formatter
 #endif

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -32,7 +32,7 @@ ormoluDescriptor plId = PluginDescriptor
 
 
 provider :: FormattingProvider
-provider _contents _uri _typ _opts =
+provider _contents _uri _ _typ _opts =
 #if __GLASGOW_HASKELL__ >= 806
   case _typ of 
     FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)


### PR DESCRIPTION
Other formatters, may be able to use this, but since other formatters have config files they don't need it.