### PR TITLE
Use installed ghc in stack linux builds

### DIFF
--- a/.azure/linux-stack.bashrc
+++ b/.azure/linux-stack.bashrc
@@ -1,1 +1,1 @@
-export PATH=$HOME/.local/bin:$PATH
+export PATH=$HOME/.local/bin:/opt/ghc/$GHC_VERSION/bin:$PATH

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -90,7 +90,7 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: z3"
   - bash: |
       source .azure/linux-stack.bashrc
-      PATH=/opt/ghc/8.6.5/bin:$PATH
+      export PATH=/opt/ghc/8.6.5/bin:$PATH
       stack install --resolver=lts-13.20 liquid-fixpoint-0.8.0.2 liquidhaskell-0.8.6.2
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |
@@ -106,6 +106,8 @@ jobs:
     displayName: "Run Test: unit-test"
   - bash: |
       source .azure/linux-stack.bashrc
+      # we need the ghc versions used by wrapper-test suite
+      export PATH=$PATH:/opt/ghc/8.8.1/bin:/opt/ghc/8.6.5/bin
       stack test :dispatcher-test :plugin-dispatcher-test :wrapper-test --stack-yaml $(YAML_FILE)
     displayName: "Run Test: dispatcher-test, plugin-dispatcher-test and wrapper-test"
   - bash: |

--- a/.azure/linux-stack.yml
+++ b/.azure/linux-stack.yml
@@ -5,29 +5,31 @@ jobs:
     vmImage: ubuntu-16.04
   strategy:
     matrix:
-      stack-def:
+      default:
         YAML_FILE: stack.yaml
-      stack-8.8.3:
-        YAML_FILE: stack-8.8.3.yaml
-      stack-8.8.2:
-        YAML_FILE: stack-8.8.2.yaml
-      stack-8.6.5:
-        YAML_FILE: stack-8.6.5.yaml
-      stack-8.6.4:
-        YAML_FILE: stack-8.6.4.yaml
-      stack-8.4.4:
-        YAML_FILE: stack-8.4.4.yaml
-      stack-8.4.3:
-        YAML_FILE: stack-8.4.3.yaml
-      stack-8.4.2:
-        YAML_FILE: stack-8.4.2.yaml
+        GHC_VERSION: "8.8.3"
+      ghc-8.8.3:
+        GHC_VERSION: "8.8.3"
+      ghc-8.8.2:
+        GHC_VERSION: "8.8.2"
+      ghc-8.6.5:
+        GHC_VERSION: "8.6.5"
+      ghc-8.6.4:
+        GHC_VERSION: "8.6.4"
+      ghc-8.4.4:
+        GHC_VERSION: "8.4.4"
+      ghc-8.4.3:
+        GHC_VERSION: "8.4.3"
+      ghc-8.4.2:
+        GHC_VERSION: "8.4.2"
   variables:
     STACK_ROOT: /home/vsts/.stack
     CABAL_VERSION: "3.0"
+    YAML_FILE: stack-$(GHC_VERSION).yaml
   steps:
   - task: Cache@2
     inputs:
-      key: '"stack" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
+      key: '"stack-v1" | "$(Agent.OS)" | $(Build.SourcesDirectory)/$(YAML_FILE)'
       path: .azure-cache
       cacheHitVar: CACHE_RESTORED
     displayName: "Download cache"
@@ -45,6 +47,9 @@ jobs:
       mkdir -p ~/.local/bin
       curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | \
         tar vxz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+      stack update
+      echo "system-ghc: true" >> $STACK_ROOT/config.yaml
+      echo "install-ghc: false" >> $STACK_ROOT/config.yaml
     displayName: Install stack
   - bash: |
       source .azure/linux-stack.bashrc
@@ -85,6 +90,7 @@ jobs:
     displayName: "Install Runtime Test-Dependencies: z3"
   - bash: |
       source .azure/linux-stack.bashrc
+      PATH=/opt/ghc/8.6.5/bin:$PATH
       stack install --resolver=lts-13.20 liquid-fixpoint-0.8.0.2 liquidhaskell-0.8.6.2
     displayName: "Install Runtime Test-Dependencies: liquidhaskell"
   - bash: |


### PR DESCRIPTION
* To avoid download it again and not waste disk space
* Fixes #1729 
* The builds are failing due to timeouts when executing `stack exec hoogle generate`: see https://github.com/ndmitchell/hoogle/issues/347