### PR TITLE
Report progress as a percentage

### DIFF
--- a/hie-plugin-api/Haskell/Ide/Engine/GhcUtils.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/GhcUtils.hs
@@ -17,7 +17,7 @@ import           Haskell.Ide.Engine.PluginUtils (ErrorHandler(..))
 -- Convert progress continuation to a messager
 toMessager :: (Core.Progress -> IO ()) -> G.Messager
 toMessager k _hsc_env (nk, n) _rc_reason ms =
-  let prog = Core.Progress (Just (fromIntegral nk/ fromIntegral n))  (Just mod_name)
+  let prog = Core.Progress (Just (100 * fromIntegral nk / fromIntegral n))  (Just mod_name)
       mod_name = T.pack $ moduleNameString (moduleName (ms_mod ms))
   in k prog
 


### PR DESCRIPTION
Previously it was displayed as a value from 0% to 1%

As specified https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workDoneProgress

See also https://github.com/alanz/haskell-lsp/blob/1f85ef3c150dc8b2626a181c47d8635015e67ee5/src/Language/Haskell/LSP/Core.hs#L150-L154