### PR TITLE
Fix failing tests in windows (reloaded)

### DIFF
--- a/.azure/windows-cabal.bashrc
+++ b/.azure/windows-cabal.bashrc
@@ -1,3 +1,6 @@
+if [ -z "$CABAL_DIR" ]; then
+  CABAL_DIR="$APPDATA\\cabal"
+fi
 export GHCS_PATH=$(cygpath $ProgramData)/chocolatey/lib/ghc/tools
 export GHC_PATH=$GHCS_PATH/ghc-$GHC_VERSION
 export CABAL_ROOT=$(cygpath $CABAL_DIR)

--- a/.azure/windows-cabal.yml
+++ b/.azure/windows-cabal.yml
@@ -14,25 +14,25 @@ jobs:
         GHC_VERSION: "8.4.4"
   variables:
     CABAL_VERSION: "3.0.0.0"
-    CABAL_DIR: "D:\\cabal"
-    CABAL_STORE_DIR: "D:\\sd"
+    CABAL_DIR: ""
+    CABAL_STORE_DIR: "C:\\sd"
     LIQUID_VERSION: "0.8.6.2"
-    STACK_ROOT: "D:\\sr"
+    STACK_ROOT: "C:\\sr"
   steps:
   - task: Cache@2
     inputs:
-      key: '"cabal-v2" | "$(Agent.OS)" | "$(CABAL_VERSION)" | "$(GHC_VERSION)" | $(Build.SourcesDirectory)/cabal.project | $(Build.SourcesDirectory)/haskell-ide-engine.cabal | $(Build.SourcesDirectory)/hie-plugin-api/hie-plugin-api.cabal'
+      key: '"cabal-v3" | "$(Agent.OS)" | "$(CABAL_VERSION)" | "$(GHC_VERSION)" | $(Build.SourcesDirectory)/cabal.project | $(Build.SourcesDirectory)/haskell-ide-engine.cabal | $(Build.SourcesDirectory)/hie-plugin-api/hie-plugin-api.cabal'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"
   - bash: |
       source .azure/windows-cabal.bashrc
       mkdir -p $CABAL_ROOT
-      tar -vxzf .azure-cache/cabal-root.tar.gz -C /d
+      tar -vxzf .azure-cache/cabal-root.tar.gz -C /c
       mkdir -p $CABAL_STORE_DIR
-      tar -vxzf .azure-cache/cabal-store.tar.gz -C /d
+      tar -vxzf .azure-cache/cabal-store.tar.gz -C /c
       mkdir -p ${CABAL_STORE_DIR}i
-      tar -vxzf .azure-cache/cabal-store-install.tar.gz -C /d
+      tar -vxzf .azure-cache/cabal-store-install.tar.gz -C /c
       mkdir -p dist-newstyle
       tar -vxzf .azure-cache/cabal-dist.tar.gz
     displayName: "Unpack cache"
@@ -95,17 +95,12 @@ jobs:
       curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       mkdir -p "$STACK_ROOT"
-      echo "local-programs-path: D:/bin/stack" > $STACK_ROOT/config.yaml
       # If we don't install the ghc used in test projects in advance, tests fail 
-      stack setup --resolver=lts-14.20
+      stack setup --stack-yaml stack-${GHC_VERSION}.yaml
     displayName: "Install Runtime Unit Test-Dependencies: stack"
   - bash: |
       source .azure/windows-cabal.bashrc
-      # TODO: Enable CabalHelper tests
-      if [ $GHC_VERSION = "8.4.4" ]; then
-        TEST_OPTIONS=--test-options="--skip=CabalHelper"
-      fi
-      cabal v2-test :unit-test $TEST_OPTIONS
+      cabal v2-test :unit-test
     displayName: "Run Test: unit-test"
   # TODO: Enable rest of test suites in windows
   - bash: |
@@ -117,7 +112,7 @@ jobs:
       source .azure/windows-cabal.bashrc
       # TODO: Enable for 8.4.4
       if [ $GHC_VERSION != "8.4.4" ]; then
-        cabal v2-test :func-test $TEST_OPTIONS
+        cabal v2-test :func-test
       fi
     displayName: "Run Test: func-test"
   - bash: |

--- a/.azure/windows-installhs-cabal.yml
+++ b/.azure/windows-installhs-cabal.yml
@@ -7,21 +7,21 @@ jobs:
     GHC_VERSION: "8.6.5"
     CABAL_VERSION: "3.0.0.0"
     CABAL_DIR: "" # To use the default one (cabal-hie-install latest fails with a custom one)
-    CABAL_STORE_DIR: "D:\\sd"
+    CABAL_STORE_DIR: "C:\\sd"
     PROJECT_FILE: "./install/shake.project"
   steps:
   - task: Cache@2
     inputs:
