### PR TITLE
Bump resolvers, hlint, brittany

### DIFF
--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -5,8 +5,10 @@ jobs:
     vmImage: windows-2019
   strategy:
     matrix:
-      stack-def:
-        YAML_FILE: stack.yaml
+      # default stack.yaml uses ghc-8.8.2 so we can't use it for windows
+      # TODO: Enable it when it uses ghc-8.8.3
+      # stack-def:
+      #  YAML_FILE: stack.yaml
       # ghc versions 8.8.1 and 8.8.2 are not usable in windows 
       # due to https://gitlab.haskell.org/ghc/ghc/issues/17575
       stack-8.6.5:

--- a/cabal.project
+++ b/cabal.project
@@ -15,4 +15,4 @@ constraints:
 
 write-ghc-environment-files: never
 
-index-state: 2020-02-01T17:43:11Z
+index-state: 2020-02-02T17:43:42Z

--- a/install/src/HieInstall.hs
+++ b/install/src/HieInstall.hs
@@ -88,7 +88,9 @@ defaultMain = do
     phony "hie"  (need ["data", "latest"])
 
     -- stack specific targets
-    when isRunFromStack $ do
+    -- Default `stack.yaml` uses ghc-8.8.2 and we can't build hie in windows
+    -- TODO: Enable for windows when it uses ghc-8.8.3
+    when (isRunFromStack && not isWindowsSystem) $ do
 
       phony "dev" $ stackInstallHieWithErrMsg Nothing
 

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -11,7 +11,7 @@ extra-deps:
 - base-compat-0.9.3
 - base-orphans-0.8.2
 - bifunctors-5.5.6
-- brittany-0.12.1.0
+- brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
 - cabal-helper-1.0.0.0
 - cabal-plan-0.5.0.0
@@ -23,8 +23,8 @@ extra-deps:
 - floskell-0.10.2
 - generic-deriving-1.13.1
 - ghc-exactprint-0.6.2 # for HaRe
-- ghc-lib-parser-8.8.1
-- ghc-lib-parser-ex-8.8.2
+- ghc-lib-parser-8.8.2
+- ghc-lib-parser-ex-8.8.4.0
 - haddock-api-2.20.0
 - haddock-library-1.6.0
 - haskell-lsp-0.19.0.0
@@ -32,7 +32,7 @@ extra-deps:
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.4.0
-- hlint-2.2.8
+- hlint-2.2.10
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - hslogger-1.3.1.0

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -51,21 +51,20 @@ extra-deps:
 - simple-sendfile-0.2.30 # for network and network-bsd
 - socks-0.6.1 # for network and network-bsd
 - syz-0.2.0.0
-- temporary-1.2.1.1
 - type-equality-1
 - unix-compat-0.5.2
 - unordered-containers-0.2.10.0
 - yaml-0.11.2.0
 - th-abstraction-0.3.1.0
-# To make build work in windows 7
-- time-compat-1.9.2.2
-- time-manager-0.0.0 # for http2
-- unix-time-0.4.7
-- wai-3.2.2.1 # for network and network-bsd
-- warp-3.2.28 # for network and network-bsd
 - windns-0.1.0.0
 - yi-rope-0.11
-
+# To make build work in windows 7
+- unix-time-0.4.7
+- temporary-1.2.1.1
+- time-compat-1.9.2.2
+- time-manager-0.0.0 # for http2
+- wai-3.2.2.1 # for network and network-bsd
+- warp-3.2.28 # for network and network-bsd
 
 flags:
   haskell-ide-engine:

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -6,25 +6,31 @@ packages:
 extra-deps:
 # - ./submodules/HaRe
 
+- QuickCheck-2.13.2
 - aeson-1.4.6.0
 - aeson-pretty-0.8.8
-- base-compat-0.9.3
+- ansi-terminal-0.10.2
+- ansi-wl-pprint-0.6.9
+- assoc-1.0.1
+- async-2.2.2
+- base-compat-0.11.1
 - base-orphans-0.8.2
