### PR TITLE
Make install script use unix-time-0.4.7

### DIFF
--- a/install/shake.yaml
+++ b/install/shake.yaml
@@ -13,6 +13,7 @@ extra-deps:
 - shake-0.18.5
 # for resolvers with ghc < 8.6
 # - shake-0.17
+- unix-time-0.4.7
 
 
 nix:


### PR DESCRIPTION
* To avoid a bug in windows of previous unix-time versions
* It is throwed with stack executions within the `install.hs` script using `./install/shake.yaml` config
* Fixes #1714 