-      key: '"cabal-installhs" | "$(Agent.OS)" | "$(CABAL_VERSION)" | "$(GHC_VERSION)" | $(Build.SourcesDirectory)/cabal.project | $(Build.SourcesDirectory)/haskell-ide-engine.cabal | $(Build.SourcesDirectory)/hie-plugin-api/hie-plugin-api.cabal'
+      key: '"cabal-installhs-v1" | "$(Agent.OS)" | "$(CABAL_VERSION)" | "$(GHC_VERSION)" | $(Build.SourcesDirectory)/cabal.project | $(Build.SourcesDirectory)/haskell-ide-engine.cabal | $(Build.SourcesDirectory)/hie-plugin-api/hie-plugin-api.cabal'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"
   - bash: |
       source .azure/windows-cabal.bashrc
       mkdir -p $CABAL_ROOT
-      tar -vxzf .azure-cache/cabal-root.tar.gz -C /d
+      tar -vxzf .azure-cache/cabal-root.tar.gz -C /c
       mkdir -p $CABAL_STORE_DIR
-      tar -vxzf .azure-cache/cabal-store.tar.gz -C /d
+      tar -vxzf .azure-cache/cabal-store.tar.gz -C /c
       mkdir -p ./dist-newstyle
       tar -vxzf .azure-cache/cabal-dist.tar.gz
     displayName: "Unpack cache"

--- a/.azure/windows-installhs-stack.yml
+++ b/.azure/windows-installhs-stack.yml
@@ -5,17 +5,17 @@ jobs:
     vmImage: windows-2019
   variables:
     YAML_FILE: install/shake.yaml
-    STACK_ROOT: "D:\\sr"
+    STACK_ROOT: "C:\\sr"
   steps:
   - task: Cache@2
     inputs:
-      key: '"stack" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE) | $(Build.SourcesDirectory)/install/shake.yaml'
+      key: '"stack-installhs-v1" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE) | $(Build.SourcesDirectory)/install/shake.yaml'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Cache stack-root"
   - bash: |
       mkdir -p "$STACK_ROOT"
-      tar -vxzf .azure-cache/stack-root.tar.gz -C /d
+      tar -vxzf .azure-cache/stack-root.tar.gz -C /c
       mkdir -p .stack-work
       tar -vxzf .azure-cache/stack-work.tar.gz
       mkdir -p ./install/.stack-work
@@ -26,7 +26,6 @@ jobs:
       curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       mkdir -p "$STACK_ROOT"
-      echo "local-programs-path: D:/bin/stack" > "$STACK_ROOT/config.yaml"
     displayName: Install stack
   - bash: |
       source .azure/windows-stack.bashrc

--- a/.azure/windows-stack.bashrc
+++ b/.azure/windows-stack.bashrc
@@ -1,3 +1,7 @@
+if [ -z "$CABAL_DIR" ]; then
+  CABAL_DIR="$APPDATA\\cabal"
+fi
 export LOCAL_BIN_PATH=$(cygpath $APPDATA\\local\\bin)
+export CABAL_ROOT=$(cygpath $CABAL_DIR)
 export Z3_BIN_PATH=/usr/local/z3-4.8.5-x64-win/bin
 export PATH=$Z3_BIN_PATH:$LOCAL_BIN_PATH:$PATH

--- a/.azure/windows-stack.yml
+++ b/.azure/windows-stack.yml
@@ -22,19 +22,20 @@ jobs:
       stack-8.4.2:
         YAML_FILE: stack-8.4.2.yaml
   variables:
-    STACK_ROOT: "D:\\sr"
+    STACK_ROOT: "C:\\sr"
     CABAL_VERSION: "3.0.0.0"
+    CABAL_STORE_DIR: "C:\\sd"
 
   steps:
   - task: Cache@2
     inputs:
-      key: '"stack" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
+      key: '"stack-v3" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Cache stack-root"
   - bash: |
       mkdir -p $STACK_ROOT
-      tar -vxzf .azure-cache/stack-root.tar.gz -C /d
+      tar -vxzf .azure-cache/stack-root.tar.gz -C /c
       mkdir -p .stack-work
       tar -vxzf .azure-cache/stack-work.tar.gz
     displayName: "Unpack cache"
@@ -47,7 +48,6 @@ jobs:
       curl -sSkL http://www.stackage.org/stack/windows-x86_64 -o /usr/bin/stack.zip
       unzip -o /usr/bin/stack.zip -d /usr/bin/
       mkdir -p "$STACK_ROOT"
-      echo "local-programs-path: D:/bin/stack" > "$STACK_ROOT/config.yaml"
     displayName: Install stack
   - bash: |
       source .azure/windows-stack.bashrc
