### PR TITLE
Allow newer optparse-applicative for ormolu

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -17,3 +17,4 @@ constraints:
 write-ghc-environment-files: never
 
 index-state: 2020-01-07T22:09:46Z
+allow-newer: ormolu:optparse-applicative


### PR DESCRIPTION
Fixes building via cabal with ghc-8.8 until ormolu bumps its dependencies