### PR TITLE
Allow newer optparse-applicative for ormolu (stack version)

### DIFF
--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -22,6 +22,8 @@ extra-deps:
 - haskell-src-exts-1.21.1
 - ilist-0.3.1.0
 - monad-dijkstra-0.1.1.2
+- ormolu-0.0.3.0
+- optparse-applicative-0.15.1.0
 
 flags:
   haskell-ide-engine:
@@ -29,8 +31,8 @@ flags:
   hie-plugin-api:
     pedantic: true
 
-
-# allow-newer: true
+# Required to build ormolu with optparse-applicative-0.15.1.0
+allow-newer: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -101,8 +101,10 @@ spec = do
       doc <- openDoc "Format.hs" "haskell"
       formatDoc doc (FormattingOptions 2 True)
       docContent <- documentContents doc
+      let formatted = liftIO $ docContent `shouldBe` formattedOrmolu
       case ghcVersion of
-        GHC86 -> liftIO $ docContent `shouldBe` formattedOrmolu
+        GHC88 -> formatted
+        GHC86 -> formatted
         _ -> liftIO $ docContent `shouldBe` unchangedOrmolu
 
 


### PR DESCRIPTION
* Follow up of #1583
* Temporary workaround until #1579 (or upstream fix) is merged