### PR TITLE
Avoid building docs for haddock-api + cabal + ghc-8.6.5

### DIFF
--- a/cabal.project-8.6.5
+++ b/cabal.project-8.6.5
@@ -1,0 +1,25 @@
+packages:
+         ./
+         ./hie-plugin-api/
+
+         -- ./submodules/HaRe
+
+tests: true
+
+-- The build is failing due a cabal bug involving haddock
+-- see https://github.com/haskell/haskell-ide-engine/issues/1741
+package haddock-api
+  documentation: False
+
+package haskell-ide-engine
+  test-show-details: direct
+
+-- Match the flag settings we use in stac builds
+constraints:
+        haskell-ide-engine +pedantic,
+        hie-plugin-api     +pedantic,
+        ghc-lib-parser == 8.8.2.20200205
+
+write-ghc-environment-files: never
+
+index-state: 2020-05-12T16:28:12Z


### PR DESCRIPTION
* To woraround a cabal bug that makes the target `./cabal-hie-install hie-8.6.5` fail if the user has the docs generation enabled in cabal global config
* Closes #1741