### PR TITLE
Azure fix win cabal 8.4.4

### DIFF
--- a/.azure/windows-cabal.bashrc
+++ b/.azure/windows-cabal.bashrc
@@ -1,6 +1,6 @@
-export CABAL_DIR=/d/cabal
+export CABAL_DIR="D:\cabal"
 export GHCS_PATH=$(cygpath $ProgramData)/chocolatey/lib/ghc/tools
 export GHC_PATH=$GHCS_PATH/ghc-$GHC_VERSION
-export CABAL_ROOT=$CABAL_DIR
+export CABAL_ROOT=$(cygpath $CABAL_DIR)
 export Z3_BIN_PATH=/usr/local/z3-4.8.5-x64-win/bin
 export PATH=$CABAL_ROOT/bin:$GHC_PATH/bin:$Z3_BIN_PATH:$PATH

--- a/.azure/windows-cabal.bashrc
+++ b/.azure/windows-cabal.bashrc
@@ -1,5 +1,6 @@
+export CABAL_DIR=/d/cabal
 export GHCS_PATH=$(cygpath $ProgramData)/chocolatey/lib/ghc/tools
 export GHC_PATH=$GHCS_PATH/ghc-$GHC_VERSION
-export CABAL_ROOT=$(cygpath $APPDATA)/cabal
+export CABAL_ROOT=$CABAL_DIR
 export Z3_BIN_PATH=/usr/local/z3-4.8.5-x64-win/bin
 export PATH=$CABAL_ROOT/bin:$GHC_PATH/bin:$Z3_BIN_PATH:$PATH

--- a/.azure/windows-cabal.yml
+++ b/.azure/windows-cabal.yml
@@ -25,10 +25,9 @@ jobs:
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"
   - bash: |
-      df -k
       source .azure/windows-cabal.bashrc
       mkdir -p $CABAL_ROOT
-      tar -vxzf .azure-cache/cabal-root.tar.gz -C /c
+      tar -vxzf .azure-cache/cabal-root.tar.gz -C /d
       mkdir -p $CABAL_STORE_DIR
       tar -vxzf .azure-cache/cabal-store.tar.gz -C /d
       mkdir -p ${CABAL_STORE_DIR}i
@@ -45,6 +44,7 @@ jobs:
       choco install -y --ignore-dependencies ghc --version=$GHC_VERSION
     displayName: Install ghc
   - bash: |
+      source .azure/windows-cabal.bashrc
       choco install -y cabal --version=$CABAL_VERSION
       $(cygpath $ProgramData)/chocolatey/bin/RefreshEnv.cmd
     displayName: Install cabal

--- a/.azure/windows-cabal.yml
+++ b/.azure/windows-cabal.yml
@@ -20,7 +20,7 @@ jobs:
   steps:
   - task: Cache@2
     inputs:
-      key: '"cabal" | "$(Agent.OS)" | "$(CABAL_VERSION)" | "$(GHC_VERSION)" | $(Build.SourcesDirectory)/cabal.project | $(Build.SourcesDirectory)/haskell-ide-engine.cabal | $(Build.SourcesDirectory)/hie-plugin-api/hie-plugin-api.cabal'
+      key: '"cabal-v2" | "$(Agent.OS)" | "$(CABAL_VERSION)" | "$(GHC_VERSION)" | $(Build.SourcesDirectory)/cabal.project | $(Build.SourcesDirectory)/haskell-ide-engine.cabal | $(Build.SourcesDirectory)/hie-plugin-api/hie-plugin-api.cabal'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"


### PR DESCRIPTION
Moving cabal root dir from `%APPDATA%\cabal` to `D:\cabal` and free space in C:
They are about to increase its capacity but this could be kept afterwards