### PR TITLE
Use sha instead revision for hsimport and other fixes

### DIFF
--- a/.azure/macos-installhs-cabal.yml
+++ b/.azure/macos-installhs-cabal.yml
@@ -21,7 +21,9 @@ jobs:
     displayName: "Unpack cache"
     condition: eq(variables.CACHE_RESTORED, 'true')
   - bash: |
-      brew install cabal-install
+      # TODO Install ghc-8.8.3 when adding stack-8.8.3.yaml 
+      brew install ghc@8.6
+      brew install cabal-install --ignore-dependencies ghc
       which cabal
       which ghc
       cabal update

--- a/.azure/macos-installhs-cabal.yml
+++ b/.azure/macos-installhs-cabal.yml
@@ -29,10 +29,12 @@ jobs:
       cabal update
     displayName: Install cabal and ghc
   - bash: |
+      export PATH="/usr/local/opt/ghc@8.6/bin:$PATH"
       source .azure/windows-cabal.bashrc
       cabal v2-run ./install.hs --project-file $PROJECT_FILE -- help
     displayName: Run help of `install.hs`
   - bash: |
+      export PATH="/usr/local/opt/ghc@8.6/bin:$PATH"
       source .azure/windows-cabal.bashrc
       cabal v2-run ./install.hs --project-file $PROJECT_FILE -- latest
     displayName: Run latest target of `install.hs`

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -205,6 +205,7 @@ test-suite unit-test
                        LiquidSpec
                        OptionsSpec
                        PackagePluginSpec
+                       Paths_haskell_ide_engine
                        Spec
   -- Technically cabal-helper should be a 'run-tool-depends', but that doesn't exist yet
   build-tool-depends:  cabal-helper:cabal-helper-main, hspec-discover:hspec-discover

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -36,7 +36,7 @@ extra-deps:
 - hie-bios-0.4.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@rev1
+- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - hslogger-1.3.1.0
 - invariant-0.5.3
 - lens-4.18.1

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -42,7 +42,7 @@ extra-deps:
 - hie-bios-0.4.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0
+- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - hslogger-1.3.1.0
 - hspec-2.7.1
 - hspec-core-2.7.1

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -35,7 +35,7 @@ extra-deps:
 - hie-bios-0.4.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0
+- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - hslogger-1.3.1.0
 - invariant-0.5.3
 - lens-4.18.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -28,7 +28,7 @@ extra-deps:
 - hie-bios-0.4.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@rev1
+- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - lsp-test-0.10.1.0
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -31,7 +31,7 @@ extra-deps:
 - hie-bios-0.4.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@rev1
+- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - indexed-profunctors-0.1
 - lsp-test-0.10.1.0
 - monad-dijkstra-0.1.1.2

--- a/stack-8.8.1.yaml
+++ b/stack-8.8.1.yaml
@@ -26,7 +26,7 @@ extra-deps:
 - hie-bios-0.4.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@rev1
+- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - ilist-0.3.1.0
 - monad-dijkstra-0.1.1.2
 - ormolu-0.0.3.1

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -31,7 +31,7 @@ extra-deps:
 - hie-bios-0.4.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@rev1
+- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - ilist-0.3.1.0
 - monad-dijkstra-0.1.1.2
 - ormolu-0.0.3.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,7 +29,7 @@ extra-deps:
 - hie-bios-0.4.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@rev1
+- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - ilist-0.3.1.0
 - monad-dijkstra-0.1.1.2
 - ormolu-0.0.3.1

--- a/test/unit/OptionsSpec.hs
+++ b/test/unit/OptionsSpec.hs
@@ -2,11 +2,13 @@ module OptionsSpec where
 
 import Prelude hiding (unzip)
 import Data.List.NonEmpty(unzip)
+import Data.Version (showVersion)
 import Test.Hspec
 import Options.Applicative
 import Haskell.Ide.Engine.Options(GlobalOpts(..), RunMode(..), ProjectLoadingOpts(..), optionParser)
 import System.Exit(ExitCode(..))
 import Data.List(isPrefixOf)
+import Paths_haskell_ide_engine as HIE (version)
 
 main :: IO ()
 main = hspec spec
@@ -39,7 +41,7 @@ spec = do
       let (maybeMessage, maybeStatusCode) = unzip $ getParseFailure result
 
       it "should return version" $
-        maybeMessage `shouldBe` Just "1.1"
+        maybeMessage `shouldBe` Just (showVersion HIE.version)
       it "shoud return exit code 0" $
         maybeStatusCode `shouldBe` Just ExitSuccess
 


### PR DESCRIPTION
* `@revn` way to specify a revision in `stack.yaml` files seems to be not reliable: it is using the package version without the revision under some circumstances. It is possible that wipping out the entire `$STACK_ROOT` could fix it but is is not desirable
* we have [tested ](https://github.com/haskell/haskell-ide-engine/issues/1689#issuecomment-597922927) that using pantry sha seems to make stack use the patched version, although it is somewhat ugly
* closes #1689