@@ -92,6 +92,8 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: z3"
   - bash: |
       source .azure/windows-stack.bashrc
+      # To make stack not pick default stack.yaml if it uses the same ghc than lts-13.20
+      cd "$(Agent.TempDirectory)"
       stack install --resolver=lts-13.20 liquid-fixpoint-0.8.0.2 liquidhaskell-0.8.6.2
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
@@ -103,14 +105,14 @@ jobs:
       source .azure/windows-stack.bashrc
       choco install -y cabal --version $CABAL_VERSION
       /C/ProgramData/chocolatey/bin/RefreshEnv.cmd
+      cabal v2-update
+      echo "store-dir: $CABAL_STORE_DIR" >> /config
     displayName: "Install Runtime Test-Dependencies: cabal"
   - bash: |
       source .azure/windows-stack.bashrc
-      # TODO: Enable CabalHelper unit tests, see https://github.com/DanielG/cabal-helper/issues/91
-      if [ $YAML_FILE = "stack-8.6.4.yaml" ]; then
-        TEST_ARGS=--test-arguments="--skip=CabalHelper"
-      fi
-      stack test :unit-test $TEST_ARGS --stack-yaml $(YAML_FILE)
+      # hie assumes that ghc is in path for cabal cradles (Haskell.Ide.Engine.Cradle.execProjectGhc)
+      export PATH="$(stack path --compiler-bin --stack-yaml $YAML_FILE)":$PATH
+      stack test :unit-test --stack-yaml $(YAML_FILE)
     displayName: "Run Test: unit-test"
   # TODO: Enable rest of test suites in windows
   - bash: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,13 @@
 packages:
          ./
          ./hie-plugin-api/
+
          -- ./submodules/HaRe
+
+source-repository-package
+    type: git
+    location: https://github.com/jneira/cabal-helper.git
+    tag: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 
 tests: true
 

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -13,7 +13,9 @@ extra-deps:
 - bifunctors-5.5.6
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-- cabal-helper-1.0.0.0
+# - cabal-helper-1.0.0.0
+- github: jneira/cabal-helper
+  commit: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 - cabal-plan-0.5.0.0
 - connection-0.3.1 # for network and network-bsd
 - constrained-dynamic-0.1.0.0

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -18,7 +18,9 @@ extra-deps:
 - bifunctors-5.5.7
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-- cabal-helper-1.0.0.0
+# - cabal-helper-1.0.0.0
+- github: jneira/cabal-helper
+  commit: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 - cabal-plan-0.6.2.0
 - connection-0.3.1 # for network and network-bsd
 - constrained-dynamic-0.1.0.0

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -12,7 +12,9 @@ extra-deps:
 - bifunctors-5.5.6
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-- cabal-helper-1.0.0.0
+# - cabal-helper-1.0.0.0
+- github: jneira/cabal-helper
+  commit: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 - cabal-plan-0.5.0.0
 - connection-0.3.1 # for network and network-bsd
 - constrained-dynamic-0.1.0.0

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -11,7 +11,9 @@ extra-deps:
 - brittany-0.12.1.1
 - butcher-1.3.2.1
 - bytestring-trie-0.2.5.0
-- cabal-helper-1.0.0.0
+# - cabal-helper-1.0.0.0
+- github: jneira/cabal-helper
+  commit: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 - cabal-plan-0.5.0.0
 - constrained-dynamic-0.1.0.0
 - extra-1.6.18

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -13,7 +13,9 @@ extra-deps:
 - base-compat-0.11.1
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-- cabal-helper-1.0.0.0
+# - cabal-helper-1.0.0.0
+- github: jneira/cabal-helper
+  commit: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 - cabal-plan-0.6.2.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0

--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -10,7 +10,9 @@ extra-deps:
 - apply-refact-0.7.0.0
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-- cabal-helper-1.0.0.0
+# - cabal-helper-1.0.0.0
+- github: jneira/cabal-helper
+  commit: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -9,7 +9,9 @@ extra-deps:
 - apply-refact-0.7.0.0
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-- cabal-helper-1.0.0.0
+# - cabal-helper-1.0.0.0
+- github: jneira/cabal-helper
+  commit: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,9 @@ extra-deps:
 - apply-refact-0.7.0.0
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-- cabal-helper-1.0.0.0
+# - cabal-helper-1.0.0.0
+- github: jneira/cabal-helper
+  commit: ffb1f57a5ffc6b7ac3c46a9974c4420a6d2bb9b2
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2


### PR DESCRIPTION
* Using a patched version of cabal-helper (until the next release)
  * It includes the remove of the private lib
* Azure windows agent have changed their drives space now `C:` has lot of more space than `D:`, so i've switched again cache to `C:`
* Some of unit failing tests had been fixed by #1654