### PR TITLE
Azure: not trigger pr builds by path

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,14 @@ pr:
   branches:
     include:
       - master
+  paths:
+    exclude:
+      - .circleci
+      - docs
+      - licenses
+      - logos
+      - LICENSE
+      - '*.md'
 
 jobs:
 - template: ./.azure/linux-stack.yml


### PR DESCRIPTION
Prs modifying docs continued to trigger the azure builds