-- bifunctors-5.5.6
-- brittany-0.12.1.0
+- bifunctors-5.5.7
+- brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
 - cabal-helper-1.0.0.0
-- cabal-plan-0.5.0.0
+- cabal-plan-0.6.2.0
 - connection-0.3.1 # for network and network-bsd
 - constrained-dynamic-0.1.0.0
+- dec-0.0.3
 - extra-1.6.18
-- file-embed-0.0.11
+- file-embed-0.0.11.1
 - filepattern-0.1.1
 - floskell-0.10.2
 - generic-deriving-1.13.1
 - ghc-exactprint-0.6.2 # for HaRe
-- ghc-lib-parser-8.8.1
-- ghc-lib-parser-ex-8.8.2
+- ghc-lib-parser-8.8.2
+- ghc-lib-parser-ex-8.8.4.0
 - haddock-api-2.20.0
 - haddock-library-1.6.0
 - haskell-lsp-0.19.0.0
@@ -32,37 +38,54 @@ extra-deps:
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.4.0
-- hlint-2.2.8
+- hlint-2.2.10
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - hslogger-1.3.1.0
+- hspec-2.7.1
+- hspec-core-2.7.1
+- hspec-discover-2.7.1
+- indexed-profunctors-0.1
 - invariant-0.5.3
 - lens-4.18.1
-- libyaml-0.1.1.0
+- libyaml-0.1.1.1
 - lsp-test-0.10.0.0
-- microlens-th-0.4.3.2
+- microlens-th-0.4.3.4
 - monad-dijkstra-0.1.1.2
 - network-3.1.1.1 # for hslogger
 - network-bsd-2.8.1.0 # for hslogger
+- optics-core-0.2
+- optparse-applicative-0.15.1.0
 - parser-combinators-1.2.1
 - profunctors-5.5.1
-- pretty-show-1.8.2
+- quickcheck-instances-0.3.22
 - rope-utf16-splay-0.3.1.0
+- semialign-1.1
+- semigroupoids-5.3.4
 - simple-sendfile-0.2.30 # for network and network-bsd
+- singleton-bool-0.1.5
 - socks-0.6.1 # for network and network-bsd
-- syz-0.2.0.0
-- unix-compat-0.5.2
-- unordered-containers-0.2.10.0
-- yaml-0.11.2.0
-- th-abstraction-0.3.1.0
-- type-equality-1
-# To make build work in windows 7
-- unix-time-0.4.7
+- splitmix-0.0.3
+- tagged-0.8.6
 - temporary-1.2.1.1
+- th-abstraction-0.3.1.0
+- these-1.0.1
 - time-compat-1.9.2.2
-- time-manager-0.0.0 # for http2
-- warp-3.2.28 # for network and network-bsd
-- wai-3.2.2.1 # for network and network-bsd
+- topograph-1
+- type-equality-1
+- unix-compat-0.5.2
+- unix-time-0.4.7
+- unordered-containers-0.2.10.0
+- vector-0.12.1.2
+- yaml-0.11.2.0
+# To make build work in windows 7
+# - unix-time-0.4.7
+# - temporary-1.2.1.1
+# - time-compat-1.9.2.2
+# - time-manager-0.0.0 # for http2
+# - warp-3.2.28 # for network and network-bsd
+# - wai-3.2.2.1 # for network and network-bsd
+
 
 flags:
   haskell-ide-engine:

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -67,24 +67,21 @@ extra-deps:
 - socks-0.6.1 # for network and network-bsd
 - splitmix-0.0.3
 - tagged-0.8.6
-- temporary-1.2.1.1
 - th-abstraction-0.3.1.0
 - these-1.0.1
-- time-compat-1.9.2.2
 - topograph-1
 - type-equality-1
 - unix-compat-0.5.2
-- unix-time-0.4.7
 - unordered-containers-0.2.10.0
 - vector-0.12.1.2
 - yaml-0.11.2.0
 # To make build work in windows 7
