### PR TITLE
Use cabal-helper 1.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -4,11 +4,6 @@ packages:
 
          -- ./submodules/HaRe
 
-source-repository-package
-    type: git
-    location: https://github.com/DanielG/cabal-helper.git
-    tag: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
-
 tests: true
 
 package haskell-ide-engine
@@ -17,8 +12,9 @@ package haskell-ide-engine
 -- Match the flag settings we use in stac builds
 constraints:
         haskell-ide-engine +pedantic,
-        hie-plugin-api     +pedantic
+        hie-plugin-api     +pedantic,
+        ghc-lib-parser == 8.8.2.20200205
 
 write-ghc-environment-files: never
 
-index-state: 2020-05-10T18:26:01Z
+index-state: 2020-05-12T16:28:12Z

--- a/haskell-ide-engine.cabal
+++ b/haskell-ide-engine.cabal
@@ -61,7 +61,7 @@ library
                      , brittany
                      , bytestring
                      , Cabal
-                     , cabal-helper >= 1.0 && < 1.1
+                     , cabal-helper >= 1.1 && < 1.2
                      , containers
                      , data-default
                      , directory

--- a/src/Haskell/Ide/Engine/Plugin/Package.hs
+++ b/src/Haskell/Ide/Engine/Plugin/Package.hs
@@ -27,7 +27,8 @@ import qualified Data.Text.Encoding            as T
 import           Data.Maybe
 #if __GLASGOW_HASKELL__ < 808
 import           Data.Monoid ((<>))
-#else
+#endif
+#if MIN_VERSION_Cabal(3,0,0)
 import qualified Data.Set                      as S
 #endif
 #if MIN_VERSION_Cabal(2,2,0)
@@ -301,7 +302,7 @@ editCabalPackage file modulePath pkgName fileMap = do
             -- Add it to the bottom of the dependencies list
             -- TODO: we could sort the depencies and then insert it,
             -- or insert it in order iff the list is already sorted.
-#if __GLASGOW_HASKELL__ >= 808
+#if MIN_VERSION_Cabal(3,0,0)
             newDeps = oldDeps ++ [Dependency (mkPackageName (T.unpack dep)) anyVersion S.empty]
 #else
             newDeps = oldDeps ++ [Dependency (mkPackageName (T.unpack dep)) anyVersion]

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -38,7 +38,7 @@ extra-deps:
 - hie-bios-0.5.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
+- hsimport-0.11.0@rev:2
 - hslogger-1.3.1.0
 - invariant-0.5.3
 - lens-4.18.1

--- a/stack-8.4.2.yaml
+++ b/stack-8.4.2.yaml
@@ -13,9 +13,9 @@ extra-deps:
 - bifunctors-5.5.6
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-# - cabal-helper-1.0.0.0
-- github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+- Cabal-3.0.2.0
+- cabal-doctest-1.0.8
+- cabal-helper-1.1.0.0
 - cabal-plan-0.5.0.0
 - connection-0.3.1 # for network and network-bsd
 - constrained-dynamic-0.1.0.0
@@ -27,8 +27,10 @@ extra-deps:
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.2.20200205
 - ghc-lib-parser-ex-8.8.5.3
-- haddock-api-2.20.0
+- ghc-paths-0.1.0.12
+- haddock-api-2.20.0@rev:1
 - haddock-library-1.6.0
+- happy-1.19.12
 - haskell-lsp-0.20.0.0
 - haskell-lsp-types-0.20.0.0
 - haskell-src-exts-1.22.0
@@ -76,6 +78,8 @@ flags:
     pedantic: true
   hie-plugin-api:
     pedantic: true
+
+# allow-newer: true
 
 nix:
   packages: [ icu libcxx zlib ]

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -44,7 +44,7 @@ extra-deps:
 - hie-bios-0.5.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
+- hsimport-0.11.0@rev:2
 - hslogger-1.3.1.0
 - hspec-2.7.1
 - hspec-core-2.7.1

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -18,9 +18,9 @@ extra-deps:
 - bifunctors-5.5.7
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-# - cabal-helper-1.0.0.0
-- github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+- Cabal-3.0.2.0
+- cabal-doctest-1.0.8
+- cabal-helper-1.1.0.0
 - cabal-plan-0.6.2.0
 - connection-0.3.1 # for network and network-bsd
 - constrained-dynamic-0.1.0.0
