### PR TITLE
Update hlint to 2.2.8 and ormolu to 0.0.3

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,5 +16,5 @@ constraints:
 
 write-ghc-environment-files: never
 
-index-state: 2020-01-07T22:09:46Z
+index-state: 2020-01-21T18:23:31Z
 allow-newer: ormolu:optparse-applicative

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -102,7 +102,7 @@ library
                      , hie-bios >= 0.3.2 && < 0.4.0
                      , bytestring-trie
                      , unliftio
-                     , hlint >= 2.2.2
+                     , hlint >= 2.2.8
   if impl(ghc >= 8.6)
      build-depends: ormolu
 

--- a/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Ormolu.hs
@@ -12,8 +12,10 @@ import Control.Monad.IO.Class ( liftIO , MonadIO(..) )
 import Data.Aeson ( Value ( Null ) )
 import Data.Text
 import Ormolu
+#if __GLASGOW_HASKELL__ < 808
 import Ormolu.Config (defaultConfig)
 import Ormolu.Exception (OrmoluException)
+#endif
 import Haskell.Ide.Engine.PluginUtils
 #endif
 
@@ -34,7 +36,7 @@ ormoluDescriptor plId = PluginDescriptor
 provider :: FormattingProvider
 provider _contents _uri _typ _opts =
 #if __GLASGOW_HASKELL__ >= 806
-  case _typ of 
+  case _typ of
     FormatRange _ -> return $ IdeResultFail (IdeError PluginError (pack "Selection formatting for Ormolu is not currently supported.") Null)
     FormatText -> pluginGetFile _contents _uri $ \file -> do
         result <- liftIO $ try @OrmoluException (ormolu defaultConfig file (unpack _contents))

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -19,6 +19,7 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
 - haskell-lsp-0.19.0.0
@@ -26,7 +27,7 @@ extra-deps:
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - hslogger-1.3.1.0
@@ -46,12 +47,12 @@ extra-deps:
 - unordered-containers-0.2.10.0
 - yaml-0.11.1.2
 # To make build work in windows 7
+- time-manager-0.0.0 # for http2
 - unix-time-0.4.7
+- wai-3.2.2.1 # for network and network-bsd
+- warp-3.2.28 # for network and network-bsd
 - windns-0.1.0.0
 - yi-rope-0.11
-- time-manager-0.0.0 # for http2
-- warp-3.2.28 # for network and network-bsd
-- wai-3.2.2.1 # for network and network-bsd
 
 
 flags:

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -19,6 +19,7 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
 - haskell-lsp-0.19.0.0
@@ -26,7 +27,7 @@ extra-deps:
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - hslogger-1.3.1.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -18,6 +18,7 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.20.0
 - haddock-library-1.6.0
 - haskell-lsp-0.19.0.0
@@ -25,7 +26,7 @@ extra-deps:
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - hslogger-1.3.1.0

--- a/stack-8.6.1.yaml
+++ b/stack-8.6.1.yaml
@@ -22,13 +22,14 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.21.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - libyaml-0.1.1.0
@@ -38,7 +39,7 @@ extra-deps:
 - monoid-subclasses-0.4.6.1
 - multistate-0.8.0.1
 - parser-combinators-1.2.1
-- ormolu-0.0.2.0
+- ormolu-0.0.3.0
 - primes-0.2.1.0
 - resolv-0.1.1.2
 - rope-utf16-splay-0.3.1.0

--- a/stack-8.6.2.yaml
+++ b/stack-8.6.2.yaml
@@ -18,13 +18,14 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.21.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - libyaml-0.1.1.0
@@ -33,7 +34,7 @@ extra-deps:
 - monad-memo-0.4.1
 - multistate-0.8.0.1
 - parser-combinators-1.2.1
-- ormolu-0.0.2.0
+- ormolu-0.0.3.0
 - rope-utf16-splay-0.3.1.0
 - strict-list-0.1.5
 - syz-0.2.0.0

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -16,13 +16,14 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.21.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.10.0.0
@@ -30,8 +31,8 @@ extra-deps:
 - monad-memo-0.4.1
 - multistate-0.8.0.1
 - optparse-simple-0.1.0
+- ormolu-0.0.3.0
 - parser-combinators-1.2.1
-- ormolu-0.0.2.0
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -16,20 +16,21 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.22.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.10.0.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1
+- ormolu-0.0.3.0
 - parser-combinators-1.2.1
-- ormolu-0.0.2.0
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -17,17 +17,18 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.22.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.10.0.0
 - monad-dijkstra-0.1.1.2@rev:1
+- ormolu-0.0.3.0
 - parser-combinators-1.2.1
-- ormolu-0.0.2.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 

--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -12,18 +12,20 @@ extra-deps:
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.23.0
 - haddock-library-1.8.0
+- haskell-src-exts-1.21.1
 - hie-bios-0.3.2
+- hlint-2.2.8
 - hoogle-5.0.17.11
 - hsimport-0.11.0
-- semigroups-0.18.5
-- temporary-1.2.1.1
-- haskell-src-exts-1.21.1
 - ilist-0.3.1.0
 - monad-dijkstra-0.1.1.2
-- ormolu-0.0.3.0
 - optparse-applicative-0.15.1.0
+- ormolu-0.0.3.0
+- semigroups-0.18.5
+- temporary-1.2.1.1
 
 flags:
   haskell-ide-engine:

--- a/stack.yaml
+++ b/stack.yaml
@@ -19,16 +19,17 @@ extra-deps:
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.1
+- ghc-lib-parser-ex-8.8.2
 - haddock-api-2.22.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - hie-bios-0.3.2
-- hlint-2.2.4
+- hlint-2.2.8
 - hsimport-0.11.0
 - lsp-test-0.10.0.0
 - monad-dijkstra-0.1.1.2@rev:1
 - parser-combinators-1.2.1
-- ormolu-0.0.2.0
+- ormolu-0.0.3.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
 - unix-compat-0.5.2


### PR DESCRIPTION
hlint 2.2.8 embeds its config file, making redistribution easier.

Closes #1587