-# - unix-time-0.4.7
-# - temporary-1.2.1.1
-# - time-compat-1.9.2.2
-# - time-manager-0.0.0 # for http2
-# - warp-3.2.28 # for network and network-bsd
-# - wai-3.2.2.1 # for network and network-bsd
+- unix-time-0.4.7
+- temporary-1.2.1.1
+- time-compat-1.9.2.2
+- time-manager-0.0.0 # for http2
+- warp-3.2.28 # for network and network-bsd
+- wai-3.2.2.1 # for network and network-bsd
 
 
 flags:

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -10,7 +10,7 @@ extra-deps:
 - aeson-pretty-0.8.8
 - base-orphans-0.8.2
 - bifunctors-5.5.6
-- brittany-0.12.1.0
+- brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
 - cabal-helper-1.0.0.0
 - cabal-plan-0.5.0.0
@@ -22,8 +22,8 @@ extra-deps:
 - floskell-0.10.2
 - generic-deriving-1.13.1
 - ghc-exactprint-0.6.2 # for HaRe
-- ghc-lib-parser-8.8.1
-- ghc-lib-parser-ex-8.8.2
+- ghc-lib-parser-8.8.2
+- ghc-lib-parser-ex-8.8.4.0
 - haddock-api-2.20.0
 - haddock-library-1.6.0
 - haskell-lsp-0.19.0.0
@@ -31,7 +31,7 @@ extra-deps:
 - haskell-src-exts-1.21.1
 - haskell-src-exts-util-0.2.5
 - hie-bios-0.4.0
-- hlint-2.2.8
+- hlint-2.2.10
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - hslogger-1.3.1.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -8,7 +8,7 @@ extra-deps:
 
 - aeson-1.4.6.0
 - aeson-pretty-0.8.8
-- brittany-0.12.1.0
+- brittany-0.12.1.1
 - butcher-1.3.2.1
 - bytestring-trie-0.2.5.0
 - cabal-helper-1.0.0.0
@@ -17,14 +17,14 @@ extra-deps:
 - extra-1.6.18
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
-- ghc-lib-parser-8.8.1
-- ghc-lib-parser-ex-8.8.2
+- ghc-lib-parser-8.8.2
+- ghc-lib-parser-ex-8.8.4.0
 - haddock-api-2.22.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - haskell-src-exts-1.21.1
 - hie-bios-0.4.0
-- hlint-2.2.8
+- hlint-2.2.10
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - lsp-test-0.10.0.0

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.20
+resolver: lts-14.22
 packages:
 - .
 - hie-plugin-api
@@ -8,32 +8,36 @@ extra-deps:
 
 - aeson-1.4.6.0
 - aeson-pretty-0.8.8
-- ansi-terminal-0.8.2
-- ansi-wl-pprint-0.6.8.2
-- brittany-0.12.1.0
+- ansi-terminal-0.10.2
+- ansi-wl-pprint-0.6.9
+- base-compat-0.11.1
+- brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
 - cabal-helper-1.0.0.0
-- cabal-plan-0.5.0.0
+- cabal-plan-0.6.2.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2
 - ghc-exactprint-0.6.2 # for HaRe
-- ghc-lib-parser-8.8.1
-- ghc-lib-parser-ex-8.8.2
+- ghc-lib-parser-8.8.2
+- ghc-lib-parser-ex-8.8.4.0
 - haddock-api-2.22.0
 - haskell-lsp-0.19.0.0
 - haskell-lsp-types-0.19.0.0
 - hie-bios-0.4.0
-- hlint-2.2.8
+- hlint-2.2.10
 - hoogle-5.0.17.11
 - hsimport-0.11.0
+- indexed-profunctors-0.1
 - lsp-test-0.10.0.0
-- monad-dijkstra-0.1.1.2@rev:1
+- monad-dijkstra-0.1.1.2
+- optics-core-0.2
+- optparse-applicative-0.15.1.0
 - ormolu-0.0.3.1
 - parser-combinators-1.2.1
-- syz-0.2.0.0
+- semialign-1.1
 - temporary-1.2.1.1
-
+- topograph-1
 flags:
   haskell-ide-engine:
     pedantic: true