@@ -33,12 +33,14 @@ extra-deps:
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.2.20200205
 - ghc-lib-parser-ex-8.8.5.3
-- haddock-api-2.20.0
+- ghc-paths-0.1.0.12
+- haddock-api-2.20.0@rev:1
 - haddock-library-1.6.0
 - haskell-lsp-0.20.0.0
 - haskell-lsp-types-0.20.0.0
 - haskell-src-exts-1.22.0
 - haskell-src-exts-util-0.2.5
+- happy-1.19.12
 - hie-bios-0.5.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
@@ -94,6 +96,8 @@ flags:
     pedantic: true
   hie-plugin-api:
     pedantic: true
+
+# allow-newer: true
 
 nix:
   packages: [icu libcxx zlib]

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -37,7 +37,7 @@ extra-deps:
 - hie-bios-0.5.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
+- hsimport-0.11.0@rev:2
 - hslogger-1.3.1.0
 - invariant-0.5.3
 - lens-4.18.1

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -12,9 +12,9 @@ extra-deps:
 - bifunctors-5.5.6
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-# - cabal-helper-1.0.0.0
-- github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+- Cabal-3.0.2.0
+- cabal-doctest-1.0.8
+- cabal-helper-1.1.0.0
 - cabal-plan-0.5.0.0
 - connection-0.3.1 # for network and network-bsd
 - constrained-dynamic-0.1.0.0
@@ -26,8 +26,10 @@ extra-deps:
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.2.20200205
 - ghc-lib-parser-ex-8.8.5.3
-- haddock-api-2.20.0
+- ghc-paths-0.1.0.12
+- haddock-api-2.20.0@rev:1
 - haddock-library-1.6.0
+- happy-1.19.12
 - haskell-lsp-0.20.0.0
 - haskell-lsp-types-0.20.0.0
 - haskell-src-exts-1.22.0
@@ -74,6 +76,8 @@ flags:
     pedantic: true
   hie-plugin-api:
     pedantic: true
+
+# allow-newer: true
 
 nix:
   packages: [icu libcxx zlib]

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -11,9 +11,9 @@ extra-deps:
 - brittany-0.12.1.1
 - butcher-1.3.2.1
 - bytestring-trie-0.2.5.0
-# - cabal-helper-1.0.0.0
-- github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+- Cabal-3.0.2.0
+- cabal-doctest-1.0.8
+- cabal-helper-1.1.0.0
 - cabal-plan-0.5.0.0
 - constrained-dynamic-0.1.0.0
 - extra-1.6.21
@@ -21,7 +21,9 @@ extra-deps:
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.2.20200205
 - ghc-lib-parser-ex-8.8.5.3
-- haddock-api-2.22.0
+- ghc-paths-0.1.0.12
+- haddock-api-2.22.0@rev:1
+- happy-1.19.12
 - haskell-lsp-0.20.0.0
 - haskell-lsp-types-0.20.0.0
 - haskell-src-exts-1.22.0
@@ -29,7 +31,9 @@ extra-deps:
 - hlint-2.2.11
 - hoogle-5.0.17.15
 - hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
+- lens-4.18
 - lsp-test-0.10.1.0
+- microlens-th-0.4.2.3@rev:1
 - monad-dijkstra-0.1.1.2@rev:1
 - monad-memo-0.4.1
 - multistate-0.8.0.1
@@ -39,7 +43,9 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - syz-0.2.0.0
 - temporary-1.2.1.1
+- th-abstraction-0.3.1.0
 - time-compat-1.9.2.2
+- type-equality-1
 - unix-compat-0.5.2
 - unliftio-0.2.12.1
 - unliftio-core-0.2.0.1

--- a/stack-8.6.4.yaml
+++ b/stack-8.6.4.yaml
@@ -30,7 +30,7 @@ extra-deps:
 - hie-bios-0.5.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
