### PR TITLE
Fix #1578 - Redesign option parsing for main executable

### DIFF
--- a/app/MainHie.hs
+++ b/app/MainHie.hs
@@ -84,8 +84,8 @@ main = do
 
   let plugins' = plugins (optExamplePlugin opts)
 
-  if optLsp opts
-    then do
+  case optMode opts of
+    LspMode -> do
       -- Start up in LSP mode
       logm $ "Run entered for HIE(" ++ progName ++ ") " ++ hieVersion
       logm $ "Operating as a LSP server on stdio"
@@ -106,7 +106,7 @@ main = do
       -- launch the dispatcher.
       scheduler <- newScheduler plugins' initOpts
       server scheduler origDir plugins' (optCaptureFile opts)
-    else do
+    ProjectLoadingMode projectLoadingOpts -> do
       -- Provide debug info
       cliOut $  "Running HIE(" ++ progName ++ ")"
       cliOut $  "  " ++ hieVersion
@@ -128,7 +128,7 @@ main = do
           cliOut $ "Project Ghc version: " ++ projGhc
           cliOut $ "Libdir: " ++ show mlibdir
           cliOut "Searching for Haskell source files..."
-          targets <- case optFiles opts of
+          targets <- case optFiles projectLoadingOpts of
             [] -> findAllSourceFiles origDir
             xs -> concat <$> mapM findAllSourceFiles xs
 
@@ -138,7 +138,7 @@ main = do
           mapM_ cliOut targets
           cliOut ""
 
-          unless (optDryRun opts) $ do
+          unless (optDryRun projectLoadingOpts) $ do
             cliOut "\nLoad them all now. This may take a very long time.\n"
             loadDiagnostics <- runServer mlibdir plugins' targets
 

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -203,6 +203,7 @@ test-suite unit-test
                        HsImportSpec
                        JsonSpec
                        LiquidSpec
+                       OptionsSpec
                        PackagePluginSpec
                        Spec
   -- Technically cabal-helper should be a 'run-tool-depends', but that doesn't exist yet
@@ -225,6 +226,7 @@ test-suite unit-test
                      , hie-plugin-api
                      , hoogle > 5.0.11
                      , hspec
+                     , optparse-applicative
                      , process
                      , quickcheck-instances
                      , text

--- a/test/unit/OptionsSpec.hs
+++ b/test/unit/OptionsSpec.hs
@@ -1,0 +1,70 @@
+module OptionsSpec where
+
+import Prelude hiding (unzip)
+import Data.List.NonEmpty(unzip)
+import Test.Hspec
+import Options.Applicative
+import Haskell.Ide.Engine.Options(GlobalOpts(..), RunMode(..), ProjectLoadingOpts(..), optionParser)
+import System.Exit(ExitCode(..))
+import Data.List(isPrefixOf)
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  let defaultGlobalOptions = GlobalOpts False Nothing Nothing False Nothing False (ProjectLoadingMode $ ProjectLoadingOpts False [])
+  let getParseFailure (Failure x) = Just (renderFailure x "hie")
+      getParseFailure _           = Nothing
+  let sut         = optionParser
+  let parserInfo  = info sut mempty
+  let parserPrefs = prefs mempty
+  let runSut :: [String] -> ParserResult GlobalOpts 
+      runSut      = execParserPure parserPrefs parserInfo
+  
+  describe "cmd option parsing" $ do
+    describe "compiler flag" $ do
+      let input  = ["--compiler"]
+      let result = runSut input
+      let (maybeMessage, maybeStatusCode) = unzip $ getParseFailure result
+
+      it "should return ghc version" $
+        maybeMessage `shouldSatisfy` any ("ghc" `isPrefixOf`)
+      it "should return exit code 0" $
+        maybeStatusCode `shouldBe` Just ExitSuccess
+
+    describe "numeric version flag" $ do
+      let input  = ["--numeric-version"]
+      let result = runSut input
+      let (maybeMessage, maybeStatusCode) = unzip $ getParseFailure result
+
+      it "should return version" $
+        maybeMessage `shouldBe` Just "1.1"
+      it "shoud return exit code 0" $
+        maybeStatusCode `shouldBe` Just ExitSuccess
+
+    describe "not providing arguments" $ do
+      let input  = []
+      let result = runSut input
+      let maybeGlobalOptions = getParseResult result
+      
+      it "should result in default options" $
+        maybeGlobalOptions `shouldBe` Just defaultGlobalOptions
+
+    describe "lsp flag" $ do
+      let input  = ["--lsp"]
+      let result = runSut input
+      let maybeGlobalOptions = getParseResult result
+      
+      it "should result in default lsp options" $
+        maybeGlobalOptions `shouldBe` Just (GlobalOpts False Nothing Nothing False Nothing False LspMode)
+    
+    describe "providing two unmatching arguments" $ do
+      let input  = ["--lsp", "--dry-run"]
+      let result = runSut input
+      let (maybeMessage, maybeStatusCode) = unzip $ getParseFailure result
+      
+      it "should return expected error message" $
+        maybeMessage `shouldSatisfy` any ("Invalid option `--dry-run'" `isPrefixOf`)
+      it "should return error exit code 1" $
+        maybeStatusCode `shouldBe` Just (ExitFailure 1)


### PR DESCRIPTION
### What has been done?
I extracted mode-specific `GlobalOpts` fields into separate types, updated the parsing logic to handle new types as an alternative and updated the places where `GlobalOpts` were used.
### How did I test it?
Added unit tests for option parser exposed by `Haskell.Ide.Engine.Options`. 