--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-01-17
+resolver: nightly-2020-01-21 # last GHC 8.8.1
 packages:
 - .
 - hie-plugin-api
@@ -8,17 +8,18 @@ extra-deps:
 
 - aeson-1.4.6.0
 - apply-refact-0.7.0.0
+- brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
 - cabal-helper-1.0.0.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2
-- ghc-lib-parser-ex-8.8.2
+- ghc-lib-parser-ex-8.8.4.0
 - haddock-api-2.23.0
 - haddock-library-1.8.0
 - haskell-src-exts-1.21.1
 - hie-bios-0.4.0
-- hlint-2.2.8
+- hlint-2.2.10
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - ilist-0.3.1.0

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-01-25
+resolver: nightly-2020-01-31
 packages:
 - .
 - hie-plugin-api
@@ -7,20 +7,22 @@ extra-deps:
 # - ./submodules/HaRe
 
 - apply-refact-0.7.0.0
+- brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
 - cabal-helper-1.0.0.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2
-- ghc-lib-parser-ex-8.8.2
+- ghc-lib-parser-ex-8.8.4.0
 - git: https://github.com/haskell/haddock.git
   commit: be8b02c4e3cffe7d45b3dad0a0f071d35a274d65
   subdirs:
     - haddock-api
+# - haddock-api-2.23.0
 - haddock-library-1.8.0
 - haskell-src-exts-1.21.1
 - hie-bios-0.4.0
-- hlint-2.2.8
+- hlint-2.2.10
 - hoogle-5.0.17.11
 - hsimport-0.11.0
 - ilist-0.3.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2019-09-21 # Last GHC 8.6.5
+resolver: nightly-2020-01-31
 packages:
 - .
 - hie-plugin-api
@@ -6,36 +6,30 @@ packages:
 extra-deps:
 # - ./submodules/HaRe
 
-- aeson-1.4.6.0
-- ansi-terminal-0.8.2
-- ansi-wl-pprint-0.6.8.2
-- brittany-0.12.1.0
+- apply-refact-0.7.0.0
+- brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
 - cabal-helper-1.0.0.0
-- cabal-plan-0.5.0.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
-- deque-0.4.3
-- extra-1.6.18
 - floskell-0.10.2
-- ghc-exactprint-0.6.2 # for HaRe
-- ghc-lib-parser-8.8.1
-- ghc-lib-parser-ex-8.8.2
-- haddock-api-2.22.0
-- haskell-lsp-0.19.0.0
-- haskell-lsp-types-0.19.0.0
+- ghc-lib-parser-ex-8.8.4.0
+- git: https://github.com/haskell/haddock.git
+  commit: be8b02c4e3cffe7d45b3dad0a0f071d35a274d65
+  subdirs:
+    - haddock-api
+# - haddock-api-2.23.0
+- haddock-library-1.8.0
+- haskell-src-exts-1.21.1
 - hie-bios-0.4.0
-- hlint-2.2.8
+- hlint-2.2.10
+- hoogle-5.0.17.11
 - hsimport-0.11.0
-- lsp-test-0.10.0.0
-- monad-dijkstra-0.1.1.2@rev:1
-- parser-combinators-1.2.1
+- ilist-0.3.1.0
+- monad-dijkstra-0.1.1.2
 - ormolu-0.0.3.1
-- syz-0.2.0.0
+- semigroups-0.18.5
 - temporary-1.2.1.1
-- unix-compat-0.5.2
-- time-compat-1.9.2.2
-- yaml-0.11.2.0
 
 flags:
   haskell-ide-engine:
@@ -46,6 +40,6 @@ flags:
 # allow-newer: true
 
 nix:
-  packages: [icu libcxx zlib]
+  packages: [ icu libcxx zlib ]
 
 concurrent-tests: false


### PR DESCRIPTION
cabal now index state 2020-01-31T21:11:24Z
GHC 8.8.2 is nightly-2020-01-31
GHC 8.6.5 is lts-14.22

hlint is 2.2.9
brittany is 0.12.1.1