### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ sudo apt install libicu-dev libtinfo-dev libgmp-dev
 **Debian 10/Ubuntu 18.10 or later**:
 
 ```bash
-sudo apt install libicu-dev libncurses-dev libgmp-dev
+sudo apt install libicu-dev libncurses-dev libgmp-dev # also zlib1g-dev if not installed
 ```
 
 **Fedora**:


### PR DESCRIPTION
`zlib1g-dev` is missing in at least the WSL2 version of Ubuntu 20.04, which causes the build to fail.