+- hsimport-0.11.0@rev:2
 - lens-4.18
 - lsp-test-0.10.1.0
 - microlens-th-0.4.2.3@rev:1

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -13,9 +13,8 @@ extra-deps:
 - base-compat-0.11.1
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-# - cabal-helper-1.0.0.0
-- github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+- Cabal-3.0.2.0
+- cabal-helper-1.1.0.0
 - cabal-plan-0.6.2.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
@@ -24,7 +23,7 @@ extra-deps:
 - ghc-exactprint-0.6.2 # for HaRe
 - ghc-lib-parser-8.8.2.20200205
 - ghc-lib-parser-ex-8.8.5.3
-- haddock-api-2.22.0
+- haddock-api-2.22.0@rev:1
 - haskell-lsp-0.20.0.0
 - haskell-lsp-types-0.20.0.0
 - haskell-src-exts-1.22.0
@@ -33,6 +32,7 @@ extra-deps:
 - hoogle-5.0.17.15
 - hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
 - indexed-profunctors-0.1
+- lens-4.18
 - lsp-test-0.10.1.0
 - monad-dijkstra-0.1.1.2
 - optics-core-0.2
@@ -43,6 +43,7 @@ extra-deps:
 - semialign-1.1
 - temporary-1.2.1.1
 - topograph-1
+- type-equality-1
 - unliftio-0.2.12.1
 - unliftio-core-0.2.0.1
 

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -30,7 +30,7 @@ extra-deps:
 - hie-bios-0.5.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
+- hsimport-0.11.0@rev:2
 - indexed-profunctors-0.1
 - lens-4.18
 - lsp-test-0.10.1.0

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -24,7 +24,7 @@ extra-deps:
 - hie-bios-0.5.0
 - hlint-2.2.11
 - hoogle-5.0.17.15
-- hsimport-0.11.0@sha256:e8f1774aff97215d7cc3a6c81635fae75b80af182f732f8fe28d1ed6eb9c7401,3170
+- hsimport-0.11.0@rev:2
 - ilist-0.3.1.0
 - monad-dijkstra-0.1.1.2
 - ormolu-0.0.3.1

--- a/stack-8.8.2.yaml
+++ b/stack-8.8.2.yaml
@@ -9,9 +9,8 @@ extra-deps:
 - apply-refact-0.7.0.0
 - brittany-0.12.1.1
 - bytestring-trie-0.2.5.0
-# - cabal-helper-1.0.0.0
-- github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+- Cabal-3.0.2.0
+- cabal-helper-1.1.0.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -7,7 +7,7 @@ extra-deps:
 # - ./submodules/HaRe
 
 - apply-refact-0.7.0.0
-- bytestring-trie-0.2.5.0@rev1
+- bytestring-trie-0.2.5.0@rev:1
 - Cabal-3.0.2.0
 - cabal-helper-1.1.0.0
 - clock-0.7.2

--- a/stack-8.8.3.yaml
+++ b/stack-8.8.3.yaml
@@ -7,10 +7,9 @@ extra-deps:
 # - ./submodules/HaRe
 
 - apply-refact-0.7.0.0
-- bytestring-trie-0.2.5.0@rev:1
-# - cabal-helper-1.0.0.0
-- github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+- bytestring-trie-0.2.5.0@rev1
+- Cabal-3.0.2.0
+- cabal-helper-1.1.0.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,9 +9,7 @@ extra-deps:
 
 - apply-refact-0.7.0.0
 - bytestring-trie-0.2.5.0
-# - cabal-helper-1.0.0.0
-- github: DanielG/cabal-helper
-  commit: a18bbb2af92e9b4337e7f930cb80754f2408bcfd
+- cabal-helper-1.1.0.0
 - clock-0.7.2
 - constrained-dynamic-0.1.0.0
 - floskell-0.10.2


### PR DESCRIPTION
* Closes #1758 
* It has needed:
  * Use Cabal-3.0.1.0 in all build plans, cause cabal-helper requires it for windows, to avoid a bug in previous versions (for windows)
  * To being able to use it we had to request revisions for haddock-api, see https://github.com/DanielG/cabal-helper/issues/116. We are using them in stack.yaml's
  * Other packages has been upgraded, to get versions compatibles with Cabal-3.0.2.0
  * There were some conditions over Cabal api changes using the ghc version instead, the code failed when changing the cabal version and now it is more correct