### PR TITLE
Rename configuration section languageServerHaskell => haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/haskell/haskell-language-server
 
 Until the new `haskell-language-server` reaches the feature level and stability of `haskell-ide-engine`, we aim to continue doing monthly releases. However, in general, bug fixes will be favored over new features and refactorings. They could be redirected to the new repo to avoid duplicated efforts.
 
-You still can contribute to improve the haskell ide experience! If you are not sure if you contribution should belong to this repo or the new one, feel free to ask in [any of the communication channels](#its-time-to-join-the-project).  
+You still can contribute to improve the haskell ide experience! If you are not sure if you contribution should belong to this repo or the new one, feel free to ask in [any of the communication channels](#its-time-to-join-the-project).
 
 # Haskell IDE Engine (HIE)
 <img src="https://github.com/haskell/haskell-ide-engine/raw/master/logos/HIE_logo_512.png" width="256" style="margin:25px;" align="right"/>
@@ -314,8 +314,8 @@ Wrapper script will analyze your project, find suitable version of HIE and launc
 Enable it by editing VS Code settings like this:
 
 ```json
-"languageServerHaskell.useCustomHieWrapper": true,
-"languageServerHaskell.useCustomHieWrapperPath": "hie-wrapper",
+"haskell.useCustomHieWrapper": true,
+"haskell.useCustomHieWrapperPath": "hie-wrapper",
 ```
 
 ## Configuration
@@ -323,7 +323,7 @@ There are some settings that can be configured via a `settings.json` file:
 
 ```
 {
-    "languageServerHaskell": {
+    "haskell": {
         "hlintOn": Boolean,
         "maxNumberOfProblems": Number
         "diagnosticsDebounceDuration" : Number
@@ -344,7 +344,7 @@ There are some settings that can be configured via a `settings.json` file:
 **For a full explanation of possible configurations, refer to [hie-bios/README](https://github.com/mpickering/hie-bios/blob/master/README.md).**
 
 HIE will attempt to automatically detect your project configuration and set up
-the environment for GHC. 
+the environment for GHC.
 
 | `cabal.project` | `stack.yaml` | `*.cabal` | Project selected |
 |-----------------|--------------|-----------|------------------|
@@ -582,7 +582,7 @@ Then issue `:CocConfig` and add the following to your Coc config file.
       "haskell"
     ],
     "initializationOptions": {
-      "languageServerHaskell": {
+      "haskell": {
       }
     }
   }

--- a/hie-plugin-api/Haskell/Ide/Engine/Config.hs
+++ b/hie-plugin-api/Haskell/Ide/Engine/Config.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Haskell.Ide.Engine.Config where
 
+import           Control.Applicative
 import           Data.Aeson
 import           Data.Default
 import qualified Data.Text as T
@@ -54,7 +55,7 @@ instance Default Config where
 -- TODO: Add API for plugins to expose their own LSP config options
 instance FromJSON Config where
   parseJSON = withObject "Config" $ \v -> do
-    s <- v .: "languageServerHaskell"
+    s <- v .: "haskell" <|> v.: "languageServerHaskell"
     flip (withObject "Config.settings") s $ \o -> Config
       <$> o .:? "hlintOn"                     .!= hlintOn def
       <*> o .:? "diagnosticsOnChange"         .!= diagnosticsOnChange def
@@ -65,17 +66,17 @@ instance FromJSON Config where
       <*> o .:? "formatOnImportOn"            .!= formatOnImportOn def
       <*> o .:? "formattingProvider"          .!= formattingProvider def
 
--- 2017-10-09 23:22:00.710515298 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"languageServerHaskell":{"maxNumberOfProblems":100,"hlintOn":true}}}}
+-- 2017-10-09 23:22:00.710515298 [ThreadId 11] - ---> {"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"haskell":{"maxNumberOfProblems":100,"hlintOn":true}}}}
 -- 2017-10-09 23:22:00.710667381 [ThreadId 15] - reactor:got didChangeConfiguration notification:
 -- NotificationMessage
 --   {_jsonrpc = "2.0"
 --   , _method = WorkspaceDidChangeConfiguration
 --   , _params = DidChangeConfigurationParams
---                 {_settings = Object (fromList [("languageServerHaskell",Object (fromList [("hlintOn",Bool True)
+--                 {_settings = Object (fromList [("haskell",Object (fromList [("hlintOn",Bool True)
 --                                                                                          ,("maxNumberOfProblems",Number 100.0)]))])}}
 
 instance ToJSON Config where
-  toJSON (Config h diag m d l c f fp) = object [ "languageServerHaskell" .= r ]
+  toJSON (Config h diag m d l c f fp) = object [ "haskell" .= r ]
     where
       r = object [ "hlintOn"                     .= h
                  , "diagnosticsOnChange"         .= diag

--- a/test/functional/CompletionSpec.hs
+++ b/test/functional/CompletionSpec.hs
@@ -330,7 +330,7 @@ spec = describe "completions" $ do
       doc <- openDoc "Completion.hs" "haskell"
       _ <- count 2 $ skipManyTill loggingNotification noDiagnostics
 
-      let config = object ["languageServerHaskell" .= (object ["completionSnippetsOn" .= False])]
+      let config = object ["haskell" .= (object ["completionSnippetsOn" .= False])]
 
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams config)
 

--- a/test/functional/FormatSpec.hs
+++ b/test/functional/FormatSpec.hs
@@ -33,7 +33,7 @@ spec = do
 
   describe "formatting provider" $ do
     let formatLspConfig provider =
-          object [ "languageServerHaskell" .= object ["formattingProvider" .= (provider :: Value)] ]
+          object [ "haskell" .= object ["formattingProvider" .= (provider :: Value)] ]
         formatConfig provider = defaultConfig { lspConfig = Just (formatLspConfig provider) }
 
     it "respects none" $ runSessionWithConfig (formatConfig "none") hieCommand fullCaps "test/testdata" $ do
@@ -94,7 +94,7 @@ spec = do
 
   describe "ormolu" $ do
     let formatLspConfig provider =
-          object [ "languageServerHaskell" .= object ["formattingProvider" .= (provider :: Value)] ]
+          object [ "haskell" .= object ["formattingProvider" .= (provider :: Value)] ]
 
     it "formats correctly" $ runSession hieCommand fullCaps "test/testdata" $ do
       sendNotification WorkspaceDidChangeConfiguration (DidChangeConfigurationParams (formatLspConfig "ormolu"))
@@ -199,7 +199,7 @@ formattedOrmolu =
   \  x <- return \"hello\"\n\
   \  return \"asdf\"\n\n\
   \data Baz = Baz {a :: Int, b :: String}\n"
-  
+
 unchangedOrmolu :: T.Text
 unchangedOrmolu =
   "module    Format where\n\


### PR DESCRIPTION
Brings it inline with other language servers, and also fixes it with vscode-hie-server 0.1.
A breaking change for people's configurations, but the ship has already sailed on vscode-hie-server, whoops!
