### PR TITLE
Fix error message parsing to import types

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Cradle.hs
@@ -786,22 +786,22 @@ isFilePathPrefixOf dir fp = isJust $ stripFilePath dir fp
 --
 -- >>> stripFilePath "app" "app/File.hs"
 -- Just "File.hs"
-
+--
 -- >>> stripFilePath "src" "app/File.hs"
 -- Nothing
-
+--
 -- >>> stripFilePath "src" "src-dir/File.hs"
 -- Nothing
-
+--
 -- >>> stripFilePath "." "src/File.hs"
 -- Just "src/File.hs"
-
+--
 -- >>> stripFilePath "app/" "./app/Lib/File.hs"
 -- Just "Lib/File.hs"
-
+--
 -- >>> stripFilePath "/app/" "./app/Lib/File.hs"
 -- Nothing -- Nothing since '/app/' is absolute
-
+--
 -- >>> stripFilePath "/app" "/app/Lib/File.hs"
 -- Just "Lib/File.hs"
 stripFilePath :: FilePath -> FilePath -> Maybe FilePath

--- a/src/Haskell/Ide/Engine/Support/HieExtras.hs
+++ b/src/Haskell/Ide/Engine/Support/HieExtras.hs
@@ -14,6 +14,7 @@ module Haskell.Ide.Engine.Support.HieExtras
   , getReferencesInDoc
   , getModule
   , extractTerm
+  , extractTerm'
   , findDef
   , findTypeDef
   , showName
@@ -238,6 +239,21 @@ extractTerm txt =
   where extract b e = T.dropWhile (== b)
                     . T.dropWhileEnd (== e)
                     . T.dropAround (\c -> c /= b && c /= e)
+
+-- | Extract a term from a compiler message.
+-- Removes whitespace and tries to extract a message between '‘' and '’' falling back to '`' and '\''
+-- (the used ones in Windows systems).
+-- Different to @extractTerm@, it does not require that the term is actually surrounded
+-- and can be used to sanitize the input.
+extractTerm' :: T.Text -> T.Text
+extractTerm' txt =
+  case extract '‘' '’' txt of
+    ""  -> extract '`' '\'' txt -- Needed for windows
+    term -> term
+  where extract b e = T.dropWhile (== b)
+                    . T.dropWhileEnd (== e)
+                    . T.strip
+
 
 -- ---------------------------------------------------------------------
 

--- a/src/Haskell/Ide/Engine/Support/Hoogle.hs
+++ b/src/Haskell/Ide/Engine/Support/Hoogle.hs
@@ -11,7 +11,7 @@ import           Data.Aeson
 import           Data.Bifunctor
 import           Data.Maybe
 import qualified Data.Text                          as T
-import Data.List
+import           Data.List
 import           Haskell.Ide.Engine.MonadTypes
 import           Haskell.Ide.Engine.MonadFunctions
 import           Hoogle


### PR DESCRIPTION
Fix error message parsing to enable HsImport plugin to import Types.
Moreover, fix generation of Code Actions to avoid cases
where the same Code Action was displayed multiple times.

Overall tests for HsImport actions are lacking. This problem flew under the radar since I initially wrote the feature of import-lists.