### PR TITLE
Azure: try to generate hoogle twice to avoid 403 http errors for macos

### DIFF
--- a/.azure/macos-stack.yml
+++ b/.azure/macos-stack.yml
@@ -92,7 +92,8 @@ jobs:
   - bash: |
       source .azure/macos.bashrc
       stack build hoogle --stack-yaml=$(YAML_FILE)
-      stack exec hoogle generate --stack-yaml=$(YAML_FILE)
+      # This step frequently fails with http 403
+      stack exec hoogle generate --stack-yaml=$(YAML_FILE) || stack exec hoogle generate --stack-yaml=$(YAML_FILE)
     displayName: "Install Runtime Test-Dependencies: hoogle database"
   - bash: |
       source .azure/macos.bashrc


### PR DESCRIPTION
...by brute force :disappointed: 