### PR TITLE
Install script with cabal: check there is one ghc in $PATH 

### DIFF
--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -113,10 +113,11 @@ cabalInstallIsOldFailMsg cabalVersion =
     ++ versionToString requiredCabalVersion
     ++ "`."
 
-
 requiredCabalVersion :: RequiredVersion
 requiredCabalVersion | isWindowsSystem = requiredCabalVersionForWindows
                      | otherwise = [2, 4, 1, 0]
 
 requiredCabalVersionForWindows :: RequiredVersion
 requiredCabalVersionForWindows = [3, 0, 0, 0]
+
+

--- a/install/src/Cabal.hs
+++ b/install/src/Cabal.hs
@@ -119,5 +119,3 @@ requiredCabalVersion | isWindowsSystem = requiredCabalVersionForWindows
 
 requiredCabalVersionForWindows :: RequiredVersion
 requiredCabalVersionForWindows = [3, 0, 0, 0]
-
-

--- a/install/src/Env.hs
+++ b/install/src/Env.hs
@@ -62,6 +62,22 @@ findInstalledGhcs = do
     -- filter out stack provided GHCs (assuming that stack programs path is the default one in linux)
     $ filter (not . isInfixOf ".stack" . snd) (knownGhcs ++ availableGhcs)
 
+showInstalledGhcs :: MonadIO m => [(VersionNumber, GhcPath)] -> m ()
+showInstalledGhcs ghcPaths = do
+  let msg = "Found the following GHC paths: \n"
+              ++ unlines
+                  (map (\(version, path) -> "ghc-" ++ version ++ ": " ++ path)
+                    ghcPaths
+                  )
+  printInStars msg
+
+checkInstalledGhcs :: MonadIO m => [(VersionNumber, GhcPath)] -> m ()
+checkInstalledGhcs ghcPaths = when (null ghcPaths) $ do
+  let msg = "No ghc installations found in $PATH. \n"
+             ++ "The script requires at least one ghc in $PATH to be able to build hie.\n"
+  printInStars msg
+  error msg
+
 -- | Get the path to a GHC that has the version specified by `VersionNumber`
 -- If no such GHC can be found, Nothing is returned.
 -- First, it is checked whether there is a GHC with the name `ghc-$VersionNumber`.


### PR DESCRIPTION
* It throws an error if there is no one 
```console
D:\ws\haskell\haskell-ide-engine>cabal v2-run .\install.hs -w D:\bin\ghc-8.6.5\bin\ghc  --project-file=install\shake.project
........
********************************************************************************

No ghc installations found in $PATH.
The script requires at least one ghc in $PATH to be able to build hie.

********************************************************************************


No ghc installations found in $PATH.
The script requires at least one ghc in $PATH to be able to build hie.

CallStack (from HasCallStack):
  error, called at src\Env.hs:79:3 in hie-install-0.8.0.0-inplace:Env
```
Closes #1620
